### PR TITLE
update installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ conda activate mace_env
 # Install PyTorch
 conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
 
-# Clone and install MACE (and all required packages), use token if still private repo
+# (optional) Install MACE's dependencies from Conda as well
+conda install numpy scipy matplotlib ase opt_einsum prettytable pandas e3nn==0.4.4
+
+# Clone and install MACE (and all required packages)
 git clone git@github.com:ACEsuit/mace.git 
 pip install ./mace
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ conda activate mace_env
 conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
 
 # (optional) Install MACE's dependencies from Conda as well
-conda install numpy scipy matplotlib ase opt_einsum prettytable pandas e3nn==0.4.4
+conda install numpy scipy matplotlib ase opt_einsum prettytable pandas e3nn
 
 # Clone and install MACE (and all required packages)
 git clone git@github.com:ACEsuit/mace.git 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ conda create mace_env
 conda activate mace_env
 
 # Install PyTorch
-conda install pytorch torchvision torchaudio cudatoolkit=11.1 -c pytorch-lts -c conda-forge
+conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
 
 # Clone and install MACE (and all required packages), use token if still private repo
 git clone git@github.com:ACEsuit/mace.git 


### PR DESCRIPTION
Updated the installation instructions in the readme for new users, so they use the correct conda channel for pytorch as well as CUDA 11.6. Added the installation of main dependencies with conda as well there.

see  https://pytorch.org/blog/pytorch-enterprise-support-update/ for information about deprecation