### PR TITLE
openmm-interop compatibility changes

### DIFF
--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -348,6 +348,7 @@ class ScaleShiftMACE(MACE):
         output = {
             "energy": total_energy,
             "node_energy": node_energy,
+            "interaction_energy": inter_e,
             "forces": forces,
             "virials": virials,
             "stress": stress,


### PR DESCRIPTION
write back the interaction energy from the scale shift mace model