### PR TITLE
Interaction layer specific settings

### DIFF
--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -47,7 +47,7 @@ class AtomicData(torch_geometric.data.Data):
     def __init__(
         self,
         edge_index: torch.Tensor,  # [2, n_edges]
-        edge_mask: torch.Tensor,  # [n_layers, n_edges]
+        edge_index_mask: torch.Tensor,  # [n_layers, n_edges]
         node_attrs: torch.Tensor,  # [n_nodes, n_node_feats]
         positions: torch.Tensor,  # [n_nodes, 3]
         shifts: torch.Tensor,  # [n_edges, 3],
@@ -69,7 +69,7 @@ class AtomicData(torch_geometric.data.Data):
         num_nodes = node_attrs.shape[0]
 
         assert edge_index.shape[0] == 2 and len(edge_index.shape) == 2
-        assert edge_mask.shape[1] == edge_index.shape[1]
+        assert edge_index_mask.shape[1] == edge_index.shape[1]
         assert positions.shape == (num_nodes, 3)
         assert shifts.shape[1] == 3
         assert unit_shifts.shape[1] == 3
@@ -90,7 +90,7 @@ class AtomicData(torch_geometric.data.Data):
         data = {
             "num_nodes": num_nodes,
             "edge_index": edge_index,
-            'edge_mask': edge_mask,
+            'edge_index_mask': edge_index_mask,
             "positions": positions,
             "shifts": shifts,
             "unit_shifts": unit_shifts,
@@ -127,7 +127,7 @@ class AtomicData(torch_geometric.data.Data):
             axis=1,
         )
 
-        edge_mask = torch.tensor(edge_distance) < cutoffs[:, np.newaxis]
+        edge_index_mask = torch.tensor(edge_distance) < cutoffs[:, np.newaxis]
         indices = atomic_numbers_to_indices(config.atomic_numbers, z_table=z_table)
         one_hot = to_one_hot(
             torch.tensor(indices, dtype=torch.long).unsqueeze(-1),
@@ -207,7 +207,7 @@ class AtomicData(torch_geometric.data.Data):
 
         return cls(
             edge_index=torch.tensor(edge_index, dtype=torch.long),
-            edge_mask=torch.tensor(edge_mask, dtype=torch.long),
+            edge_index_mask=torch.tensor(edge_index_mask, dtype=torch.bool),
             positions=torch.tensor(config.positions, dtype=torch.get_default_dtype()),
             shifts=torch.tensor(shifts, dtype=torch.get_default_dtype()),
             unit_shifts=torch.tensor(unit_shifts, dtype=torch.get_default_dtype()),

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -131,8 +131,7 @@ class AtomicData(torch_geometric.data.Data):
             config.positions[edge_index[0]] - config.positions[edge_index[1]] - shifts,
             axis=1,
         )
-
-        edge_index_mask = torch.tensor(edge_distance) < cutoffs[:, np.newaxis]
+        edge_index_mask = torch.tensor(edge_distance, device=cutoffs.device) < cutoffs[:, None]
         indices = atomic_numbers_to_indices(config.atomic_numbers, z_table=z_table)
         one_hot = to_one_hot(
             torch.tensor(indices, dtype=torch.long).unsqueeze(-1),

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -350,8 +350,8 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
             self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
         )
         self.conv_tp = o3.TensorProduct(
-            self.node_feats_irreps,
-            self.edge_attrs_irreps,
+            self.node_feats_irreps,  # h,
+            self.edge_attrs_irreps,  # Y(r)
             irreps_mid,
             instructions=instructions,
             shared_weights=False,
@@ -363,7 +363,7 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
         self.conv_tp_weights = nn.FullyConnectedNet(
             [input_dim] + self.radial_MLP + [self.conv_tp.weight_numel],
             torch.nn.functional.silu,
-        )
+        )  # Radial basis (RW)
 
         # Linear
         irreps_mid = irreps_mid.simplify()
@@ -389,7 +389,7 @@ class AgnosticNonlinearInteractionBlock(InteractionBlock):
         sender = edge_index[0]
         receiver = edge_index[1]
         num_nodes = node_feats.shape[0]
-        tp_weights = self.conv_tp_weights(edge_feats)
+        tp_weights = self.conv_tp_weights(edge_feats)  # R(r)
         node_feats = self.linear_up(node_feats)
         mji = self.conv_tp(
             node_feats[sender], edge_attrs, tp_weights

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -335,16 +335,16 @@ class ScaleShiftMACE(MACE):
         for i, (interaction, product, readout, radial_embedding) in enumerate(zip(
             self.interactions, self.products, self.readouts, self.radial_embeddings
         )):
-            edge_mask = data["edge_mask"][i, :]
-            edge_attrsi = edge_attrs[edge_mask]
-            edge_featsi = radial_embedding(lengths[edge_mask])
+            edge_index_mask = data["edge_index_mask"][i, :]
+            edge_attrsi = edge_attrs[edge_index_mask]
+            edge_featsi = radial_embedding(lengths[edge_index_mask])
 
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
                 node_feats=node_feats,
                 edge_attrs=edge_attrsi,
                 edge_feats=edge_featsi,
-                edge_index=data["edge_index"][:,edge_mask],
+                edge_index=data["edge_index"][:,edge_index_mask],
             )
             node_feats = product(
                 node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -211,7 +211,6 @@ class MACE(torch.nn.Module):
             shifts=data["shifts"],
         )
         edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
 
         # Interactions
         energies = [e0]

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -39,7 +39,7 @@ from .utils import (
 class MACE(torch.nn.Module):
     def __init__(
         self,
-        r_max: float,
+        r_max: List[float],
         num_bessel: int,
         num_polynomial_cutoff: int,
         max_ell: int,
@@ -52,7 +52,7 @@ class MACE(torch.nn.Module):
         atomic_energies: np.ndarray,
         avg_num_neighbors: float,
         atomic_numbers: List[int],
-        correlation: int,
+        correlations: List[int],
         gate: Optional[Callable],
     ):
         super().__init__()
@@ -63,18 +63,23 @@ class MACE(torch.nn.Module):
         self.register_buffer(
             "num_interactions", torch.tensor(num_interactions, dtype=torch.int64)
         )
+
+        # Radial embedding, interactions and readouts
+        self.radial_embeddings = torch.nn.ModuleList()
+
         # Embedding
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
             irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
         )
-        self.radial_embedding = RadialEmbeddingBlock(
-            r_max=r_max,
+        radial_embedding_first = RadialEmbeddingBlock(
+            r_max=r_max[0],
             num_bessel=num_bessel,
             num_polynomial_cutoff=num_polynomial_cutoff,
         )
-        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
+        edge_feats_irreps_first = o3.Irreps(f"{radial_embedding_first.out_dim}x0e")
+        self.radial_embeddings.append(radial_embedding_first)
 
         sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
         num_features = hidden_irreps.count(o3.Irrep(0, 1))
@@ -90,7 +95,7 @@ class MACE(torch.nn.Module):
             node_attrs_irreps=node_attr_irreps,
             node_feats_irreps=node_feats_irreps,
             edge_attrs_irreps=sh_irreps,
-            edge_feats_irreps=edge_feats_irreps,
+            edge_feats_irreps=edge_feats_irreps_first,
             target_irreps=interaction_irreps,
             hidden_irreps=hidden_irreps,
             avg_num_neighbors=avg_num_neighbors,
@@ -106,7 +111,7 @@ class MACE(torch.nn.Module):
         prod = EquivariantProductBasisBlock(
             node_feats_irreps=node_feats_irreps_out,
             target_irreps=hidden_irreps,
-            correlation=correlation,
+            correlation=correlations[0],
             num_elements=num_elements,
             use_sc=use_sc_first,
         )
@@ -122,6 +127,15 @@ class MACE(torch.nn.Module):
                 )  # Select only scalars for last layer
             else:
                 hidden_irreps_out = hidden_irreps
+
+            radial_embedding = RadialEmbeddingBlock(
+                r_max=r_max[i + 1],
+                num_bessel=num_bessel,
+                num_polynomial_cutoff=num_polynomial_cutoff,
+            )
+            edge_feats_irreps = o3.Irreps(f"{radial_embedding.out_dim}x0e")
+            self.radial_embeddings.append(radial_embedding)
+
             inter = interaction_cls(
                 node_attrs_irreps=node_attr_irreps,
                 node_feats_irreps=hidden_irreps,
@@ -135,7 +149,7 @@ class MACE(torch.nn.Module):
             prod = EquivariantProductBasisBlock(
                 node_feats_irreps=interaction_irreps,
                 target_irreps=hidden_irreps_out,
-                correlation=correlation,
+                correlation=correlations[i+1],
                 num_elements=num_elements,
                 use_sc=True,
             )
@@ -192,14 +206,20 @@ class MACE(torch.nn.Module):
             shifts=data["shifts"],
         )
         edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
 
         # Interactions
         energies = [e0]
         node_energies_list = [node_e0]
-        for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
+        for (interaction, product, readout, radial_embedding) in zip(
+            self.interactions, self.products, self.readouts, self.radial_embeddings
         ):
+            vectorsi, lengthsi = get_edge_vectors_and_lengths(
+                positions=data["positions"],
+                edge_index=data["edge_index"],
+                shifts=data["shifts"],
+            )
+            edge_attrsi = self.spherical_harmonics(vectors)
+            edge_feats = radial_embedding(lengths)
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
                 node_feats=node_feats,
@@ -297,7 +317,11 @@ class ScaleShiftMACE(MACE):
             src=node_e0, index=data["batch"], dim=-1, dim_size=num_graphs
         )  # [n_graphs,]
 
+
         # Embeddings
+
+        # First get all spherical harmonic
+
         node_feats = self.node_embedding(data["node_attrs"])
         vectors, lengths = get_edge_vectors_and_lengths(
             positions=data["positions"],
@@ -305,19 +329,22 @@ class ScaleShiftMACE(MACE):
             shifts=data["shifts"],
         )
         edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
 
         # Interactions
         node_es_list = []
-        for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
-        ):
+        for i, (interaction, product, readout, radial_embedding) in enumerate(zip(
+            self.interactions, self.products, self.readouts, self.radial_embeddings
+        )):
+            edge_mask = data["edge_mask"][i, :]
+            edge_attrsi = edge_attrs[edge_mask]
+            edge_featsi = radial_embedding(lengths[edge_mask])
+
             node_feats, sc = interaction(
                 node_attrs=data["node_attrs"],
                 node_feats=node_feats,
-                edge_attrs=edge_attrs,
-                edge_feats=edge_feats,
-                edge_index=data["edge_index"],
+                edge_attrs=edge_attrsi,
+                edge_feats=edge_featsi,
+                edge_index=data["edge_index"][:,edge_mask],
             )
             node_feats = product(
                 node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]
