### PR TITLE
Fix deprecation warning from default `mace_mp()` behavior

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -26,8 +26,10 @@ def mace_mp(
     Note:
         If you are using this function, please cite the relevant paper for the Materials Project,
         any paper associated with the MACE model, and also the following:
-        - "MACE-Universal by Yuan Chiang, 2023, Hugging Face, Revision e5ebd9b, DOI: 10.57967/hf/1202, URL: https://huggingface.co/cyrusyc/mace-universal"
-        - "Matbench Discovery by Janosh Riebesell, Rhys EA Goodall, Anubhav Jain, Philipp Benner, Kristin A Persson, Alpha A Lee, 2023, arXiv:2308.14920"
+        - MACE-Universal by Yuan Chiang, 2023, Hugging Face, Revision e5ebd9b,
+            DOI: 10.57967/hf/1202, URL: https://huggingface.co/cyrusyc/mace-universal
+        - Matbench Discovery by Janosh Riebesell, Rhys EA Goodall, Philipp Benner, Yuan Chiang,
+            Alpha A Lee, Anubhav Jain, Kristin A Persson, 2023, arXiv:2308.14920
 
     Args:
         device (str, optional): Device to use for the model. Defaults to "cuda".

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -6,6 +6,7 @@ from typing import Union
 import torch
 from ase import units
 from ase.calculators.mixing import SumCalculator
+
 from .mace import MACECalculator
 
 module_dir = os.path.dirname(__file__)
@@ -32,10 +33,10 @@ def mace_mp(
             Alpha A Lee, Anubhav Jain, Kristin A Persson, 2023, arXiv:2308.14920
 
     Args:
-        device (str, optional): Device to use for the model. Defaults to "cuda".
         model (str, optional): Path to the model. Defaults to None which first checks for
             a local model and then downloads the default model from figshare. Specify "medium"
             or "large" to download a smaller or larger model from figshare.
+        device (str, optional): Device to use for the model. Defaults to "cuda".
         default_dtype (str, optional): Default dtype for the model. Defaults to "float32".
         dispersion (bool, optional): Whether to use D3 dispersion corrections. Defaults to False.
         dispersion_xc (str, optional): Exchange-correlation functional for D3 dispersion corrections.
@@ -88,7 +89,7 @@ def mace_mp(
 
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     mace_calc = MACECalculator(
-        model, device=device, default_dtype=default_dtype, **kwargs
+        models_paths=model, device=device, default_dtype=default_dtype, **kwargs
     )
     if dispersion:
         try:

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -90,7 +90,7 @@ class MACECalculator(Calculator):
             model_paths = kwargs["model_path"]
 
         if isinstance(model_paths, str):
-            # Find all models that staisfy the wildcard (e.g. mace_model_*.pt)
+            # Find all models that satisfy the wildcard (e.g. mace_model_*.pt)
             model_paths_glob = glob(model_paths)
             if len(model_paths_glob) == 0:
                 raise ValueError(f"Couldn't find MACE model files: {model_paths}")
@@ -98,7 +98,7 @@ class MACECalculator(Calculator):
         elif isinstance(model_paths, Path):
             model_paths = [model_paths]
         if len(model_paths) == 0:
-            raise ValueError("No mace file neames supplied")
+            raise ValueError("No mace file names supplied")
         self.num_models = len(model_paths)
         if len(model_paths) > 1:
             print(f"Running committee mace with {len(model_paths)} models")
@@ -153,7 +153,7 @@ class MACECalculator(Calculator):
         """
         Create tensors to store the results of the committee
         :param model_type: str, type of model to load
-                    Options: [MACE, DipoleMACE, EnergyDipoleMACE]
+            Options: [MACE, DipoleMACE, EnergyDipoleMACE]
         :param num_models: int, number of models in the committee
         :return: tuple of torch tensors
         """


### PR DESCRIPTION
Currently calling `mace_mp` with no args issues warning

> `model_path` argument deprecated, use `model_paths`

Also, adding to @chiang-yuan to Matbench Discovery list of authors in `mace_mp` doc string.