### PR TITLE
Update plot_train.py

### DIFF
--- a/mace/cli/plot_train.py
+++ b/mace/cli/plot_train.py
@@ -178,7 +178,7 @@ def main():
         for results in parse_training_results(path)
     )
 
-    for name, group in data.groupby(["name"]):
+    for name, group in data.groupby("name"):
         plot(group, min_epoch=args.min_epoch, output_path=f"{name}.pdf")
 
 


### PR DESCRIPTION
Fix PDF file names of the `mace_plot_train` command. . Previous, the names of the output files are tuples:

```
('<my_filename>',).pdf
```

is this due to passing a list of grouped keys to the `groupby`, which results in a tuple of grouped keys being returned. 
Since we are only grouping a single key (`'name'`), passing a string should be sufficient.