### PR TITLE
Add finetuning for maceoff models

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -56,7 +56,7 @@ def mace_mp(
         print(
             f"Using local medium Materials Project MACE model for MACECalculator {model}"
         )
-    elif model in (None, "small", "medium", "large") or str(model).startswith("https:"):
+    elif model in (None, "mace-mp-small", "mace-mp-medium", "mace-mp-large") or str(model).startswith("https:"):
         try:
             urls = dict(
                 small="http://tinyurl.com/46jrkm3v",  # 2023-12-10-mace-128-L0_energy_epoch-249.model
@@ -64,8 +64,8 @@ def mace_mp(
                 large="http://tinyurl.com/43hjdekn",  # MACE_MPtrj_2022.9.model
             )
             checkpoint_url = (
-                urls.get(model, urls["medium"])
-                if model in (None, "small", "medium", "large")
+                urls.get(model.split('-')[-1], urls["medium"])
+                if model in (None, "mace-mp-small", "mace-mp-medium", "mace-mp-large")
                 else model
             )
             cache_dir = os.path.expanduser("~/.cache/mace")
@@ -161,8 +161,8 @@ def mace_off(
             large="https://github.com/ACEsuit/mace-off/blob/main/mace_off23/MACE-OFF23_large.model?raw=true",
         )
         checkpoint_url = (
-            urls.get(model, urls["medium"])
-            if model in (None, "small", "medium", "large")
+            urls.get(model.split("-")[-1], urls["small"])
+            if model in (None, "mace-off-small", "mace-off-medium", "mace-off-large")
             else model
         )
         cache_dir = os.path.expanduser("~/.cache/mace")

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -227,36 +227,37 @@ def main() -> None:
     logging.info(f"Selected the following outputs: {output_args}")
 
     # Build model
-    if args.foundation_model in ["small", "medium", "large"]:
-        logging.info("Building model")
-        if args.num_channels is not None and args.max_L is not None:
-            assert args.num_channels > 0, "num_channels must be positive integer"
-            assert args.max_L >= 0, "max_L must be non-negative integer"
-            args.hidden_irreps = o3.Irreps(
-                (args.num_channels * o3.Irreps.spherical_harmonics(args.max_L))
-                .sort()
-                .irreps.simplify()
-            )
-
-        assert (
-            len({irrep.mul for irrep in o3.Irreps(args.hidden_irreps)}) == 1
-        ), "All channels must have the same dimension, use the num_channels and max_L keywords to specify the number of channels and the maximum L"
-
-        logging.info(f"Hidden irreps: {args.hidden_irreps}")
-        model_config = dict(
-            r_max=args.r_max,
-            num_bessel=args.num_radial_basis,
-            num_polynomial_cutoff=args.num_cutoff_basis,
-            max_ell=args.max_ell,
-            interaction_cls=modules.interaction_classes[args.interaction],
-            num_interactions=args.num_interactions,
-            num_elements=len(z_table),
-            hidden_irreps=o3.Irreps(args.hidden_irreps),
-            atomic_energies=atomic_energies,
-            avg_num_neighbors=args.avg_num_neighbors,
-            atomic_numbers=z_table.zs,
-        )
-    else:
+    # if args.foundation_model is None:
+    #     logging.info("Building model")
+    #     if args.num_channels is not None and args.max_L is not None:
+    #         assert args.num_channels > 0, "num_channels must be positive integer"
+    #         assert args.max_L >= 0, "max_L must be non-negative integer"
+    #         args.hidden_irreps = o3.Irreps(
+    #             (args.num_channels * o3.Irreps.spherical_harmonics(args.max_L))
+    #             .sort()
+    #             .irreps.simplify()
+    #         )
+    #
+    #     assert (
+    #         len({irrep.mul for irrep in o3.Irreps(args.hidden_irreps)}) == 1
+    #     ), "All channels must have the same dimension, use the num_channels and max_L keywords to specify the number of channels and the maximum L"
+    #
+    #     logging.info(f"Hidden irreps: {args.hidden_irreps}")
+    #     model_config = dict(
+    #         r_max=args.r_max,
+    #         num_bessel=args.num_radial_basis,
+    #         num_polynomial_cutoff=args.num_cutoff_basis,
+    #         max_ell=args.max_ell,
+    #         interaction_cls=modules.interaction_classes[args.interaction],
+    #         num_interactions=args.num_interactions,
+    #         num_elements=len(z_table),
+    #         hidden_irreps=o3.Irreps(args.hidden_irreps),
+    #         atomic_energies=atomic_energies,
+    #         avg_num_neighbors=args.avg_num_neighbors,
+    #         atomic_numbers=z_table.zs,
+    #     )
+    # else:
+    if args.foundation_model is not None:
         if "mace-mp" in args.foundation_model:
             args.model = "ScaleShiftMACE"
             args.num_channels = 128
@@ -269,7 +270,6 @@ def main() -> None:
             args.num_bessel = 8
             args.r_max = 5.0
             args.interaction = "RealAgnosticResidualInteractionBlock"
-
         if args.foundation_model == "mace-mp-small":
             args.max_L = 0
         elif args.foundation_model == "mace-mp-medium":

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -345,6 +345,7 @@ class ScaleShiftMACE(MACE):
                 node_feats=node_feats, sc=sc, node_attrs=data["node_attrs"]
             )
             node_feats_list.append(node_feats)
+            # print(node_feats)
             node_es_list.append(readout(node_feats).squeeze(-1))  # {[n_nodes, ], }
 
         # Concatenate node features

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -429,6 +429,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
     )
