### PR TITLE
Refactor MACE subclasses - reduce code duplication & clearer logic

### DIFF
--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -18,9 +18,11 @@ from .blocks import (
     EquivariantProductBasisBlock,
     InteractionBlock,
     LinearDipoleReadoutBlock,
+    LinearDipoleOnlyReadoutBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
     NonLinearDipoleReadoutBlock,
+    NonLinearDipoleOnlyReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
     ScaleShiftBlock,
@@ -37,6 +39,9 @@ from .utils import (
 @compile_mode("script")
 class MACE(torch.nn.Module):
     """MACE model"""
+
+    _LINEAR_READOUT_CLASS = LinearReadoutBlock
+    _NONLINEAR_READOUT_CLASS = NonLinearReadoutBlock
 
     def __init__(
         self,
@@ -117,13 +122,11 @@ class MACE(torch.nn.Module):
         self.products = torch.nn.ModuleList([prod])
 
         self.readouts = torch.nn.ModuleList()
-        self.readouts.append(LinearReadoutBlock(hidden_irreps))
+        self.readouts.append(self._LINEAR_READOUT_CLASS(hidden_irreps))
 
         for i in range(num_interactions - 1):
             if i == num_interactions - 2:
-                hidden_irreps_out = str(
-                    hidden_irreps[0]
-                )  # Select only scalars for last layer
+                hidden_irreps_out = self._last_layer_irreps(hidden_irreps)
             else:
                 hidden_irreps_out = hidden_irreps
             inter = interaction_cls(
@@ -147,10 +150,19 @@ class MACE(torch.nn.Module):
             self.products.append(prod)
             if i == num_interactions - 2:
                 self.readouts.append(
-                    NonLinearReadoutBlock(hidden_irreps_out, MLP_irreps, gate)
+                    self._NONLINEAR_READOUT_CLASS(hidden_irreps_out, MLP_irreps, gate)
                 )
             else:
-                self.readouts.append(LinearReadoutBlock(hidden_irreps))
+                self.readouts.append(self._LINEAR_READOUT_CLASS(hidden_irreps))
+
+    @staticmethod
+    def _last_layer_irreps(hidden_irreps) -> o3.Irreps:
+        """Irreps to use in the last layer - used for initialisation of subclasses
+
+        energy: Select only scalars for last layer
+
+        """
+        return o3.Irreps(str(hidden_irreps[0]))
 
     def _forward_calculate_e0(self, data: Dict[str, torch.Tensor]) -> torch.Tensor:
         """Forward pass internal - e0 calculation
@@ -198,7 +210,7 @@ class MACE(torch.nn.Module):
         edge_feats = self.radial_embedding(lengths)
 
         # Interactions
-        node_interaction_energies = []
+        layer_outputs = []
         for interaction, product, readout in zip(
             self.interactions, self.products, self.readouts
         ):
@@ -214,11 +226,10 @@ class MACE(torch.nn.Module):
                 sc=sc,
                 node_attrs=data["node_attrs"],
             )
-            node_interaction_energies.append(
-                readout(node_feats).squeeze(-1)  # [n_nodes, ]
-            )
 
-        return torch.sum(torch.stack(node_interaction_energies, dim=0), dim=0)
+            layer_outputs.append(readout(node_feats).squeeze(-1))  # [n_nodes, ]
+
+        return torch.sum(torch.stack(layer_outputs, dim=0), dim=0)
 
     def forward(
         self,
@@ -414,15 +425,15 @@ class BOTNet(torch.nn.Module):
         data.positions.requires_grad = True
 
         # Atomic energies
-        node_e0 = self.atomic_energies_fn(data.node_attrs)
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])
         e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_e0, index=data["batch"], dim=-1, dim_size=data["num_graphs"]
         )  # [n_graphs,]
 
         # Embeddings
-        node_feats = self.node_embedding(data.node_attrs)
+        node_feats = self.node_embedding(data["node_attrs"])
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions, edge_index=data["edge_index"], shifts=data.shifts
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -431,15 +442,18 @@ class BOTNet(torch.nn.Module):
         energies = [e0]
         for interaction, readout in zip(self.interactions, self.readouts):
             node_feats = interaction(
-                node_attrs=data.node_attrs,
+                node_attrs=data["node_attrs"],
                 node_feats=node_feats,
                 edge_attrs=edge_attrs,
                 edge_feats=edge_feats,
-                edge_index=data.edge_index,
+                edge_index=data["edge_index"],
             )
             node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
             energy = scatter_sum(
-                src=node_energies, index=data.batch, dim=-1, dim_size=data.num_graphs
+                src=node_energies,
+                index=data["batch"],
+                dim=-1,
+                dim_size=data["num_graphs"],
             )  # [n_graphs,]
             energies.append(energy)
 
@@ -475,15 +489,15 @@ class ScaleShiftBOTNet(BOTNet):
         data.positions.requires_grad = True
 
         # Atomic energies
-        node_e0 = self.atomic_energies_fn(data.node_attrs)
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])
         e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_e0, index=data["batch"], dim=-1, dim_size=data["num_graphs"]
         )  # [n_graphs,]
 
         # Embeddings
-        node_feats = self.node_embedding(data.node_attrs)
+        node_feats = self.node_embedding(data["node_attrs"])
         vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+            positions=data.positions, edge_index=data["edge_index"], shifts=data.shifts
         )
         edge_attrs = self.spherical_harmonics(vectors)
         edge_feats = self.radial_embedding(lengths)
@@ -492,11 +506,11 @@ class ScaleShiftBOTNet(BOTNet):
         node_es_list = []
         for interaction, readout in zip(self.interactions, self.readouts):
             node_feats = interaction(
-                node_attrs=data.node_attrs,
+                node_attrs=data["node_attrs"],
                 node_feats=node_feats,
                 edge_attrs=edge_attrs,
                 edge_feats=edge_feats,
-                edge_index=data.edge_index,
+                edge_index=data["edge_index"],
             )
 
             node_es_list.append(readout(node_feats).squeeze(-1))  # {[n_nodes, ], }
@@ -509,7 +523,7 @@ class ScaleShiftBOTNet(BOTNet):
 
         # Sum over nodes in graph
         inter_e = scatter_sum(
-            src=node_inter_es, index=data.batch, dim=-1, dim_size=data.num_graphs
+            src=node_inter_es, index=data["batch"], dim=-1, dim_size=data["num_graphs"]
         )  # [n_graphs,]
 
         # Add E_0 and (scaled) interaction energy
@@ -525,7 +539,13 @@ class ScaleShiftBOTNet(BOTNet):
         return output
 
 
-class AtomicDipolesMACE(torch.nn.Module):
+@compile_mode("script")
+class AtomicDipolesMACE(MACE):
+    """MACE model for Dipoles only"""
+
+    _LINEAR_READOUT_CLASS = LinearDipoleOnlyReadoutBlock
+    _NONLINEAR_READOUT_CLASS = NonLinearDipoleOnlyReadoutBlock
+
     def __init__(
         self,
         r_max: float,
@@ -545,114 +565,59 @@ class AtomicDipolesMACE(torch.nn.Module):
         atomic_energies: Optional[
             None
         ],  # Just here to make it compatible with energy models, MUST be None
+        radial_MLP: Optional[List[int]] = None,
     ):
-        super().__init__()
-        assert atomic_energies is None
-        self.r_max = r_max
-        self.atomic_numbers = atomic_numbers
+        assert (
+            len(hidden_irreps) > 1
+        ), "To predict dipoles use at least l=1 hidden_irreps"
 
-        # Embedding
-        node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
-        node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
-        self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
-        )
-        self.radial_embedding = RadialEmbeddingBlock(
+        super().__init__(
             r_max=r_max,
             num_bessel=num_bessel,
             num_polynomial_cutoff=num_polynomial_cutoff,
-        )
-        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
-
-        sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
-        num_features = hidden_irreps.count(o3.Irrep(0, 1))
-        interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
-        self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
-        )
-
-        # Interactions and readouts
-        inter = interaction_cls_first(
-            node_attrs_irreps=node_attr_irreps,
-            node_feats_irreps=node_feats_irreps,
-            edge_attrs_irreps=sh_irreps,
-            edge_feats_irreps=edge_feats_irreps,
-            target_irreps=hidden_irreps,
-            hidden_irreps=hidden_irreps,
-            avg_num_neighbors=avg_num_neighbors,
-        )
-        self.interactions = torch.nn.ModuleList([inter])
-
-        # Use the appropriate self connection at the first layer
-        use_sc_first = False
-        if "Residual" in str(interaction_cls_first):
-            use_sc_first = True
-
-        node_feats_irreps_out = inter.target_irreps
-        prod = EquivariantProductBasisBlock(
-            node_feats_irreps=node_feats_irreps_out,
-            target_irreps=hidden_irreps,
-            correlation=correlation,
+            max_ell=max_ell,
+            interaction_cls=interaction_cls,
+            interaction_cls_first=interaction_cls_first,
+            num_interactions=num_interactions,
             num_elements=num_elements,
-            use_sc=use_sc_first,
+            hidden_irreps=hidden_irreps,
+            MLP_irreps=MLP_irreps,
+            atomic_energies=np.array([]),
+            avg_num_neighbors=avg_num_neighbors,
+            atomic_numbers=atomic_numbers,
+            correlation=correlation,
+            gate=gate,
+            radial_MLP=radial_MLP,
         )
-        self.products = torch.nn.ModuleList([prod])
 
-        self.readouts = torch.nn.ModuleList()
-        self.readouts.append(LinearDipoleReadoutBlock(hidden_irreps, dipole_only=True))
+    @staticmethod
+    def _last_layer_irreps(hidden_irreps) -> o3.Irreps:
+        """Irreps to use in the last layer - used for initialisation of subclasses
 
-        for i in range(num_interactions - 1):
-            if i == num_interactions - 2:
-                assert (
-                    len(hidden_irreps) > 1
-                ), "To predict dipoles use at least l=1 hidden_irreps"
-                hidden_irreps_out = str(
-                    hidden_irreps[1]
-                )  # Select only l=1 vectors for last layer
-            else:
-                hidden_irreps_out = hidden_irreps
-            inter = interaction_cls(
-                node_attrs_irreps=node_attr_irreps,
-                node_feats_irreps=inter.irreps_out,
-                edge_attrs_irreps=sh_irreps,
-                edge_feats_irreps=edge_feats_irreps,
-                target_irreps=interaction_irreps,
-                hidden_irreps=hidden_irreps_out,
-                avg_num_neighbors=avg_num_neighbors,
-            )
-            self.interactions.append(inter)
-            prod = EquivariantProductBasisBlock(
-                node_feats_irreps=interaction_irreps,
-                target_irreps=hidden_irreps_out,
-                correlation=correlation,
-                num_elements=num_elements,
-                use_sc=True,
-            )
-            self.products.append(prod)
-            if i == num_interactions - 2:
-                self.readouts.append(
-                    NonLinearDipoleReadoutBlock(
-                        hidden_irreps_out, MLP_irreps, gate, dipole_only=True
-                    )
-                )
-            else:
-                self.readouts.append(
-                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=True)
-                )
+        dipole: Select only l=1 vectors for last layer
+
+        """
+        return o3.Irreps(str(hidden_irreps[1]))
 
     def forward(
         self,
-        data: AtomicData,
-        training=False,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
         compute_force: bool = False,
         compute_virials: bool = False,
         compute_stress: bool = False,
-    ) -> Dict[str, Any]:
-        assert compute_force is False
-        assert compute_virials is False
-        assert compute_stress is False
+        compute_displacement: bool = False,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # dipoles and virials / stress not supported simultaneously
+        error_msg = "AtomicDipolesMACE does not support energy & its derivatives"
+        assert not compute_force, error_msg
+        assert not compute_virials, error_msg
+        assert not compute_stress, error_msg
+        assert not compute_displacement, error_msg
+
         # Setup
-        data.positions.requires_grad = True
+        num_graphs = data["ptr"].numel() - 1
+        data["positions"].requires_grad = True
         if not training:
             for p in self.parameters():
                 p.requires_grad = False
@@ -660,60 +625,37 @@ class AtomicDipolesMACE(torch.nn.Module):
             for p in self.parameters():
                 p.requires_grad = True
 
-        # Embeddings
-        node_feats = self.node_embedding(data.node_attrs)
-        vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
-        )
-        edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
+        # Evaluate layer outputs
+        atomic_dipoles = self._forward_calculate_interactions(data)
 
-        # Interactions
-        dipoles = []
-        for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
-        ):
-            node_feats, sc = interaction(
-                node_attrs=data.node_attrs,
-                node_feats=node_feats,
-                edge_attrs=edge_attrs,
-                edge_feats=edge_feats,
-                edge_index=data.edge_index,
-            )
-            node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data.node_attrs
-            )
-            node_dipoles = readout(node_feats).squeeze(-1)  # [n_nodes,3]
-            dipoles.append(node_dipoles)
-
-        # Compute the dipoles
-        contributions_dipoles = torch.stack(
-            dipoles, dim=-1
-        )  # [n_nodes,3,n_contributions]
-        atomic_dipoles = torch.sum(contributions_dipoles, dim=-1)  # [n_nodes,3]
+        # Sum over dipole contributions
+        baseline_dipole = compute_fixed_charge_dipole(
+            charges=data["charges"],
+            positions=data["positions"],
+            batch=data["batch"],
+            num_graphs=num_graphs,
+        )  # [n_graphs,3]
         total_dipole = scatter_sum(
             src=atomic_dipoles,
-            index=data.batch.unsqueeze(-1),
+            index=data["batch"].unsqueeze(-1),
             dim=0,
-            dim_size=data.num_graphs,
+            dim_size=num_graphs,
         )  # [n_graphs,3]
-        baseline = compute_fixed_charge_dipole(
-            charges=data.charges,
-            positions=data.positions,
-            batch=data.batch,
-            num_graphs=data.num_graphs,
-        )  # [n_graphs,3]
-        total_dipole = total_dipole + baseline
+        total_dipole += baseline_dipole
 
-        output = {
+        return {
             "dipole": total_dipole,
             "atomic_dipoles": atomic_dipoles,
         }
 
-        return output
 
+@compile_mode("script")
+class EnergyDipolesMACE(MACE):
+    """MACE model for Energy & Dipoles"""
 
-class EnergyDipolesMACE(torch.nn.Module):
+    _LINEAR_READOUT_CLASS = LinearDipoleReadoutBlock
+    _NONLINEAR_READOUT_CLASS = NonLinearDipoleReadoutBlock
+
     def __init__(
         self,
         r_max: float,
@@ -726,119 +668,63 @@ class EnergyDipolesMACE(torch.nn.Module):
         num_elements: int,
         hidden_irreps: o3.Irreps,
         MLP_irreps: o3.Irreps,
+        atomic_energies: np.ndarray,
         avg_num_neighbors: float,
         atomic_numbers: List[int],
         correlation: int,
         gate: Optional[Callable],
-        atomic_energies: Optional[np.ndarray],
+        radial_MLP: Optional[List[int]] = None,
     ):
-        super().__init__()
-        self.r_max = r_max
-        self.atomic_numbers = atomic_numbers
-        # Embedding
-        node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
-        node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
-        self.node_embedding = LinearNodeEmbeddingBlock(
-            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
-        )
-        self.radial_embedding = RadialEmbeddingBlock(
+        assert (
+            len(hidden_irreps) > 1
+        ), "To predict dipoles use at least l=1 hidden_irreps"
+
+        super().__init__(
             r_max=r_max,
             num_bessel=num_bessel,
             num_polynomial_cutoff=num_polynomial_cutoff,
-        )
-        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
-
-        sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
-        num_features = hidden_irreps.count(o3.Irrep(0, 1))
-        interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
-        self.spherical_harmonics = o3.SphericalHarmonics(
-            sh_irreps, normalize=True, normalization="component"
-        )
-
-        # Interactions and readouts
-        self.atomic_energies_fn = AtomicEnergiesBlock(atomic_energies)
-
-        inter = interaction_cls_first(
-            node_attrs_irreps=node_attr_irreps,
-            node_feats_irreps=node_feats_irreps,
-            edge_attrs_irreps=sh_irreps,
-            edge_feats_irreps=edge_feats_irreps,
-            target_irreps=hidden_irreps,
-            hidden_irreps=hidden_irreps,
-            avg_num_neighbors=avg_num_neighbors,
-        )
-        self.interactions = torch.nn.ModuleList([inter])
-
-        # Use the appropriate self connection at the first layer
-        use_sc_first = False
-        if "Residual" in str(interaction_cls_first):
-            use_sc_first = True
-
-        node_feats_irreps_out = inter.target_irreps
-        prod = EquivariantProductBasisBlock(
-            node_feats_irreps=node_feats_irreps_out,
-            target_irreps=hidden_irreps,
-            correlation=correlation,
+            max_ell=max_ell,
+            interaction_cls=interaction_cls,
+            interaction_cls_first=interaction_cls_first,
+            num_interactions=num_interactions,
             num_elements=num_elements,
-            use_sc=use_sc_first,
+            hidden_irreps=hidden_irreps,
+            MLP_irreps=MLP_irreps,
+            atomic_energies=atomic_energies,
+            avg_num_neighbors=avg_num_neighbors,
+            atomic_numbers=atomic_numbers,
+            correlation=correlation,
+            gate=gate,
+            radial_MLP=radial_MLP,
         )
-        self.products = torch.nn.ModuleList([prod])
 
-        self.readouts = torch.nn.ModuleList()
-        self.readouts.append(LinearDipoleReadoutBlock(hidden_irreps, dipole_only=False))
+    @staticmethod
+    def _last_layer_irreps(hidden_irreps) -> o3.Irreps:
+        """Irreps to use in the last layer - used for initialisation of subclasses
 
-        for i in range(num_interactions - 1):
-            if i == num_interactions - 2:
-                assert (
-                    len(hidden_irreps) > 1
-                ), "To predict dipoles use at least l=1 hidden_irreps"
-                hidden_irreps_out = str(
-                    hidden_irreps[:2]
-                )  # Select scalars and l=1 vectors for last layer
-            else:
-                hidden_irreps_out = hidden_irreps
-            inter = interaction_cls(
-                node_attrs_irreps=node_attr_irreps,
-                node_feats_irreps=inter.irreps_out,
-                edge_attrs_irreps=sh_irreps,
-                edge_feats_irreps=edge_feats_irreps,
-                target_irreps=interaction_irreps,
-                hidden_irreps=hidden_irreps_out,
-                avg_num_neighbors=avg_num_neighbors,
-            )
-            self.interactions.append(inter)
-            prod = EquivariantProductBasisBlock(
-                node_feats_irreps=interaction_irreps,
-                target_irreps=hidden_irreps_out,
-                correlation=correlation,
-                num_elements=num_elements,
-                use_sc=True,
-            )
-            self.products.append(prod)
-            if i == num_interactions - 2:
-                self.readouts.append(
-                    NonLinearDipoleReadoutBlock(
-                        hidden_irreps_out, MLP_irreps, gate, dipole_only=False
-                    )
-                )
-            else:
-                self.readouts.append(
-                    LinearDipoleReadoutBlock(hidden_irreps, dipole_only=False)
-                )
+        energy & dipole: Select scalars and l=1 vectors for last layer
+
+        """
+        return o3.Irreps(str(hidden_irreps[:2]))
 
     def forward(
         self,
-        data: AtomicData,
-        training=False,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,
         compute_force: bool = True,
         compute_virials: bool = False,
         compute_stress: bool = False,
-    ) -> Dict[str, Any]:
+        compute_displacement: bool = False,
+    ) -> Dict[str, Optional[torch.Tensor]]:
         # dipoles and virials / stress not supported simultaneously
-        assert compute_virials is False
-        assert compute_stress is False
+        error_msg = "dipoles and virials / stress not supported simultaneously"
+        assert not compute_virials, error_msg
+        assert not compute_stress, error_msg
+        assert not compute_displacement, error_msg
+
         # Setup
-        data.positions.requires_grad = True
+        num_graphs = data["ptr"].numel() - 1
+        data["positions"].requires_grad = True
         if not training:
             for p in self.parameters():
                 p.requires_grad = False
@@ -847,84 +733,50 @@ class EnergyDipolesMACE(torch.nn.Module):
                 p.requires_grad = True
 
         # Atomic energies
-        node_e0 = self.atomic_energies_fn(data.node_attrs)
-        e0 = scatter_sum(
-            src=node_e0, index=data.batch, dim=-1, dim_size=data.num_graphs
+        node_e0 = self._forward_calculate_e0(data)
+
+        # Evaluate layer outputs
+        layer_outputs = self._forward_calculate_interactions(data)
+        interaction_energies = layer_outputs[:, 0]
+        atomic_dipoles = layer_outputs[:, 1:]
+
+        # Sum over energy contributions
+        node_energy = node_e0 + interaction_energies
+        total_energy = scatter_sum(
+            src=node_energy, index=data["batch"], dim=-1, dim_size=num_graphs
         )  # [n_graphs,]
 
-        # Embeddings
-        node_feats = self.node_embedding(data.node_attrs)
-        vectors, lengths = get_edge_vectors_and_lengths(
-            positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
-        )
-        edge_attrs = self.spherical_harmonics(vectors)
-        edge_feats = self.radial_embedding(lengths)
-
-        # Interactions
-        energies = [e0]
-        dipoles = []
-        for interaction, product, readout in zip(
-            self.interactions, self.products, self.readouts
-        ):
-            node_feats, sc = interaction(
-                node_attrs=data.node_attrs,
-                node_feats=node_feats,
-                edge_attrs=edge_attrs,
-                edge_feats=edge_feats,
-                edge_index=data.edge_index,
-            )
-            node_feats = product(
-                node_feats=node_feats, sc=sc, node_attrs=data.node_attrs
-            )
-            node_out = readout(node_feats).squeeze(-1)  # [n_nodes, ]
-            # node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
-            node_energies = node_out[:, 0]
-            energy = scatter_sum(
-                src=node_energies, index=data.batch, dim=-1, dim_size=data.num_graphs
-            )  # [n_graphs,]
-            energies.append(energy)
-            # node_dipoles = readout(node_feats).squeeze(-1)  # [n_nodes,3]
-            node_dipoles = node_out[:, 1:]
-            dipoles.append(node_dipoles)
-
-        # Compute the energies and dipoles
-        contributions = torch.stack(energies, dim=-1)
-        total_energy = torch.sum(contributions, dim=-1)  # [n_graphs, ]
-        contributions_dipoles = torch.stack(
-            dipoles, dim=-1
-        )  # [n_nodes,3,n_contributions]
-        atomic_dipoles = torch.sum(contributions_dipoles, dim=-1)  # [n_nodes,3]
+        # Sum over dipole contributions
+        baseline_dipole = compute_fixed_charge_dipole(
+            charges=data["charges"],
+            positions=data["positions"],
+            batch=data["batch"],
+            num_graphs=num_graphs,
+        )  # [n_graphs,3]
         total_dipole = scatter_sum(
             src=atomic_dipoles,
-            index=data.batch.unsqueeze(-1),
+            index=data["batch"].unsqueeze(-1),
             dim=0,
-            dim_size=data.num_graphs,
+            dim_size=num_graphs,
         )  # [n_graphs,3]
-        baseline = compute_fixed_charge_dipole(
-            charges=data.charges,
-            positions=data.positions,
-            batch=data.batch,
-            num_graphs=data.num_graphs,
-        )  # [n_graphs,3]
-        total_dipole = total_dipole + baseline
+        total_dipole += baseline_dipole
 
+        # Calculate derivatives if needed
         forces, _, _ = get_outputs(
             energy=total_energy,
-            positions=data.positions,
+            positions=data["positions"],
             displacement=None,
-            cell=data.cell,
+            cell=data["cell"],
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,
             compute_stress=compute_stress,
         )
 
-        output = {
+        return {
             "energy": total_energy,
-            "contributions": contributions,
+            "node_energy": node_energy,
             "forces": forces,
             "dipole": total_dipole,
             "atomic_dipoles": atomic_dipoles,
         }
-
-        return output

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -182,7 +182,7 @@ def test_energy_dipole_mace():
     )
     batch = next(iter(data_loader))
     output = model(
-        batch,
+        batch.to_dict(),
         training=True,
     )
     # sanity check of dipoles being the right shape


### PR DESCRIPTION
Supersedes #65, implements the JIT part of #95 as well for free

Refactored subclasses of `MACE`:
- `ScaleShiftMACE`: Only scales & shifts MACE
- `AtomicDipolesMACE`: Only defined dipole calculation capabilities
- `EnergyDipolesMACE`: Energy & dipole calculation

Main changes:
- `__init__` is basically the same, there is only a little difference, which is handled with
    - readout block classes are kept in as class members
    - irreps of the last layer is computed with a function (overwritten by subclasses)
- parts of the forward pass calculation are separated into internal functions