### PR TITLE
Update all docs references to contents of scripts/ to mace/cli/

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install ./mace
 To train a MACE model, you can use the `run_train.py` script:
 
 ```sh
-python ./mace/scripts/run_train.py \
+python <mace_repo_dir>/mace/cli/run_train.py \
     --name="MACE_model" \
     --train_file="train.xyz" \
     --valid_fraction=0.05 \

--- a/docs/examples/training_examples.rst
+++ b/docs/examples/training_examples.rst
@@ -14,7 +14,7 @@ An example script for training the 2-layer model on the carbon nanotube (largest
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="nanotube_large_r55" \
         --train_file="nanotube_large.xyz" \
         --valid_fraction=0.05 \
@@ -49,7 +49,7 @@ In comparison, the single layer model uses ``max_L=0``, because there is no equi
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="nano_large_r6" \
         --train_file="nanotube_large.xyz" \
         --valid_fraction=0.05 \
@@ -90,7 +90,7 @@ To train MACE on large datasets one can preprocess the data and use on the fly d
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/preprocess_data.py \
+    python <mace_repo_dir>/mace/cli/preprocess_data.py \
         --train_file="ani1x_cc_dft.xyz" \
         --valid_fraction=0.03 \
         --energy_key="DFT_energy" \
@@ -106,7 +106,7 @@ The training script for the smallest model is given below.
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="ani500k_small" \
         --train_file="ANI1x_cc_DFT_rc5_train.h5" \
         --valid_file="ANI1x_cc_DFT_rc5_valid.h5" \
@@ -145,7 +145,7 @@ The model can easily be transfer learned to CC level of theory. For this the pre
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="ani500k_small" \
         --train_file="ANI1x_cc_rc5_train.h5" \
         --valid_file="ANI1x_cc_rc5_valid.h5" \
@@ -193,7 +193,7 @@ To train the smaller MACE model used in the simulations of the paper we used the
 
 .. code-block:: shell
 
-    python /PATH/TO/MACE/mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="water_1k_small" \
         --train_file="train.xyz" \
         --valid_fraction=0.05 \

--- a/docs/guide/evaluation.rst
+++ b/docs/guide/evaluation.rst
@@ -8,7 +8,7 @@ To evaluate your MACE model on an XYZ file, run the `eval_configs.py`:
 
 .. code-block:: bash
     
-    python3 ./mace/scripts/eval_configs.py \
+    python3 <mace_repo_dir>/mace/cli/eval_configs.py \
         --configs="your_configs.xyz" \
         --model="your_model.model" \
         --output="./your_output.xyz" 

--- a/docs/guide/lammps.rst
+++ b/docs/guide/lammps.rst
@@ -21,7 +21,7 @@ Preparing your model
 
 Train the model using the `develop` branch. Afterwards, use the `create_lammps_model.py` script to prepare a torchscript-compiled LAMMPS_MACE model::
 
-    python [mace_dir]/scripts/create_lammps_model.py my_mace.model
+    python <mace_repo_dir>/mace/cli/create_lammps_model.py my_mace.model
 
 Instructions for GPU
 ====================

--- a/docs/guide/training.rst
+++ b/docs/guide/training.rst
@@ -7,11 +7,12 @@ Training
 Script
 ------
 
-To train a MACE model, you can use the `run_train.py` script:
+To train a MACE model, you can use the `run_train.py` script (note that if you used `pip install` to install
+mace, you can also use the executable `mace_run_train` entry point which should be in your path).
 
 .. code-block:: bash
 
-    python ./mace/scripts/run_train.py \
+    python <mace_repo_dir>/mace/cli/run_train.py \
         --name="MACE_model" \
         --train_file="train.xyz" \
         --valid_fraction=0.05 \


### PR DESCRIPTION
Updated in various docs file.  Note that there's a reference to `preprocess_data.py`, whose path I updated, although it doesn't actually seem to exist anymore.