### PR TITLE
Argparse list arguments

### DIFF
--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -460,7 +460,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--wandb_log_hypers",
         help="The hyperparameters to log in Weights and Biases",
-        type=list,
+        type=str,
+        nargs="+",
         default=[
             "num_channels",
             "max_L",


### PR DESCRIPTION
Previous `type=list` would parse option

`--wandb_log_hypers "aa bb" ` -> `["a", "a", " ", "b", "b"]`

Now 

`--wandb_log_hypers aa bb` ->` ["aa", "bb"]`. 



