### PR TITLE
improved multihead pretrained set selection for fine tuning

### DIFF
--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -289,7 +289,6 @@ def select_samples(
                 )
             )
             np.save(args.output.replace(".xyz", "descriptors.npy"), descriptors_list)
-<<<<<<< HEAD
 
     # actually do filtering
     atoms_list_pt_filtered = [atoms_list_pt[ind] for ind in indices_pt_filtered]

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -246,6 +246,7 @@ def main() -> None:
                     "weight_pt": args.weight_pt_head,
                     "weight_ft": 1.0,
                     "filtering_type": args.filtering_type_pt,
+                    "extra_filtering_type": args.extra_filtering_type_pt,
                     "output": f"mp_finetuning-{tag}.xyz",
                     "descriptors": descriptors_mp,
                     "device": args.device,

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -245,7 +245,7 @@ def main() -> None:
                     "head_ft": "Default",
                     "weight_pt": args.weight_pt_head,
                     "weight_ft": 1.0,
-                    "filtering_type": "combination",
+                    "filtering_type": args.filtering_type_pt,
                     "output": f"mp_finetuning-{tag}.xyz",
                     "descriptors": descriptors_mp,
                     "device": args.device,

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -343,6 +343,14 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         required=False,
     )
     parser.add_argument(
+        "--extra_filtering_type_pt",
+        help="strategy for selecting extra configs (in addition to filtering) from pretrained database",
+        choices=["random",
+                 "fps_npdu_kdtree"],
+        default="random",
+        required=False,
+    )
+    parser.add_argument(
         "--heads",
         help="List of heads in the training set",
         type=str,

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -332,6 +332,17 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         required=False,
     )
     parser.add_argument(
+        "--filtering_type_pt",
+        help="strategy for filtering configs from pretrained database",
+        choices=["none",
+                 "combinations",
+                 "exclusive",
+                 "inclusive",
+                 "any"],
+        default="combinations",
+        required=False,
+    )
+    parser.add_argument(
         "--heads",
         help="List of heads in the training set",
         type=str,

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -56,7 +56,7 @@ def valid_err_log(
         error_e = eval_metrics["rmse_e_per_atom"] * 1e3
         error_f = eval_metrics["rmse_f"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_E_per_atom={error_e:.2f} meV, RMSE_F={error_f:.1f} meV / A"
         )
     elif (
         log_errors == "PerAtomRMSEstressvirials"
@@ -66,7 +66,7 @@ def valid_err_log(
         error_f = eval_metrics["rmse_f"] * 1e3
         error_stress = eval_metrics["rmse_stress"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_stress={error_stress:.1f} meV / A^3"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_E_per_atom={error_e:.2f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_stress={error_stress:.2f} meV / A^3"
         )
     elif (
         log_errors == "PerAtomRMSEstressvirials"
@@ -76,37 +76,37 @@ def valid_err_log(
         error_f = eval_metrics["rmse_f"] * 1e3
         error_virials = eval_metrics["rmse_virials_per_atom"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_virials_per_atom={error_virials:.1f} meV"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_E_per_atom={error_e:.2f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_virials_per_atom={error_virials:.1f} meV"
         )
     elif log_errors == "TotalRMSE":
         error_e = eval_metrics["rmse_e"] * 1e3
         error_f = eval_metrics["rmse_f"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_E={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A"
         )
     elif log_errors == "PerAtomMAE":
         error_e = eval_metrics["mae_e_per_atom"] * 1e3
         error_f = eval_metrics["mae_f"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, MAE_E_per_atom={error_e:.1f} meV, MAE_F={error_f:.1f} meV / A"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, MAE_E_per_atom={error_e:.2f} meV, MAE_F={error_f:.1f} meV / A"
         )
     elif log_errors == "TotalMAE":
         error_e = eval_metrics["mae_e"] * 1e3
         error_f = eval_metrics["mae_f"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, MAE_E={error_e:.1f} meV, MAE_F={error_f:.1f} meV / A"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, MAE_E={error_e:.1f} meV, MAE_F={error_f:.1f} meV / A"
         )
     elif log_errors == "DipoleRMSE":
         error_mu = eval_metrics["rmse_mu_per_atom"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_MU_per_atom={error_mu:.2f} mDebye"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_MU_per_atom={error_mu:.2f} mDebye"
         )
     elif log_errors == "EnergyDipoleRMSE":
         error_e = eval_metrics["rmse_e_per_atom"] * 1e3
         error_f = eval_metrics["rmse_f"] * 1e3
         error_mu = eval_metrics["rmse_mu_per_atom"] * 1e3
         logging.info(
-            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.4f}, RMSE_E_per_atom={error_e:.1f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_Mu_per_atom={error_mu:.2f} mDebye"
+            f"head: {valid_loader_name}, Epoch {epoch}: loss={valid_loss:.8f}, RMSE_E_per_atom={error_e:.2f} meV, RMSE_F={error_f:.1f} meV / A, RMSE_Mu_per_atom={error_mu:.2f} mDebye"
         )
 
 


### PR DESCRIPTION
Major refactor of code that subselects pretrained configurations for multihead playback finetuning

Lots of cleanup of code, and substantial change in strategy.
For now:
 - First pick by requested strategy
 - If it's too many, add only a subset
   - first select subset that matches `"exclusive"` (perfect element match)
   - then select subset that matches `"combinations"` (elements in config are a subset of desired)
   - then select subset that matches `"any"` (any overlap between elements in config and desired)
   - if at any point there are too many, pick subset weighted toward better match of elements
 - If that's not enough, add more with FPS