### PR TITLE
Handle a wider range of possible slurm env vars

### DIFF
--- a/mace/tools/slurm_distributed.py
+++ b/mace/tools/slurm_distributed.py
@@ -23,6 +23,7 @@ class DistributedEnvironment:
         hostname = hostlist.expand_hostlist(os.environ["SLURM_JOB_NODELIST"])[0]
         os.environ["MASTER_ADDR"] = hostname
         os.environ["MASTER_PORT"] = os.environ.get("MASTER_PORT", "33333")
-        os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"]
+        os.environ["WORLD_SIZE"] = os.environ.get("SLURM_NTASKS",
+            str(int(os.environ["SLURM_NTASKS_PER_NODE"]) * int(os.environ["SLURM_NNODES"])))
         os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
         os.environ["RANK"] = os.environ["SLURM_PROCID"]


### PR DESCRIPTION
If the slurm job is started with --ntasks_per_node and --nnodes, rather than --ntasks, the env vars currently expected aren' present. Fix that parsing.

Note that I think it'd be good to make the interface to this more general. Maybe all that's needed it to remove "slurm" from the `slurm_distributed.py` filename and check the possible env vars of different queuing systems (maybe not even actually implement any yet, but at least structure it that way). 