### PR TITLE
Adding hessians based on autograd to MACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Usage](#usage)
   - [Training](#training)
   - [Evaluation](#evaluation)
+  - [Calculate Hessinas](#calculate-hessinas)
 - [Tutorial](#tutorial)
 - [Weights and Biases](#weights-and-biases-for-experiment-tracking)
 - [Development](#development)
@@ -154,6 +155,20 @@ mace_eval_configs \
     --model="your_model.model" \
     --output="./your_output.xyz"
 ```
+
+### Calculate Hessinas
+This branch includes the option to calculate Hessian based on a autograd implementation. To obtain the hessian the following commands can be use:
+```py
+from mace.calculators import mace_mp
+from ase import build
+
+atoms = build.molecule('H2O')
+calc = mace_mp(model="medium", dispersion=False, default_dtype="float64",device='cuda', )#device='cpu')
+atoms.calc = calc
+hessian=calc.get_hessian(atoms=atoms)
+print("h:",hessian)
+```
+A [file](https://github.com/Nilsgoe/mace_hessian/tree/main/tests/test_mace_hessian.py) for a larger test and a comparison with numerical derivatives is also provided.
 
 ## Tutorial
 

--- a/tests/test_mace_hessian.py
+++ b/tests/test_mace_hessian.py
@@ -1,0 +1,55 @@
+import time
+from mace.calculators import mace_mp
+import numpy as np
+from ase.build import fcc111
+
+
+calc = mace_mp(model="medium", dispersion=False, default_dtype="float64",device='cuda', )#device='cpu')
+
+initial = fcc111('Pt', size=(7, 8, 1), vacuum=10.0, orthogonal=True)
+initial.calc = calc
+
+s=time.time()
+e0=initial.get_potential_energy()
+h_autograd=calc.get_hessian(atoms=initial,method="loop")
+print("h:",h_autograd)
+
+e=time.time()
+print(f"This system need {e-s} seconds")
+
+s=time.time()
+indicies =[i for i in range(len(initial))]
+delta =1e-4
+ndim = 3
+hessian = np.zeros((len(indicies) * ndim, len(indicies) * ndim))
+atoms_h = initial.copy()
+
+atoms_h.set_constraint()
+
+#finite difference approach
+for i,index in enumerate(indicies):
+    for j in range(ndim):
+        # Perturb the position of atom i in dimension j
+        atoms_i = atoms_h.copy()
+        atoms_i.positions[index, j] += delta
+        
+        # Calculate forces for the perturbed configuration
+        atoms_i.calc=calc
+        forces_i = atoms_i.get_forces()
+
+        # Same just in the other direction
+        atoms_j = atoms_h.copy()
+        atoms_j.positions[index, j] -= delta
+        atoms_j.calc=calc
+        forces_j = atoms_j.get_forces()
+ 
+        # central difference
+        hessian[:, i * ndim + j] = -(forces_i - forces_j)[indicies].flatten() / (2 * delta)
+
+e=time.time()
+hessian= hessian.reshape(-1,len(initial),3)
+
+print(f"This system need {e-s} seconds")
+
+is_close = np.allclose(h_autograd, hessian, atol=1e-6)
+print("Are autograd and numerical close within tolerance of 1e-6? ", is_close)


### PR DESCRIPTION
Hello, dear MACE team,

I already answered an Issue post about autograd Hessians and as a result, I got contacted by other people about a autograd Hessian implementation. Therefore, I thought a proper implementation of autograd based Hessians would be very useful for MACE. I tried to make my implementation more clean to hopefully be integrated into a branch of the mace gitHub and here is now a first idea for a possible pull. 

To show why autograd Hessians could make sense, I added a comparison in calculation time between a numerical and autograd based Hessian.
![large_time_vs_size_plot](https://github.com/ACEsuit/mace/assets/92968559/84caf89b-0144-471d-bc5c-691641291172)

I have also added a test file for a very simple test, and I am working on more tests.
The implementation works for mace_mp, mace_off and self-trained mace potentials.
I would welcome a brief discussion about some tests I could run to convince you about the performance and  reliability of the implementation.
At this point, only the simplest way of getting autograd Hessians is part of the pull request, as the other options either would need larger changes in the mace code or still have some problems (which I would be very happy to discuss at a later point).

