### PR TITLE
fix rms/rmse for forces, off by a factor of 1/sqrt(3)

### DIFF
--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -234,7 +234,7 @@ def compute_mean_rms_energy_forces(
     forces = torch.cat(forces_list, dim=0)  # {[total_n_graphs*n_atoms,3], }
 
     mean = to_numpy(torch.mean(atom_energies)).item()
-    rms = to_numpy(torch.sqrt(torch.mean(torch.square(forces)))).item()
+    rms = to_numpy(torch.sqrt(3*torch.mean(torch.square(forces)))).item()
     rms = _check_non_zero(rms)
 
     return mean, rms

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -234,7 +234,7 @@ def compute_mean_rms_energy_forces(
     forces = torch.cat(forces_list, dim=0)  # {[total_n_graphs*n_atoms,3], }
 
     mean = to_numpy(torch.mean(atom_energies)).item()
-    rms = to_numpy(torch.sqrt(3*torch.mean(torch.square(forces)))).item()
+    rms = to_numpy(torch.sqrt(torch.mean(torch.square(forces),axis=0).sum())).item()
     rms = _check_non_zero(rms)
 
     return mean, rms

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -26,7 +26,7 @@ def compute_rel_mae(delta: np.ndarray, target_val: np.ndarray) -> float:
 
 
 def compute_rmse(delta: np.ndarray) -> float:
-    return np.sqrt(np.mean(np.square(delta))).item()
+    return np.sqrt(3*np.mean(np.square(delta))).item()
 
 
 def compute_rel_rmse(delta: np.ndarray, target_val: np.ndarray) -> float:

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -26,7 +26,7 @@ def compute_rel_mae(delta: np.ndarray, target_val: np.ndarray) -> float:
 
 
 def compute_rmse(delta: np.ndarray) -> float:
-    return np.sqrt(3*np.mean(np.square(delta))).item()
+    return np.sqrt(np.mean(np.square(delta),axis=0).sum()).item()
 
 
 def compute_rel_rmse(delta: np.ndarray, target_val: np.ndarray) -> float:


### PR DESCRIPTION
In the current implementation RMS/RMSE of forces is scaled by a factor of 1/sqrt(3) to where I think it should be, although I might be wrong. 

`return np.sqrt(np.mean(np.square(delta))).item()`

^ delta has shape (n,3) and n.mean() divides the sum out by n*3, when it should only be dividing by n, averaging over number of atoms, not 3*number of atoms. 

I checked a 
https://github.com/mir-group/pytorch_runstats/blob/main/torch_runstats/_runstats.py#L206

For the RMS rescale factor it might not matter too much, but when reporting RMSE values for forces I think this results in RMSE being ~40% (1-1/sqrt(3)) off. 