### PR TITLE
Weights and Biases support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ python3 ./mace/scripts/eval_configs.py \
 
 You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE.
 
+## Weights and Biases for experiment tracking
+
+If you would like to use MACE with Weights and Biases to log your experiments simply install with 
+
+```sh
+pip install ./mace[wandb]
+```
+
+And specify the necessary keyword arguments (`--wandb`, `--wandb_project`, `--wandb_entity`, `--wandb_name`, `--wandb_log_hypers`)
+
 ## Development
 
 We use `black`, `isort`, `pylint`, and `mypy`.

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -196,7 +196,6 @@ def load_from_xyz(
     charges_key: str = "charges",
     extract_atomic_energies: bool = False,
 ) -> Tuple[Dict[int, float], Configurations]:
-
     atoms_list = ase.io.read(file_path, index=":")
 
     if not isinstance(atoms_list, list):

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -541,7 +541,6 @@ class RealAgnosticInteractionBlock(InteractionBlock):
 @compile_mode("script")
 class RealAgnosticResidualInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
-
         # First linear
         self.linear_up = o3.Linear(
             self.node_feats_irreps,

--- a/mace/tools/__init__.py
+++ b/mace/tools/__init__.py
@@ -6,13 +6,13 @@ from .torch_tools import (
     cartesian_to_spherical,
     count_parameters,
     init_device,
+    init_wandb,
     set_default_dtype,
     set_seeds,
     spherical_to_cartesian,
     to_numpy,
     to_one_hot,
     voigt_to_matrix,
-    init_wandb,
 )
 from .train import SWAContainer, evaluate, train
 from .utils import (

--- a/mace/tools/__init__.py
+++ b/mace/tools/__init__.py
@@ -12,6 +12,7 @@ from .torch_tools import (
     to_numpy,
     to_one_hot,
     voigt_to_matrix,
+    init_wandb,
 )
 from .train import SWAContainer, evaluate, train
 from .utils import (
@@ -62,4 +63,5 @@ __all__ = [
     "spherical_to_cartesian",
     "cartesian_to_spherical",
     "voigt_to_matrix",
+    "init_wandb",
 ]

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -139,6 +139,19 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default="32x0e",
     )
+    # add option to specify irreps by channel number and max L
+    parser.add_argument(
+        "--num_channels",
+        help="number of embedding channels",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "--max_L",
+        help="max L equivariance of the message",
+        type=int,
+        default=None,
+    )
     parser.add_argument(
         "--gate",
         help="non linearity for last readout",
@@ -411,6 +424,42 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         help="Gradient Clipping Value",
         type=check_float_or_none,
         default=10.0,
+    )
+    # options for using Weights and Biases for experiment tracking
+    # to install see https://wandb.ai
+    parser.add_argument(
+        "--wandb",
+        help="Use Weights and Biases for experiment tracking",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--wandb_project",
+        help="Weights and Biases project name",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "--wandb_entity",
+        help="Weights and Biases entity name",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "--wandb_name",
+        help="Weights and Biases experiment name",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "--wandb_log_hypers",
+        help="The hyperparameters to log in Weights and Biases",
+        type=list,
+        default=["num_channels", "max_L", 
+                 "correlation", "lr", "swa_lr",
+                 "weight_decay", "batch_size",
+                 "max_num_epochs", "start_swa",
+                 "energy_weight", "forces_weight",],
     )
     return parser
 

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -455,11 +455,19 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--wandb_log_hypers",
         help="The hyperparameters to log in Weights and Biases",
         type=list,
-        default=["num_channels", "max_L", 
-                 "correlation", "lr", "swa_lr",
-                 "weight_decay", "batch_size",
-                 "max_num_epochs", "start_swa",
-                 "energy_weight", "forces_weight",],
+        default=[
+            "num_channels",
+            "max_L",
+            "correlation",
+            "lr",
+            "swa_lr",
+            "weight_decay",
+            "batch_size",
+            "max_num_epochs",
+            "start_swa",
+            "energy_weight",
+            "forces_weight",
+        ],
     )
     return parser
 

--- a/mace/tools/scatter.py
+++ b/mace/tools/scatter.py
@@ -58,7 +58,6 @@ def scatter_std(
     dim_size: Optional[int] = None,
     unbiased: bool = True,
 ) -> torch.Tensor:
-
     if out is not None:
         dim_size = out.size(dim)
 

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -107,8 +107,11 @@ def create_error_table(
     model: torch.nn.Module,
     loss_fn: torch.nn.Module,
     output_args: Dict[str, bool],
+    log_wandb: bool,
     device: str,
 ) -> PrettyTable:
+    if log_wandb:
+        import wandb
     table = PrettyTable()
     if table_type == "TotalRMSE":
         table.field_names = [
@@ -186,6 +189,13 @@ def create_error_table(
             output_args=output_args,
             device=device,
         )
+        if log_wandb:
+            wandb_log_dict = {
+                name + "_final_rmse_e_per_atom": metrics["rmse_e_per_atom"] * 1e3,  # meV / atom
+                name + "_final_rmse_f": metrics["rmse_f"] * 1e3,  # meV / A
+                name + "_final_rel_rmse_f": metrics["rel_rmse_f"],
+            }
+            wandb.log(wandb_log_dict)
         if table_type == "TotalRMSE":
             table.add_row(
                 [

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -191,7 +191,9 @@ def create_error_table(
         )
         if log_wandb:
             wandb_log_dict = {
-                name + "_final_rmse_e_per_atom": metrics["rmse_e_per_atom"] * 1e3,  # meV / atom
+                name
+                + "_final_rmse_e_per_atom": metrics["rmse_e_per_atom"]
+                * 1e3,  # meV / atom
                 name + "_final_rmse_f": metrics["rmse_f"] * 1e3,  # meV / A
                 name + "_final_rel_rmse_f": metrics["rel_rmse_f"],
             }

--- a/mace/tools/torch_geometric/dataloader.py
+++ b/mace/tools/torch_geometric/dataloader.py
@@ -71,7 +71,6 @@ class DataLoader(torch.utils.data.DataLoader):
         exclude_keys: Optional[List[str]] = [None],
         **kwargs,
     ):
-
         if "collate_fn" in kwargs:
             del kwargs["collate_fn"]
 

--- a/mace/tools/torch_geometric/dataset.py
+++ b/mace/tools/torch_geometric/dataset.py
@@ -200,7 +200,6 @@ class Dataset(torch.utils.data.Dataset):
             or (isinstance(idx, Tensor) and idx.dim() == 0)
             or (isinstance(idx, np.ndarray) and np.isscalar(idx))
         ):
-
             data = self.get(self.indices()[idx])
             data = data if self.transform is None else self.transform(data)
             return data

--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -113,3 +113,7 @@ def voigt_to_matrix(t: torch.Tensor):
     return torch.tensor(
         [[t[0], t[5], t[4]], [t[5], t[1], t[3]], [t[4], t[3], t[2]]], dtype=t.dtype
     )
+
+def init_wandb(project:str, entity:str, name:str, config:dict):
+    import wandb
+    wandb.init(project=project, entity=entity, name=name, config=config)

--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -114,6 +114,8 @@ def voigt_to_matrix(t: torch.Tensor):
         [[t[0], t[5], t[4]], [t[5], t[1], t[3]], [t[4], t[3], t[2]]], dtype=t.dtype
     )
 
-def init_wandb(project:str, entity:str, name:str, config:dict):
+
+def init_wandb(project: str, entity: str, name: str, config: dict):
     import wandb
+
     wandb.init(project=project, entity=entity, name=name, config=config)

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -55,7 +55,7 @@ def train(
     swa: Optional[SWAContainer] = None,
     ema: Optional[ExponentialMovingAverage] = None,
     max_grad_norm: Optional[float] = 10.0,
-    log_wandb:bool = False,
+    log_wandb: bool = False,
 ):
     lowest_loss = np.inf
     valid_loss = np.inf
@@ -181,7 +181,7 @@ def train(
                 logging.info(
                     f"Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_Mu_per_atom={error_mu:.2f} mDebye"
                 )
-            if wandb:
+            if log_wandb:
                 wandb_log_dict = {
                     "epoch": epoch,
                     "valid_loss": valid_loss,
@@ -234,7 +234,6 @@ def take_step(
     max_grad_norm: Optional[float],
     device: torch.device,
 ) -> Tuple[float, Dict[str, Any]]:
-
     start_time = time.time()
     batch = batch.to(device)
     optimizer.zero_grad(set_to_none=True)

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -55,12 +55,15 @@ def train(
     swa: Optional[SWAContainer] = None,
     ema: Optional[ExponentialMovingAverage] = None,
     max_grad_norm: Optional[float] = 10.0,
+    log_wandb:bool = False,
 ):
     lowest_loss = np.inf
     valid_loss = np.inf
     patience_counter = 0
     swa_start = True
     keep_last = False
+    if log_wandb:
+        import wandb
 
     if max_grad_norm is not None:
         logging.info(f"Using gradient clipping with tolerance={max_grad_norm:.3f}")
@@ -178,6 +181,14 @@ def train(
                 logging.info(
                     f"Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_Mu_per_atom={error_mu:.2f} mDebye"
                 )
+            if wandb:
+                wandb_log_dict = {
+                    "epoch": epoch,
+                    "valid_loss": valid_loss,
+                    "valid_rmse_e_per_atom": eval_metrics["rmse_e_per_atom"],
+                    "valid_rmse_f": eval_metrics["rmse_f"],
+                }
+                wandb.log(wandb_log_dict)
             if valid_loss >= lowest_loss:
                 patience_counter += 1
                 if patience_counter >= patience and epoch < swa.start:

--- a/scripts/run_train.py
+++ b/scripts/run_train.py
@@ -206,14 +206,16 @@ def main() -> None:
     logging.info("Building model")
     if args.num_channels is not None and args.max_L is not None:
         assert args.num_channels > 0, "num_channels must be positive integer"
-        assert args.max_L >= 0 and args.max_L < 4, "max_L must be between 0 and 3, if you want to use larger specify it via the hidden_irrpes keyword"
-        args.hidden_irreps = "{}x0e".format(args.num_channels)
+        assert (
+            args.max_L >= 0 and args.max_L < 4
+        ), "max_L must be between 0 and 3, if you want to use larger specify it via the hidden_irrpes keyword"
+        args.hidden_irreps = f"{args.num_channels:d}x0e"
         if args.max_L > 0:
-            args.hidden_irreps += " + {}x1o".format(args.num_channels)
+            args.hidden_irreps += f" + {args.num_channels:d}x1o"
         if args.max_L > 1:
-            args.hidden_irreps += " + {}x2e".format(args.num_channels)
+            args.hidden_irreps += f" + {args.num_channels:d}x2e"
         if args.max_L > 2:
-            args.hidden_irreps += " + {}x3o".format(args.num_channels)
+            args.hidden_irreps += f" + {args.num_channels:d}x3o"
     logging.info(f"Hidden irreps: {args.hidden_irreps}")
     model_config = dict(
         r_max=args.r_max,
@@ -469,10 +471,12 @@ def main() -> None:
         args_dict = vars(args)
         for key in args.wandb_log_hypers:
             wandb_config[key] = args_dict[key]
-        tools.init_wandb(project=args.wandb_project, 
-                         entity=args.wandb_entity, 
-                         name=args.wandb_name,
-                         config=wandb_config,)
+        tools.init_wandb(
+            project=args.wandb_project,
+            entity=args.wandb_entity,
+            name=args.wandb_name,
+            config=wandb_config,
+        )
 
     tools.train(
         model=model,

--- a/scripts/run_train.py
+++ b/scripts/run_train.py
@@ -184,7 +184,7 @@ def main() -> None:
 
     if args.compute_avg_num_neighbors:
         args.avg_num_neighbors = modules.compute_avg_num_neighbors(train_loader)
-    logging.info(f"Average number of neighbors: {args.avg_num_neighbors:.3f}")
+    logging.info(f"Average number of neighbors: {args.avg_num_neighbors}")
 
     # Selecting outputs
     compute_virials = False

--- a/scripts/run_train.py
+++ b/scripts/run_train.py
@@ -8,6 +8,7 @@ import ast
 import logging
 from pathlib import Path
 from typing import Optional
+import json
 
 import numpy as np
 import torch.nn.functional
@@ -467,8 +468,10 @@ def main() -> None:
 
     if args.wandb:
         logging.info("Using Weights and Biases for logging")
+        import wandb
         wandb_config = {}
         args_dict = vars(args)
+        args_dict_json = json.dumps(args_dict)
         for key in args.wandb_log_hypers:
             wandb_config[key] = args_dict[key]
         tools.init_wandb(
@@ -477,6 +480,7 @@ def main() -> None:
             name=args.wandb_name,
             config=wandb_config,
         )
+        wandb.run.summary["params"] = args_dict_json
 
     tools.train(
         model=model,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ install_requires =
     # for plotting:
     matplotlib
     pandas
+
+[options.extras_require]
+wandb = wandb

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,6 @@ from mace.tools import AtomicNumberTable, torch_geometric
 
 
 class TestAtomicData:
-
     config = Configuration(
         atomic_numbers=np.array([8, 1, 1]),
         positions=np.array(


### PR DESCRIPTION
This pull requests implements the option to track experiments using Weights and Biases as an optional dependency. 

Other small enhancements are specifying hidden irreps via `num_channels` and` max_L` and logging of average number of neighbours precisely. 