### PR TITLE
Slight modification to HDF5Dataset

### DIFF
--- a/mace/data/hdf5_dataset.py
+++ b/mace/data/hdf5_dataset.py
@@ -30,7 +30,6 @@ class HDF5ChainDataset(ChainDataset):
         return _d
 
     def __call__(self):
-        self.file = h5py.File(self.file, "r")
         datasets = []
         for i in range(self.length):
             grp = self.file["config_" + str(i)]


### PR DESCRIPTION
If a `h5py.File` object is an attribute of the Dataset, pickle will complain that the file is not pickleable. 

This change resolves that by making file a property that is constructed and cached when it is first accessed. This allows the `h5py.File` to be excluded when pickling.