### PR TITLE
add config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ conda activate mace_env
 conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
 
 # (optional) Install MACE's dependencies from Conda as well
-conda install numpy scipy matplotlib ase opt_einsum prettytable pandas e3nn
+conda install numpy scipy matplotlib ase opt_einsum prettytable pandas e3nn configargparse
 
 # Clone and install MACE (and all required packages)
 git clone https://github.com/ACEsuit/mace.git
@@ -157,7 +157,7 @@ mace_eval_configs \
 
 ## Tutorial
 
-You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE. 
+You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE.
 
 We also have a more detailed user and developer tutorial at https://github.com/ilyes319/mace-tutorials
 
@@ -193,7 +193,7 @@ print(atoms.get_potential_energy())
 
 ### MACE-OFF: Transferable Organic Force Fields
 
-There is a series (small, medium, large) transferable organic force fields. These can be used for the simulation of organic molecules, crystals and molecular liquids, or as a starting point for fine-tuning on a new dataset. The models are released under the [ASL license](https://github.com/gabor1/ASL). 
+There is a series (small, medium, large) transferable organic force fields. These can be used for the simulation of organic molecules, crystals and molecular liquids, or as a starting point for fine-tuning on a new dataset. The models are released under the [ASL license](https://github.com/gabor1/ASL).
 The models are releaed on GitHub at https://github.com/ACEsuit/mace-off.
 If you use them please cite [our paper](https://arxiv.org/abs/2312.15211) which also contains detailed benchmarks and example applications.
 

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -4,13 +4,18 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
-import argparse
+import configargparse
 import ast
 from typing import List, Optional, Union
 
 
-def build_default_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser()
+def build_default_arg_parser() -> configargparse.ArgumentParser:
+    parser = configargparse.ArgumentParser(
+            config_file_parser_class=configargparse.YAMLConfigFileParser,
+            )
+
+    # config file
+    parser.add("--config", type=str, is_config_file=True, help='config file to agregate options')
 
     # Name and seed
     parser.add_argument("--name", help="experiment name", required=True)
@@ -494,6 +499,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "forces_weight",
         ],
     )
+
     return parser
 
 


### PR DESCRIPTION
replaces argparse with configargparse to allow reading cli params from a yaml file.
now usage can be

```bash
mace_run_train  --name="MACE_model"     --valid_fraction=0.05  --model="MACE" --hidden_irreps='128x0e + 128x1o'  --r_max=5.0   --batch_size=10  --ema  --ema_decay=0.99  --amsgrad --restart_latest --config mace.yaml
```

with mace.yaml

```yaml
name: nacl
seed: 2024
train_file: train.xyz
swa: yes
start_swa: 1200
max_num_epochs: 1500
device: cpu
test_file: test.xyz
E0s:
  41: -1029.2809654211628
  38: -1484.1187695035828
  8: -2042.0330099956639
config_type_weights:
  Default: 1.0

```