### PR TITLE
Require stress in shape (3,3) or (6,)

### DIFF
--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -109,10 +109,21 @@ def voigt_to_matrix(t: torch.Tensor):
     """
     if t.shape == (3, 3):
         return t
-
-    return torch.tensor(
-        [[t[0], t[5], t[4]], [t[5], t[1], t[3]], [t[4], t[3], t[2]]], dtype=t.dtype
-    )
+    elif t.shape == (6,):
+        return torch.tensor(
+            [
+                [t[0], t[5], t[4]],
+                [t[5], t[1], t[3]],
+                [t[4], t[3], t[2]],
+            ],
+            dtype=t.dtype,
+        )
+    else:
+        raise ValueError(
+            "Stress tensor must be of shape (6,) or (3, 3), but has shape {}.".format(
+                t.shape
+            )
+        )
 
 
 def init_wandb(project: str, entity: str, name: str, config: dict):


### PR DESCRIPTION
## Desired behaviour: 
Stress can either be supplied in Voigt notation (6,) or as a full 3x3 matrix. If the stress property has any other shape an error should be raised. 

## Previous behaviour:
If a (n,) vector is supplied, the first six elements are taken to be stress matrix in Voigt notation. Hence if a flattened 3x3 matrix (ie of shape (9,)) is supplied, one would obtain insensible stresses. 
