### PR TITLE
Add DOI badge and automated release

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release on tag
+
+on:
+  push:
+    tags:
+      # After vMajor.Minor.Patch _anything_ is allowed (without "/") !
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'ACEsuit/mace' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: "pip"
+
+    - name: Build project for distribution
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+        python -m build
+
+    - name: Create Release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "dist/*"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        draft: false
+        skipIfReleaseExists: true

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/License-MIT%202.0-blue.svg)](https://opensource.org/licenses/mit)
 [![GitHub issues](https://img.shields.io/github/issues/ACEsuit/mace.svg)](https://GitHub.com/ACEsuit/mace/issues/)
 [![Documentation Status](https://readthedocs.org/projects/mace/badge/)](https://mace-docs.readthedocs.io/en/latest/)
+[![DOI](https://zenodo.org/badge/x.svg)](https://zenodo.org/badge/latestdoi/x)
 
 ## Table of contents
 


### PR DESCRIPTION
As discussed with @alinelena and @ilyes319, adds release workflow to automate releasing on tagged commits.

Tested on my fork: https://github.com/ElliottKasoar/mace/releases

Once set up, each release would then be preserved via zenodo (see [GitHub ](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content)/ [Zenodo](https://zenodo.org/account/settings/github/) instructions).

An admin of the repository can reserve a DOI, so we can update the placeholders in the README before the next release, which should then immediately link correctly.

It would also be relatively straightforward to extend this workflow e.g. to use different build systems, or release to PyPI etc.

(Note: this also bumps versions in other GitHub Actions, but this can be separated/removed if preferable)