### PR TITLE
Allow MACECalculator to pick theory used for multihead models

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -57,12 +57,14 @@ class MACECalculator(Calculator):
         charges_key="Qs",
         model_type="MACE",
         compile_mode=None,
+        multihead_theory=None,
         **kwargs,
     ):
         Calculator.__init__(self, **kwargs)
         self.results = {}
 
         self.model_type = model_type
+        self.multihead_theory = multihead_theory
 
         if model_type == "MACE":
             self.implemented_properties = [
@@ -217,6 +219,8 @@ class MACECalculator(Calculator):
 
         # prepare data
         config = data.config_from_atoms(atoms, charges_key=self.charges_key)
+        if self.multihead_theory is not None:
+            config.theory = self.multihead_theory
         data_loader = torch_geometric.dataloader.DataLoader(
             dataset=[
                 data.AtomicData.from_config(
@@ -333,6 +337,8 @@ class MACECalculator(Calculator):
         if num_layers == -1:
             num_layers = int(self.models[0].num_interactions)
         config = data.config_from_atoms(atoms, charges_key=self.charges_key)
+        if self.multihead_theory is not None:
+            config.theory = self.multihead_theory
         data_loader = torch_geometric.dataloader.DataLoader(
             dataset=[
                 data.AtomicData.from_config(


### PR DESCRIPTION
Initial form of this PR allows `MACECalculator` to override `Atoms.info["theory"]` when deciding which head to use for prediction. This is the minimal change I need to be able to use such models cleanly, but I'm not sure it's sufficient.

Other related things I've noticed
- if you don't specify a theory (i.e. nothing in info `"theory"` field), it prints an error about `'Default'` not matching. I think it's from https://github.com/ACEsuit/mace/blob/5a66ca442391a73e81bf4cadcfec22d6d31c3c96/mace/data/atomic_data.py#L131
- I'm not sure defaulting to any particular theory (first, as it does now, or any other arbitrary choice, like last) is a good idea to begin with. However, this choice might be related to details of the multi-head **fitting** (e.g. if we're using multi-head to stabilize fine-tuning, we could default to calling the new head a specific name, like `'Default'`).

closes #390 