### PR TITLE
sort instructions in tp_out_irreps_with_instructions

### DIFF
--- a/mace/modules/irreps_tools.py
+++ b/mace/modules/irreps_tools.py
@@ -39,6 +39,8 @@ def tp_out_irreps_with_instructions(
         for i_in1, i_in2, i_out, mode, train in instructions
     ]
 
+    instructions = sorted(instructions, key=lambda x: x[2])
+
     return irreps_out, instructions
 
 


### PR DESCRIPTION
Reordering the interactions in the same order as the outputs simplifies the structure of the weights.

This help to convert the weights from `torch` to `jax`.