### PR TITLE
Fix `mace_mp` download

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ mace_eval_configs \
 
 ## Tutorial
 
-You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE. We also have a more detailed user and developer tutorial at https://github.com/ilyes319/mace-tutorials 
+You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE. We also have a more detailed user and developer tutorial at https://github.com/ilyes319/mace-tutorials
 
 ## Weights and Biases for experiment tracking
 
@@ -171,9 +171,9 @@ We are happy to accept pull requests under an [MIT license](https://choosealicen
 
 ## Pretrained Universal MACE Checkpoints
 
-### Materials Project 
+### Materials Project
 
-We have collaborated with the Materials Project (MP) who trained universal MACE checkpoints covering 89 elements on 1.6 M bulk crystals in the [MPTrj dataset](https://figshare.com/articles/dataset/23713842) selected from MP relaxation trajectories. These pretrained models were used for materials stability prediction in [Matbench Discovery](https://matbench-discovery.materialsproject.org) and the corresponding [preprint](https://arxiv.org/abs/2308.14920). For easy reuse, these checkpoints were published on [Hugging Face](https://huggingface.co/cyrusyc/mace-universal).
+We have collaborated with the Materials Project (MP) who trained universal MACE checkpoints covering 89 elements on 1.6 M bulk crystals in the [MPTrj dataset](https://figshare.com/articles/dataset/23713842) selected from MP relaxation trajectories. These pretrained models were used for materials stability prediction in [Matbench Discovery](https://matbench-discovery.materialsproject.org) and the corresponding [preprint](https://arxiv.org/abs/2308.14920). For easy reuse, these checkpoints were published on [Hugging Face](https://huggingface.co/cyrusyc/mace-universal) and [Figshare](https://figshare.com/articles/dataset/22715158) with direct download links for the [`medium`](https://figshare.com/ndownloader/files/42374049) and [`large`](https://figshare.com/ndownloader/files/43117273) checkpoints.
 
 ## References
 

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -71,8 +71,8 @@ def mace_mp(
             if not os.path.isfile(cached_model_path):
                 os.makedirs(cache_dir, exist_ok=True)
                 # download and save to disk
-                print(f"Downloading MACE model from {model!r}")
-                urllib.request.urlretrieve(model, cached_model_path)
+                print(f"Downloading MACE model from {checkpoint_url!r}")
+                urllib.request.urlretrieve(checkpoint_url, cached_model_path)
                 print(f"Cached MACE model to {cached_model_path}")
             model = cached_model_path
             msg = f"Using Materials Project MACE for MACECalculator with {model=}"


### PR DESCRIPTION
Was trying to download from 

```py
urllib.request.urlretrieve(model, cached_model_path)
```

which should have been

```py
urllib.request.urlretrieve(checkpoint_url, cached_model_path)
```

since `model` can be `None`. Thanks @utf for reporting.
