### PR TITLE
fix incorrect conversion of forces from calculator to atoms.arrays for finetuning pbe mp replay head

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -246,14 +246,14 @@ def main() -> None:
                     "weight_pt": args.weight_pt_head,
                     "weight_ft": 1.0,
                     "filtering_type": "combination",
-                    "output": f"{cache_dir}/mp_finetuning.xyz",
+                    "output": f"mp_finetuning-{tag}.xyz",
                     "descriptors": descriptors_mp,
                     "device": args.device,
                     "default_dtype": args.default_dtype,
                 }
                 select_samples(dict_to_namespace(args_samples))
                 collections_mp, _, _ = get_dataset_from_xyz(
-                    train_path=f"{cache_dir}/mp_finetuning.xyz",
+                    train_path=f"mp_finetuning-{tag}.xyz",
                     valid_path=None,
                     valid_fraction=args.valid_fraction,
                     config_type_weights=config_type_weights,

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -248,10 +248,10 @@ def load_from_xyz(
 
         if forces_from_calc:
             try:
-                atoms.info["_REF_forces"] = atoms.get_forces()
+                atoms.arrays["_REF_forces"] = atoms.get_forces()
             except Exception as e:  # pylint: disable=W0703
                 logging.warning(f"Failed to extract forces: {e}")
-                atoms.info["_REF_forces"] = None
+                atoms.arrays["_REF_forces"] = None
 
         if stress_from_calc:
             try:


### PR DESCRIPTION
Actually store multihead fine-tuning pbe mp forces in `Atoms.arrays`, rather than incorrect current storage in `Atoms.info`

Also, store configs selected when multihead fine-tuning in local, tag dependent filename, rather than fixed filename in `~/.cache/mace`