### PR TITLE
Update compile test case to use larger test system

### DIFF
--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -5,6 +5,7 @@
 ###########################################################################################
 
 import logging
+from contextlib import contextmanager
 from typing import Dict
 
 import numpy as np
@@ -133,3 +134,16 @@ def init_wandb(project: str, entity: str, name: str, config: dict):
     import wandb
 
     wandb.init(project=project, entity=entity, name=name, config=config)
+
+
+@contextmanager
+def default_dtype(dtype: torch.dtype):
+    """Context manager for configuring the default_dtype used by torch
+
+    Args:
+        dtype (torch.dtype): the default dtype to use within this context manager
+    """
+    init = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    yield
+    torch.set_default_dtype(init)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -87,10 +87,8 @@ def time_func(func: Callable):
 
 @pytest.fixture(params=[torch.float32, torch.float64], ids=["fp32", "fp64"])
 def default_dtype(request):
-    init = torch.get_default_dtype()
-    torch.set_default_dtype(request.param)
-    yield torch.get_default_dtype()
-    torch.set_default_dtype(init)
+    with tools.torch_tools.default_dtype(request.param):
+        yield torch.get_default_dtype()
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])


### PR DESCRIPTION
This PR follows up the earlier torch.compile support #300 and aims to make the input test a bit more realistic with 64 carbon atoms.   Added additional test cases that use the [pytest-benchmark](https://pypi.org/project/pytest-benchmark/) plugin to collect timings for different options.

One subtlety/controversial change is that the correctness test (`test_mace`) now uses `torch.testing.assert_allclose` as this uses more permissive comparison tolerances than using `assert torch.allclose` directly.

Measuring the inference time on an A10G:

|  | Time (ms) | Speedup vs eager fp64 |
|--------|--------|--------|
| Eager fp64 | 65.1 | 1 |
| Eager fp32 | 23.4 | 2.8 |
| compile default fp32 | 11.17 | 5.8 |
| reduce-overhead fp32 | 9.75 | 6.7 | 
| compile default mixed precision | 8.84 | 7.4 | 
| max-autotune fp32 | 6.75 | 9.6  | 
| reduce-overhead mixed precision | 4.81 | 13.5 | 
| max-autotune mixed precision | 4.25 | 15.3 | 
