### PR TITLE
Make CPU saving default

### DIFF
--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -429,8 +429,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--save_cpu",
         help="Save a model to be loaded on cpu",
-        action="store_true",
-        default=False,
+        action="store_false",
+        default=True,
     )
     parser.add_argument(
         "--clip_grad",


### PR DESCRIPTION
## Goal
Make saving to cpu the default saving mode for more robustness.

## Change
The "--save_cpu" flag is now a "store_false" action and should be used to **not** save to the cpu see https://github.com/ACEsuit/mace/blob/7543f162cfc02b41c1654c73d8c7a393b8b9e9d5/mace/tools/arg_parser.py#L417