### PR TITLE
Refactor Mace & ScaleShiftMace to re-use code

### DIFF
--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -80,7 +80,7 @@ def get_symmetric_displacement(
     edge_index: torch.Tensor,
     num_graphs: torch.Tensor,
     batch: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if cell is None:
         logging.info("Virial required but no cell provided")
         cell = torch.zeros(


### PR DESCRIPTION
refactor to reduce code duplication between the MACE & ScaleShiftMace classes, letting the latter have energy contributions calculated as well.

To my understanding the changes lead to an isomorphic computational graph, however please sanity check it @ilyes319 @davkovacs.