@@ -384,18 +411,25 @@ class BOTNet(torch.nn.Module):
         super().__init__()
         self.r_max = r_max
         self.atomic_numbers = atomic_numbers
+
+        # Radial embedding, interactions and readouts
+        self.interactions = torch.nn.ModuleList()
+        self.readouts = torch.nn.ModuleList()
+        self.radial_embeddings = torch.nn.ModuleList()
+
         # Embedding
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
         self.node_embedding = LinearNodeEmbeddingBlock(
             irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
         )
-        self.radial_embedding = RadialEmbeddingBlock(
-            r_max=r_max,
+        radial_embedding_first = RadialEmbeddingBlock(
+            r_max=r_max[0],
             num_bessel=num_bessel,
             num_polynomial_cutoff=num_polynomial_cutoff,
         )
-        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
+
+        edge_feats_irreps_first = o3.Irreps(f"{radial_embedding_first.out_dim}x0e")
 
         sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
         self.spherical_harmonics = o3.SphericalHarmonics(
@@ -405,14 +439,13 @@ class BOTNet(torch.nn.Module):
         # Interactions and readouts
         self.atomic_energies_fn = AtomicEnergiesBlock(atomic_energies)
 
-        self.interactions = torch.nn.ModuleList()
-        self.readouts = torch.nn.ModuleList()
+
 
         inter = interaction_cls_first(
             node_attrs_irreps=node_attr_irreps,
             node_feats_irreps=node_feats_irreps,
             edge_attrs_irreps=sh_irreps,
-            edge_feats_irreps=edge_feats_irreps,
+            edge_feats_irreps=edge_feats_irreps_first,
             target_irreps=hidden_irreps,
             avg_num_neighbors=avg_num_neighbors,
         )
@@ -420,6 +453,14 @@ class BOTNet(torch.nn.Module):
         self.readouts.append(LinearReadoutBlock(inter.irreps_out))
 
         for i in range(num_interactions - 1):
+            radial_embedding = RadialEmbeddingBlock(
+                r_max=r_max[i+1],
+                num_bessel=num_bessel,
+                num_polynomial_cutoff=num_polynomial_cutoff,
+            )
+            edge_feats_irreps = o3.Irreps(f"{radial_embedding.out_dim}x0e")
+            self.radial_embeddings.append(radial_embedding)
+
             inter = interaction_cls(
                 node_attrs_irreps=node_attr_irreps,
                 node_feats_irreps=inter.irreps_out,
@@ -452,11 +493,12 @@ class BOTNet(torch.nn.Module):
             positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
         )
         edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
 
         # Interactions
         energies = [e0]
         for interaction, readout in zip(self.interactions, self.readouts):
+            edge_feats = self.radial_embedding(lengths)
+
             node_feats = interaction(
                 node_attrs=data.node_attrs,
                 node_feats=node_feats,

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -214,12 +214,10 @@ def compute_mean_rms_energy_forces(
 
 def compute_avg_num_neighbors(data_loader: torch.utils.data.DataLoader) -> float:
     num_neighbors = []
-
     for batch in data_loader:
         _, receivers = batch.edge_index
         _, counts = torch.unique(receivers, return_counts=True)
         num_neighbors.append(counts)
-
     avg_num_neighbors = torch.mean(
         torch.cat(num_neighbors, dim=0).type(torch.get_default_dtype())
     )

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -84,7 +84,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         ],
     )
     parser.add_argument(
-        "--r_max", help="distance cutoff (in Ang)", type=float, default=5.0
+        "--r_max", help="distance cutoff (in Ang). Float or list of values for each layer", type=str, default=5.0
     )
     parser.add_argument(
         "--num_radial_basis",
@@ -122,7 +122,11 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--max_ell", help=r"highest \ell of spherical harmonics", type=int, default=3
     )
     parser.add_argument(
-        "--correlation", help="correlation order at each layer", type=int, default=3
+        "--correlation",
+        help="correlation order at each layer. "
+        "Can be list of values for each layer or single int ",
+        type=str,
+        default=3,
     )
     parser.add_argument(
         "--num_interactions", help="number of interactions", type=int, default=2

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -173,7 +173,7 @@ def create_error_table(
     for name, subset in all_collections:
         data_loader = torch_geometric.dataloader.DataLoader(
             dataset=[
-                AtomicData.from_config(config, z_table=z_table, cutoff=r_max)
+                AtomicData.from_config(config, z_table=z_table, cutoffs=r_max)
                 for config in subset
             ],
             batch_size=valid_batch_size,

--- a/mace/tools/torch_geometric/batch.py
+++ b/mace/tools/torch_geometric/batch.py
@@ -116,6 +116,7 @@ class Batch(Data):
                             torch.full((size,), i, dtype=torch.long, device=device)
                         )
 
+
             if hasattr(data, "__num_nodes__"):
                 num_nodes_list.append(data.__num_nodes__)
             else:
@@ -136,12 +137,11 @@ class Batch(Data):
 
         ref_data = data_list[0]
         for key in batch.keys:
-            print(key)
             items = batch[key]
             item = items[0]
+            # currently checks if index or face in key. If true -1, else 0
             cat_dim = ref_data.__cat_dim__(key, item)
             cat_dim = 0 if cat_dim is None else cat_dim
-            breakpoint()
             if isinstance(item, Tensor):
                 batch[key] = torch.cat(items, cat_dim)
             elif isinstance(item, (int, float)):

--- a/mace/tools/torch_geometric/batch.py
+++ b/mace/tools/torch_geometric/batch.py
@@ -136,10 +136,12 @@ class Batch(Data):
 
         ref_data = data_list[0]
         for key in batch.keys:
+            print(key)
             items = batch[key]
             item = items[0]
             cat_dim = ref_data.__cat_dim__(key, item)
             cat_dim = 0 if cat_dim is None else cat_dim
+            breakpoint()
             if isinstance(item, Tensor):
                 batch[key] = torch.cat(items, cat_dim)
             elif isinstance(item, (int, float)):

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -182,11 +182,15 @@ def train(
                     f"Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_Mu_per_atom={error_mu:.2f} mDebye"
                 )
             if log_wandb:
+                eval_metrics_valid_prefix = {
+                    f"valid_{k}": v for k, v in eval_metrics.items()
+                }
                 wandb_log_dict = {
                     "epoch": epoch,
                     "valid_loss": valid_loss,
                     "valid_rmse_e_per_atom": eval_metrics["rmse_e_per_atom"],
                     "valid_rmse_f": eval_metrics["rmse_f"],
+                    **eval_metrics_valid_prefix,
                 }
                 wandb.log(wandb_log_dict)
             if valid_loss >= lowest_loss:

--- a/scripts/run_train.py
+++ b/scripts/run_train.py
@@ -201,7 +201,6 @@ def main() -> None:
             energy_weight=args.energy_weight, forces_weight=args.forces_weight
         )
     logging.info(loss_fn)
-    breakpoint()
     if args.compute_avg_num_neighbors:
         args.avg_num_neighbors = modules.compute_avg_num_neighbors(train_loader)
     logging.info(f"Average number of neighbors: {args.avg_num_neighbors}")
@@ -276,7 +275,7 @@ def main() -> None:
         mean, std = modules.scaling_classes[args.scaling](train_loader, atomic_energies)
         model = modules.ScaleShiftMACE(
             **model_config,
-            correlation=args.correlation,
+            correlations=correlation,
             gate=modules.gate_dict[args.gate],
             interaction_cls_first=modules.interaction_classes[args.interaction_first],
             MLP_irreps=o3.Irreps(args.MLP_irreps),


### PR DESCRIPTION
This commit allows for the cutoff and correlation order to be different for different message passing layers. 

`correlation` and `r_max` now accepts a list of length `num_interactions`. 

eg. 

```
--num_interactions=3
--correlation="[3,3,1]"
--r_max="[7.0,3.0,7.0]"
```