### PR TITLE
Fix check for patience that fails if swa start was not specified

### DIFF
--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -244,12 +244,12 @@ def train(
 
             if valid_loss >= lowest_loss:
                 patience_counter += 1
-                if patience_counter >= patience and epoch < swa.start:
+                if patience_counter >= patience and (swa.start is not None and epoch < swa.start):
                     logging.info(
                         f"Stopping optimization after {patience_counter} epochs without improvement and starting swa"
                     )
                     epoch = swa.start
-                elif patience_counter >= patience and epoch >= swa.start:
+                elif patience_counter >= patience and (swa.start is None or epoch >= swa.start):
                     logging.info(
                         f"Stopping optimization after {patience_counter} epochs without improvement"
                     )


### PR DESCRIPTION
Make sure check for patience does not try to use swa.start if it is None, in two tests: switching to swa, and terminating iterations altogether.