### PR TITLE
load_foundations support for max_L other than 2

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -351,6 +351,7 @@ def main() -> None:
             model_foundation,
             z_table,
             load_readout=True,
+            max_L=args.max_L,
         )
     model.to(device)
 

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -157,6 +157,7 @@ def load_foundations(
     load_readout=False,
     use_shift=False,
     use_scale=True,
+    max_L=2,
 ):
     """
     Load the foundations of a model into a model for fine-tuning.
@@ -230,7 +231,7 @@ def load_foundations(
 
     # Transferring products
     for i in range(2):  # Assuming 2 products modules
-        max_range = 3 if i == 0 else 1
+        max_range = max_L + 1 if i == 0 else 1
         for j in range(max_range):  # Assuming 3 contractions in symmetric_contractions
             model.products[i].symmetric_contractions.contractions[
                 j


### PR DESCRIPTION
Pass `max_L` argument to `load_foundations`, and use it to control j (# of contractions) loop