### PR TITLE
Add link to github models

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -57,8 +57,8 @@ def mace_mp(
     elif model in (None, "small", "medium", "large") or str(model).startswith("https:"):
         try:
             urls = dict(
-                small="https://tinyurl.com/2jmmb8b7",  # 2023-12-10-mace-128-L0_energy_epoch-249.model
-                medium="https://tinyurl.com/y7uhwpje",  # 2023-12-03-mace-128-L1_epoch-199.model
+                small="https://tinyurl.com/2jmmb8b7?confirm=yTib",  # 2023-12-10-mace-128-L0_energy_epoch-249.model
+                medium="https://tinyurl.com/y7uhwpje?confirm=yTib",  # 2023-12-03-mace-128-L1_epoch-199.model
                 large="https://figshare.com/ndownloader/files/43117273",
             )
             checkpoint_url = (
@@ -75,7 +75,14 @@ def mace_mp(
                 os.makedirs(cache_dir, exist_ok=True)
                 # download and save to disk
                 print(f"Downloading MACE model from {checkpoint_url!r}")
-                urllib.request.urlretrieve(checkpoint_url, cached_model_path)
+                _, http_msg = urllib.request.urlretrieve(
+                    checkpoint_url, cached_model_path
+                )
+                # make sure download was successful
+                if "Content-Type: application/octet-stream" not in http_msg:
+                    raise RuntimeError(
+                        f"Model download failed, please check {checkpoint_url}"
+                    )
                 print(f"Cached MACE model to {cached_model_path}")
             model = cached_model_path
             msg = f"Using Materials Project MACE for MACECalculator with {model}"
@@ -165,9 +172,11 @@ def mace_off(
             # download and save to disk
             print(f"Downloading MACE model from {checkpoint_url!r}")
             print(
-                f"The model is distributed under the Academic Software License (ASL) license, see https://github.com/gabor1/ASL \n To use the model you accept the terms of the license."
+                "The model is distributed under the Academic Software License (ASL) license, see https://github.com/gabor1/ASL \n To use the model you accept the terms of the license."
             )
-            print("ASL is based on the Gnu Public License, but does not permit commercial use")
+            print(
+                "ASL is based on the Gnu Public License, but does not permit commercial use"
+            )
             urllib.request.urlretrieve(checkpoint_url, cached_model_path)
             print(f"Cached MACE model to {cached_model_path}")
         model = cached_model_path

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -26,10 +26,12 @@ def mace_mp(
 ) -> MACECalculator:
     """
     Constructs a MACECalculator with a pretrained model based on the Materials Project (89 elements).
-    The model is released under the MIT license.
+    The model is released under the MIT license. See https://github.com/ACEsuit/mace-mp for all models.
     Note:
         If you are using this function, please cite the relevant paper for the Materials Project,
         any paper associated with the MACE model, and also the following:
+        - MACE-MP by Ilyes Batatia, Philipp Benner, Yuan Chiang, Alin M. Elena,
+            Dávid P. Kovács, Janosh Riebesell, et al., 2023, arXiv:2401.00096
         - MACE-Universal by Yuan Chiang, 2023, Hugging Face, Revision e5ebd9b,
             DOI: 10.57967/hf/1202, URL: https://huggingface.co/cyrusyc/mace-universal
         - Matbench Discovery by Janosh Riebesell, Rhys EA Goodall, Philipp Benner, Yuan Chiang,
@@ -57,9 +59,9 @@ def mace_mp(
     elif model in (None, "small", "medium", "large") or str(model).startswith("https:"):
         try:
             urls = dict(
-                small="https://tinyurl.com/2jmmb8b7?confirm=yTib",  # 2023-12-10-mace-128-L0_energy_epoch-249.model
-                medium="https://tinyurl.com/y7uhwpje?confirm=yTib",  # 2023-12-03-mace-128-L1_epoch-199.model
-                large="https://figshare.com/ndownloader/files/43117273",
+                small="http://tinyurl.com/46jrkm3v",  # 2023-12-10-mace-128-L0_energy_epoch-249.model
+                medium="http://tinyurl.com/5yyxdm76",  # 2023-12-03-mace-128-L1_epoch-199.model
+                large="http://tinyurl.com/5f5yavf3",  # MACE_MPtrj_2022.9.model
             )
             checkpoint_url = (
                 urls.get(model, urls["medium"])
@@ -78,10 +80,9 @@ def mace_mp(
                 _, http_msg = urllib.request.urlretrieve(
                     checkpoint_url, cached_model_path
                 )
-                # make sure download was successful
-                if "Content-Type: application/octet-stream" not in http_msg:
+                if "Content-Type: text/html" in http_msg:
                     raise RuntimeError(
-                        f"Model download failed, please check {checkpoint_url}"
+                        f"Model download failed, please check the URL {checkpoint_url}"
                     )
                 print(f"Cached MACE model to {cached_model_path}")
             model = cached_model_path


### PR DESCRIPTION
Based on this answer https://stackoverflow.com/a/35160609 and my own testing, appending `?confirm=yTib` to the download URL avoids the Google Drive virus scan page that the model checkpoint links are automatically redirected to.

I confirmed locally that this resolves the pickle error reported by @Andrew-S-Rosen and also seen in [`matcalc`](https://github.com/materialsvirtuallab/matcalc/actions/runs/7486930755/job/20378280067):

```py
>       magic_number = pickle_module.load(f, **pickle_load_args)
E       _pickle.UnpicklingError: invalid load key, '<'.

/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/torch/serialization.py:1246: UnpicklingError
```