### PR TITLE
Add an option to set the D3 damping function, which defaults to D3(BJ)

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -1,7 +1,7 @@
 import os
 import urllib.request
 from pathlib import Path
-from typing import Union
+from typing import Literal, Union
 
 import torch
 from ase import units
@@ -20,6 +20,7 @@ def mace_mp(
     device: str = "",
     default_dtype: str = "float32",
     dispersion: bool = False,
+    damping: Literal["zero", "bj", "zerom", "bjm"] = "bj",
     dispersion_xc="pbe",
     dispersion_cutoff=40.0 * units.Bohr,
     **kwargs,
@@ -42,6 +43,7 @@ def mace_mp(
         device (str, optional): Device to use for the model. Defaults to "cuda".
         default_dtype (str, optional): Default dtype for the model. Defaults to "float32".
         dispersion (bool, optional): Whether to use D3 dispersion corrections. Defaults to False.
+        damping (str): The damping function associated with the D3 correction. Defaults to "bj" for D3(BJ).
         dispersion_xc (str, optional): Exchange-correlation functional for D3 dispersion corrections.
         dispersion_cutoff (float, optional): Cutoff radius in Bhor for D3 dispersion corrections.
         **kwargs: Passed to MACECalculator and TorchDFTD3Calculator.
@@ -111,7 +113,7 @@ def mace_mp(
         dtype = torch.float32 if default_dtype == "float32" else torch.float64
         d3_calc = TorchDFTD3Calculator(
             device=device,
-            damping="bj",
+            damping=damping,
             dtype=dtype,
             xc=dispersion_xc,
             cutoff=dispersion_cutoff,

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -21,8 +21,8 @@ def mace_mp(
     default_dtype: str = "float32",
     dispersion: bool = False,
     damping: Literal["zero", "bj", "zerom", "bjm"] = "bj",
-    dispersion_xc="pbe",
-    dispersion_cutoff=40.0 * units.Bohr,
+    dispersion_xc: str = "pbe",
+    dispersion_cutoff: float = 40.0 * units.Bohr,
     **kwargs,
 ) -> MACECalculator:
     """
@@ -124,8 +124,8 @@ def mace_mp(
 
 
 def mace_anicc(
-    device="cuda",
-    model_path=None,
+    device: str ="cuda",
+    model_path: str | Path = None,
 ) -> MACECalculator:
     """
     Constructs a MACECalculator with a pretrained model based on the ANI (H, C, N, O).


### PR DESCRIPTION
This PR adds the `damping` parameter to the foundation model calculator, which defaults to "bj" for backwards compatibility (and because it makes the most sense). This is also done for added clarity, as it's not mentioned anywhere in the docstring whether a damping function is used. In fact, at a quick glance, the user might be misled to thinking no damping is used since "D3" is printed to screen even though it is actually D3(BJ).