### PR TITLE
Added a way to extract invariant node embeddings

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -249,3 +249,36 @@ class MACECalculator(Calculator):
                     .cpu()
                     .numpy()
                 )
+    def get_invariant_descriptors(self, atoms=None) -> np.ndarray|list[np.ndarray]:
+        """ Extracts the invariant part from the node features after each interaction block in the MACE model.
+        :param atoms: ase.Atoms object
+        :return: np.ndarray (num_atoms, num_interactions, invariant_features) of invariant descriptors if num_models is 1 or list[np.ndarray] otherwise
+        """
+        if atoms is None and self.atoms is None:
+            raise ValueError("atoms not set")
+        elif atoms is None:
+            atoms = self.atoms
+            
+        if self.model_type != "MACE":
+            raise NotImplementedError("Only implemented for MACE models")
+            
+        config = data.config_from_atoms(atoms, charges_key=self.charges_key)
+        data_loader = torch_geometric.dataloader.DataLoader(
+            dataset=[
+                data.AtomicData.from_config(
+                    config, z_table=self.z_table, cutoff=self.r_max
+                )
+            ],
+            batch_size=1,
+            shuffle=False,
+            drop_last=False,
+        )
+        batch = next(iter(data_loader)).to(self.device)
+        descriptors = [model.get_node_invariant_descriptors(batch.to_dict()) for model in self.models]
+        descriptors = [descriptor.detach().cpu().numpy() for descriptor in descriptors]
+        
+        if self.num_models == 1:
+            return descriptors[0]
+        else:
+            return descriptors
+        

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -10,6 +10,7 @@ from .blocks import (
     InteractionBlock,
     LinearDipoleReadoutBlock,
     LinearNodeEmbeddingBlock,
+    LinearNodeEmbeddingExtractionBlock,
     LinearReadoutBlock,
     NonLinearDipoleReadoutBlock,
     NonLinearReadoutBlock,

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -40,7 +40,7 @@ class LinearNodeEmbeddingExtractionBlock(torch.nn.Module):
     def __init__(self, irreps_in: o3.Irreps, irreps_out: o3.Irreps):
         super().__init__()
         self.linear = o3.Linear(irreps_in=irreps_in, irreps_out=irreps_out)
-        self.linear.weight.data.fill_(1)
+        self.linear.weight.data = torch.eye(irreps_out.dim).flatten()
         for param in self.linear.parameters():
             param.requires_grad = False
     def forward(

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -34,6 +34,20 @@ class LinearNodeEmbeddingBlock(torch.nn.Module):
         node_attrs: torch.Tensor,
     ) -> torch.Tensor:  # [n_nodes, irreps]
         return self.linear(node_attrs)
+    
+@compile_mode("script")
+class LinearNodeEmbeddingExtractionBlock(torch.nn.Module):
+    def __init__(self, irreps_in: o3.Irreps, irreps_out: o3.Irreps):
+        super().__init__()
+        self.linear = o3.Linear(irreps_in=irreps_in, irreps_out=irreps_out)
+        self.linear.weight.data.fill_(1)
+        for param in self.linear.parameters():
+            param.requires_grad = False
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+    ) -> torch.Tensor:  # [n_nodes, irreps]
+        return self.linear(node_attrs)
 
 
 @compile_mode("script")

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -124,11 +124,11 @@ class MACE(torch.nn.Module):
         self.readouts = torch.nn.ModuleList()
         invariant_irreps = o3.Irreps([(self._num_invariant_features, (0, 1))])
         self.node_extractions = torch.nn.ModuleList(
-            LinearNodeEmbeddingExtractionBlock(
+            [LinearNodeEmbeddingExtractionBlock(
                 irreps_in=hidden_irreps,
-                irreps_out=invariant_irreps),
+                irreps_out=invariant_irreps),]
             )
-        )
+        
 
         self.readouts.append(LinearReadoutBlock(hidden_irreps))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -220,4 +220,4 @@ def test_get_local_embeddings(
         water_configuration, z_table=Z_TABLE, cutoff=3.0
     )
     embeddings = model.get_node_invariant_descriptors(atomic_data)
-    assert embeddings.shape == (*expected_shape, model._num_features)
+    assert embeddings.shape == (*expected_shape, model._num_invariant_features)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,57 +1,23 @@
 import numpy as np
+import pytest
 import torch
 import torch.nn.functional
 from e3nn import o3
 from e3nn.util import jit
 from scipy.spatial.transform import Rotation as R
+import dataclasses
 
 from mace import data, modules, tools
 from mace.tools import torch_geometric
 
 torch.set_default_dtype(torch.float64)
