### PR TITLE
fix atom e0s being subtracted twice in mace calculator

### DIFF
--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -31,9 +31,9 @@ def fitting_configs_fixture():
         Atoms(numbers=[8], positions=[[0, 0, 0]], cell=[6] * 3),
         Atoms(numbers=[1], positions=[[0, 0, 0]], cell=[6] * 3),
     ]
-    fit_configs[0].info["REF_energy"] = 0.0
+    fit_configs[0].info["REF_energy"] = 1.0
     fit_configs[0].info["config_type"] = "IsolatedAtom"
-    fit_configs[1].info["REF_energy"] = 0.0
+    fit_configs[1].info["REF_energy"] = -0.5
     fit_configs[1].info["config_type"] = "IsolatedAtom"
 
     np.random.seed(5)
@@ -370,6 +370,15 @@ def trained_committee_fixture(tmp_path_factory, fitting_configs):
 
     return MACECalculator(_model_paths, device="cpu")
 
+def test_calculator_node_energy(fitting_configs, trained_model):
+    for at in fitting_configs:
+        trained_model.calculate(at)
+        node_energies = trained_model.results["node_energy"]
+        batch = trained_model._atoms_to_batch(at)
+        node_e0 = trained_model.models[0].atomic_energies_fn(batch["node_attrs"]).detach().numpy()
+        energy_via_nodes = np.sum(node_energies+node_e0)
+        energy = trained_model.results["energy"]
+        np.testing.assert_allclose(energy, energy_via_nodes, atol=1e-6)
 
 def test_calculator_forces(fitting_configs, trained_model):
     at = fitting_configs[2].copy()


### PR DESCRIPTION
Fixed a bug when using the MACE calculator to calculate node interaction energies.

Previously, the isolated atom energy was being subtracted twice. Note, I had to modify the `fitting_configs` fixture to add E0s to the configs there, otherwise this bug was not being caught even with the old implementation.

Also, I added an additional helper function to the calculator to batchify the atoms since the exact same code was used in two places within the calculator.

Also, changed the name of the function `_prepare_batch`  to `_clone_batch` to better reflect what it is doing.

This should also resolve the following discussion:
https://github.com/ACEsuit/mace/discussions/417 