+    parser.add_argument("--freeze_weights", help="Freeze weights", action="store_true")
     parser.add_argument(
         "--foundation_model_readout",
         help="Use readout of foundation model for transfer learning",

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -262,7 +262,6 @@ def take_step(
         compute_stress=output_args["stress"],
     )
     loss = loss_fn(pred=output, ref=batch)
-    print("loss", loss)
     loss.backward()
     if max_grad_norm is not None:
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=max_grad_norm)

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -150,6 +150,22 @@ class MetricsLogger:
             f.write("\n")
 
 
+
+def load_maceoff_foundations(model: torch.nn.Module, model_foundations: torch.nn.Module) -> torch.nn.Module:
+    state_dict = model_foundations.state_dict()
+    torch.save(state_dict, "foundation_state_dict.pt")
+    model.load_state_dict(torch.load("foundation_state_dict.pt"))
+    # for (name_foundations, param_foundations) in model_foundations.state_dict():
+    #     for (name, param) in model.state_dict():
+    #         if name_foundations == name:
+    #             logging.info(f"copying parameter, {name}, {name_foundations}")
+    #             param = param_foundations.data.clone()
+
+    # model.scale_shift.scale = model_foundations.scale_shift.scale.clone()
+    # model.scale_shift.shift = model_foundations.scale_shift.shift.clone()
+    # logging.info(model.scale_shift.scale, model.scale_shift.shift)
+    return model
+
 def load_foundations(
     model: torch.nn.Module,
     model_foundations: torch.nn.Module,
@@ -162,7 +178,6 @@ def load_foundations(
     """
     Load the foundations of a model into a model for fine-tuning.
     """
-    print(model_foundations.r_max, model.r_max)
     assert model_foundations.r_max == model.r_max
     z_table = AtomicNumberTable([int(z) for z in model_foundations.atomic_numbers])
     new_z_table = table

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -162,6 +162,7 @@ def load_foundations(
     """
     Load the foundations of a model into a model for fine-tuning.
     """
+    print(model_foundations.r_max, model.r_max)
     assert model_foundations.r_max == model.r_max
     z_table = AtomicNumberTable([int(z) for z in model_foundations.atomic_numbers])
     new_z_table = table
@@ -213,6 +214,7 @@ def load_foundations(
         model.interactions[i].linear.weight = torch.nn.Parameter(
             model_foundations.interactions[i].linear.weight.clone()
         )
+        print(model.interactions[i].__class__.__name__)
         if (
             model.interactions[i].__class__.__name__
             == "RealAgnosticResidualInteractionBlock"


### PR DESCRIPTION

Allow finetuning of maceoff models

Notes

- Slightly different way of initialising the models: using the parameter copying scheme from the mace-mp does not seem to work - since we want to keep the number of elements unchanged we simply intiialize from a checkpoint