-config = data.Configuration(
-    atomic_numbers=np.array([8, 1, 1]),
-    positions=np.array(
-        [
-            [0.0, -2.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-        ]
-    ),
-    forces=np.array(
-        [
-            [0.0, -1.3, 0.0],
-            [1.0, 0.2, 0.0],
-            [0.0, 1.1, 0.3],
-        ]
-    ),
-    energy=-1.5,
-    charges=np.array([-2.0, 1.0, 1.0]),
-    dipole=np.array([-1.5, 1.5, 2.0]),
-)
-# Created the rotated environment
-rot = R.from_euler("z", 60, degrees=True).as_matrix()
-positions_rotated = np.array(rot @ config.positions.T).T
-config_rotated = data.Configuration(
-    atomic_numbers=np.array([8, 1, 1]),
-    positions=positions_rotated,
-    forces=np.array(
-        [
-            [0.0, -1.3, 0.0],
-            [1.0, 0.2, 0.0],
-            [0.0, 1.1, 0.3],
-        ]
-    ),
-    energy=-1.5,
-    charges=np.array([-2.0, 1.0, 1.0]),
-    dipole=np.array([-1.5, 1.5, 2.0]),
-)
-table = tools.AtomicNumberTable([1, 8])
-atomic_energies = np.array([1.0, 3.0], dtype=float)
+
+Z_TABLE = tools.AtomicNumberTable([1, 8])
 
 
-def test_mace():
-    # Create MACE model
+@pytest.fixture
+def default_params():
+    atomic_energies = np.array([1.0, 3.0], dtype=float)
     model_config = dict(
         r_max=5,
         num_bessel=8,
@@ -70,15 +36,62 @@ def test_mace():
         gate=torch.nn.functional.silu,
         atomic_energies=atomic_energies,
         avg_num_neighbors=8,
-        atomic_numbers=table.zs,
+        atomic_numbers=Z_TABLE.zs,
         correlation=3,
     )
-    model = modules.MACE(**model_config)
+    return model_config
+
+
+@pytest.fixture
+def water_configuration():
+    config = data.Configuration(
+        atomic_numbers=np.array([8, 1, 1]),
+        positions=np.array(
+            [
+                [0.0, -2.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        ),
+        forces=np.array(
+            [
+                [0.0, -1.3, 0.0],
+                [1.0, 0.2, 0.0],
+                [0.0, 1.1, 0.3],
+            ]
+        ),
+        energy=-1.5,
+        charges=np.array([-2.0, 1.0, 1.0]),
+        dipole=np.array([-1.5, 1.5, 2.0]),
+    )
+    return config
+
+
+@pytest.fixture
+def rotation():
+    rot = R.from_euler("z", 60, degrees=True).as_matrix()
+    return rot
+
+
+@pytest.fixture
+def rotated_water(water_configuration, rotation):
+    config_rotated = dataclasses.replace(water_configuration)
+    positions_rotated = np.array(rotation @ config_rotated.positions.T).T
+    config_rotated.positions = positions_rotated
+    return config_rotated
+
+
+def test_mace(default_params, water_configuration, rotated_water):
+    # Create MACE model
+    model = modules.MACE(**default_params)
     model_compiled = jit.compile(model)
 
-    atomic_data = data.AtomicData.from_config(config, z_table=table, cutoff=3.0)
+    config = water_configuration
+    config_rotated = rotated_water
+
+    atomic_data = data.AtomicData.from_config(config, z_table=Z_TABLE, cutoff=3.0)
     atomic_data2 = data.AtomicData.from_config(
-        config_rotated, z_table=table, cutoff=3.0
+        config_rotated, z_table=Z_TABLE, cutoff=3.0
     )
 
     data_loader = torch_geometric.dataloader.DataLoader(
@@ -94,34 +107,24 @@ def test_mace():
     assert torch.allclose(output2["energy"][0], output2["energy"][1])
 
 
-def test_dipole_mace():
+def test_dipole_mace(default_params, water_configuration, rotated_water, rotation):
     # create dipole MACE model
-    model_config = dict(
-        r_max=5,
-        num_bessel=8,
-        num_polynomial_cutoff=5,
-        max_ell=2,
-        interaction_cls=modules.interaction_classes[
-            "RealAgnosticResidualInteractionBlock"
-        ],
-        interaction_cls_first=modules.interaction_classes[
-            "RealAgnosticResidualInteractionBlock"
-        ],
-        num_interactions=2,
-        num_elements=2,
-        hidden_irreps=o3.Irreps("16x0e + 16x1o + 16x2e"),
-        MLP_irreps=o3.Irreps("16x0e"),
-        gate=torch.nn.functional.silu,
-        atomic_energies=None,
-        avg_num_neighbors=3,
-        atomic_numbers=table.zs,
-        correlation=3,
+    model_config = default_params.copy()
+    model_config.update(
+        {
+            "hidden_irreps": o3.Irreps("16x0e + 16x1o + 16x2e"),
+            "atomic_energies": None,
+            "avg_num_neighbors": 3,
+        }
     )
     model = modules.AtomicDipolesMACE(**model_config)
 
-    atomic_data = data.AtomicData.from_config(config, z_table=table, cutoff=3.0)
+    config = water_configuration
+    config_rotated = rotated_water
+
+    atomic_data = data.AtomicData.from_config(config, z_table=Z_TABLE, cutoff=3.0)
     atomic_data2 = data.AtomicData.from_config(
-        config_rotated, z_table=table, cutoff=3.0
+        config_rotated, z_table=Z_TABLE, cutoff=3.0
     )
 
     data_loader = torch_geometric.dataloader.DataLoader(
@@ -139,39 +142,31 @@ def test_dipole_mace():
     assert output["dipole"][0].unsqueeze(0).shape == atomic_data.dipole.shape
     # test equivariance of output dipoles
     assert np.allclose(
-        np.array(rot @ output["dipole"][0].detach().numpy()),
+        np.array(rotation @ output["dipole"][0].detach().numpy()),
         output["dipole"][1].detach().numpy(),
     )
 
 
-def test_energy_dipole_mace():
+def test_energy_dipole_mace(
+    default_params, water_configuration, rotated_water, rotation
+):
     # create dipole MACE model
-    model_config = dict(
-        r_max=5,
-        num_bessel=8,
-        num_polynomial_cutoff=5,
-        max_ell=2,
-        interaction_cls=modules.interaction_classes[
-            "RealAgnosticResidualInteractionBlock"
-        ],
-        interaction_cls_first=modules.interaction_classes[
-            "RealAgnosticResidualInteractionBlock"
-        ],
-        num_interactions=2,
-        num_elements=2,
-        hidden_irreps=o3.Irreps("16x0e + 16x1o + 16x2e"),
-        MLP_irreps=o3.Irreps("16x0e"),
-        gate=torch.nn.functional.silu,
-        atomic_energies=atomic_energies,
-        avg_num_neighbors=3,
-        atomic_numbers=table.zs,
-        correlation=3,
+    model_config = default_params.copy()
+    model_config.update(
+        {
+            "hidden_irreps": o3.Irreps("16x0e + 16x1o + 16x2e"),
+            "avg_num_neighbors": 3,
+            "num_interactions": 2,
+        }
     )
     model = modules.EnergyDipolesMACE(**model_config)
 
-    atomic_data = data.AtomicData.from_config(config, z_table=table, cutoff=3.0)
+    config = water_configuration
+    config_rotated = rotated_water
+
+    atomic_data = data.AtomicData.from_config(config, z_table=Z_TABLE, cutoff=3.0)
     atomic_data2 = data.AtomicData.from_config(
-        config_rotated, z_table=table, cutoff=3.0
+        config_rotated, z_table=Z_TABLE, cutoff=3.0
     )
 
     data_loader = torch_geometric.dataloader.DataLoader(
@@ -191,6 +186,38 @@ def test_energy_dipole_mace():
     assert torch.allclose(output["energy"][0], output["energy"][1])
     # test equivariance of output dipoles
     assert np.allclose(
-        np.array(rot @ output["dipole"][0].detach().numpy()),
+        np.array(rotation @ output["dipole"][0].detach().numpy()),
         output["dipole"][1].detach().numpy(),
     )
+
+
+@pytest.mark.parametrize(
+    "param_changes, expected_shape",
+    [
+        (
+            {},
+            (
+                3,
+                5,
+            ),
+        ),
+        (
+            {"num_interactions": 1, "hidden_irreps": o3.Irreps("96x0e + 96x1o")},
+            (
+                3,
+                1,
+            ),
+        ),
+    ],
+)
+def test_get_local_embeddings(
+    default_params, water_configuration, param_changes, expected_shape
+):
+    default_params = default_params.copy()
+    default_params.update(param_changes)
+    model = modules.MACE(**default_params)
+    atomic_data = data.AtomicData.from_config(
+        water_configuration, z_table=Z_TABLE, cutoff=3.0
+    )
+    embeddings = model.get_node_invariant_descriptors(atomic_data)
+    assert embeddings.shape == (*expected_shape, model._num_features)

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -10,6 +10,7 @@ from mace.modules import (
     PolynomialCutoff,
     SymmetricContraction,
     WeightedEnergyForcesLoss,
+    LinearNodeEmbeddingExtractionBlock,
 )
 from mace.tools import AtomicNumberTable, scatter, to_numpy, torch_geometric
 
@@ -103,3 +104,12 @@ class TestBlocks:
         out = scatter.scatter_sum(src=energies, index=batch.batch, dim=-1, reduce="sum")
         out = to_numpy(out)
         assert np.allclose(out, np.array([5.0, 5.0]))
+
+    def test_node_extraction_block(self):
+        irrep_in = o3.Irreps("17x0e + 5x1o + 3x2e")
+        irrep_out = o3.Irreps("17x0e")
+        extraction_block = LinearNodeEmbeddingExtractionBlock(irrep_in, irrep_out)
+        test_input = irrep_in.randn(10, -1)
+        out = extraction_block(test_input)
+        assert out.shape == (10, 17)
+        np.testing.assert_array_almost_equal(out, test_input[:, :17] / np.sqrt(17))


### PR DESCRIPTION
[Related issue](https://github.com/ACEsuit/mace/issues/68)

Added a method `get_node_invariant_descriptors` to extract the invariant part of the learnt node representations using MACE and models that inherit the MACE class.

Cleaned up the forward by putting the calculation of initial embeddings in a separate function.

Added tests for the descriptor retrieval.

Cleaned up test_models.py by adding fixtures to reduce code repetition. 

