### PR TITLE
Calculate virials and stress with vectors to get atomic virial

### DIFF
--- a/mace/calculators/lammps_mace.py
+++ b/mace/calculators/lammps_mace.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import torch
+from torch_runstats.scatter import scatter
 from e3nn.util.jit import compile_mode
 
 from mace.tools.scatter import scatter_sum
@@ -22,6 +23,7 @@ class LAMMPS_MACE(torch.nn.Module):
         data: Dict[str, torch.Tensor],
         local_or_ghost: torch.Tensor,
         compute_virials: bool = False,
+        compute_force: bool = False,
     ) -> Dict[str, Optional[torch.Tensor]]:
         num_graphs = data["ptr"].numel() - 1
         compute_displacement = False
@@ -44,27 +46,85 @@ class LAMMPS_MACE(torch.nn.Module):
                 "virials": None,
             }
         positions = data["positions"]
+        edge_index = data["edge_index"]
+        batch = data["batch"]
         displacement = out["displacement"]
-        forces: Optional[torch.Tensor] = torch.zeros_like(positions)
-        virials: Optional[torch.Tensor] = torch.zeros_like(data["cell"])
-        # accumulate energies of local atoms
+        vectors = out["vectors"]
+        forces: Optional[torch.Tensor] = torch.zeros_like(positions) if compute_force else None
+        virials: Optional[torch.Tensor] = torch.zeros_like(data["cell"]) if compute_virials else None
+  
+
+        if compute_virials and vectors is not None:
+            vector_force: Optional[torch.Tensor]  = torch.zeros_like(vectors)
+        else:
+            vector_force = None
+
+        if compute_virials and vectors is not None:
+            edge_virial: Optional[torch.Tensor]   = torch.zeros_like(vectors).unsqueeze(dim=-1)
+        else:
+            edge_virial = None
+
+        if edge_virial is not None:
+            edge_virial = edge_virial.repeat(1, 1, 3)
+
+        if compute_virials and vectors is not None:
+            atom_virial: Optional[torch.Tensor]   = torch.zeros_like(positions).unsqueeze(dim=-1)
+        else:
+            atom_virial = None
+
+        if atom_virial is not None:
+            atom_virial = atom_virial.repeat(1, 1, 3)
+
+        #accumulate energies of local atoms
         node_energy_local = node_energy * local_or_ghost
         total_energy_local = scatter_sum(
             src=node_energy_local, index=data["batch"], dim=-1, dim_size=num_graphs
         )
+
         # compute partial forces and (possibly) partial virials
         grad_outputs: List[Optional[torch.Tensor]] = [
             torch.ones_like(total_energy_local)
         ]
-        if compute_virials and displacement is not None:
-            forces, virials = torch.autograd.grad(
-                outputs=[total_energy_local],
-                inputs=[positions, displacement],
+
+        if compute_virials and vectors is not None:
+            forces, vector_force = torch.autograd.grad(
+                outputs=[total_energy_local],  
+                inputs=[positions, vectors],  
                 grad_outputs=grad_outputs,
-                retain_graph=False,
-                create_graph=False,
+                retain_graph=False,  
+                create_graph=False, 
                 allow_unused=True,
             )
+
+            if vector_force is not None and vectors is not None:
+                edge_virial = torch.einsum("zi,zj->zij", vector_force, vectors)
+            else:
+                edge_virial = None
+ 
+            if edge_virial is not None and edge_index[0] is not None:
+                atom_virial = scatter_sum(edge_virial, edge_index[0], dim=0, dim_size=len(positions),)
+            else:
+                atom_virial = None
+
+            if edge_virial is not None and edge_index[1] is not None:
+                scattered_virial = scatter_sum(edge_virial, edge_index[1], dim=0, dim_size=len(positions))
+                if atom_virial is not None:
+                    atom_virial = (atom_virial + scattered_virial) / 2
+                else:
+                    atom_virial = None
+            else:
+                atom_virial = None
+
+            if atom_virial is not None and batch is not None:
+                virials = scatter_sum(atom_virial, batch, dim=0,)
+            else:
+                virials = None
+
+            if virials is not None :
+                virials = (virials + virials.transpose(-1, -2)) / 2
+            else:
+                virials = None
+
             if forces is not None:
                 forces = -1 * forces
             else:
@@ -72,7 +132,11 @@ class LAMMPS_MACE(torch.nn.Module):
             if virials is not None:
                 virials = -1 * virials
             else:
-                virials = torch.zeros_like(displacement)
+                virials = torch.zeros((1, 3, 3))
+            if atom_virial is not None:
+                atom_virial = -1 * atom_virial
+            else:
+                atom_virial = torch.zeros((1,3,3))
         else:
             forces = torch.autograd.grad(
                 outputs=[total_energy_local],
@@ -86,9 +150,13 @@ class LAMMPS_MACE(torch.nn.Module):
                 forces = -1 * forces
             else:
                 forces = torch.zeros_like(positions)
+
         return {
             "total_energy_local": total_energy_local,
             "node_energy": node_energy,
             "forces": forces,
             "virials": virials,
+            "atom_virial": atom_virial,
         }
+
+

--- a/mace/cli/create_lammps_model.py
+++ b/mace/cli/create_lammps_model.py
@@ -1,8 +1,9 @@
 import sys
 
 import torch
+from torch_runstats.scatter import scatter
 from e3nn.util import jit
-
+from e3nn.util.jit import compile_mode
 from mace.calculators import LAMMPS_MACE
 
 

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -167,7 +167,7 @@ class MACE(torch.nn.Module):
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
-    ) -> Dict[str, Optional[torch.Tensor]]:
+    ) -> Dict[str, torch.Tensor]:
         # Setup
         data["node_attrs"].requires_grad_(True)
         data["positions"].requires_grad_(True)
@@ -244,10 +244,13 @@ class MACE(torch.nn.Module):
         node_energy = torch.sum(node_energy_contributions, dim=-1)  # [n_nodes, ]
 
         # Outputs
-        forces, virials, stress = get_outputs(
+        forces, virials, stress, atom_virial = get_outputs(
             energy=total_energy,
             positions=data["positions"],
+            batch=data["batch"],
             displacement=displacement,
+            edge_index=data["edge_index"],
+            vectors=vectors,
             cell=data["cell"],
             training=training,
             compute_force=compute_force,
@@ -264,6 +267,8 @@ class MACE(torch.nn.Module):
             "stress": stress,
             "displacement": displacement,
             "node_feats": node_feats_out,
+            "vectors": vectors,
+            "atom_virial": atom_virial
         }
 
 
@@ -365,10 +370,16 @@ class ScaleShiftMACE(MACE):
         total_energy = e0 + inter_e
         node_energy = node_e0 + node_inter_es
 
-        forces, virials, stress = get_outputs(
+
+
+        atom_virial = torch.zeros((num_graphs, 3, 3), dtype=data["positions"].dtype, device=data["positions"].device)
+        forces, virials, stress, atom_virial = get_outputs(
             energy=inter_e,
             positions=data["positions"],
+            batch=data["batch"],
             displacement=displacement,
+            edge_index=data["edge_index"],
+            vectors=vectors,
             cell=data["cell"],
             training=training,
             compute_force=compute_force,
@@ -385,8 +396,9 @@ class ScaleShiftMACE(MACE):
             "stress": stress,
             "displacement": displacement,
             "node_feats": node_feats_out,
+            "vectors": vectors,
+            "atom_virial": atom_virial,
         }
-
         return output
 
 

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -41,22 +41,58 @@ def compute_forces(
 def compute_forces_virials(
     energy: torch.Tensor,
     positions: torch.Tensor,
+    batch: torch.Tensor,
     displacement: torch.Tensor,
+    edge_index: torch.Tensor,
+    vectors: torch.Tensor,    
     cell: torch.Tensor,
     training: bool = True,
     compute_stress: bool = False,
-) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
     grad_outputs: List[Optional[torch.Tensor]] = [torch.ones_like(energy)]
-    forces, virials = torch.autograd.grad(
+    forces, vector_force = torch.autograd.grad(
         outputs=[energy],  # [n_graphs, ]
-        inputs=[positions, displacement],  # [n_nodes, 3]
+        inputs=[positions, vectors],  # [n_nodes, 3]
         grad_outputs=grad_outputs,
         retain_graph=training,  # Make sure the graph is not destroyed during training
         create_graph=training,  # Create graph for second derivative
         allow_unused=True,
     )
+
+    if vector_force is not None and vectors is not None:
+        edge_virial = torch.einsum("zi,zj->zij", vector_force, vectors)
+    else:
+        edge_virial = None
+
+    if edge_virial is not None and edge_index[0] is not None:
+        atom_virial = scatter_sum(edge_virial, edge_index[0], dim=0, dim_size=len(positions),)
+    else:
+        atom_virial = None
+
+    if edge_virial is not None and edge_index[1] is not None:
+        scattered_virial = scatter_sum(edge_virial, edge_index[1], dim=0, dim_size=len(positions))
+        if atom_virial is not None:
+            atom_virial = (atom_virial + scattered_virial) / 2
+        else:
+            atom_virial = None
+    else:
+        atom_virial = None
+
+    if atom_virial is not None and batch is not None:
+        virials = scatter_sum(atom_virial, batch, dim=0,)
+    else:
+        virials = None
+
+
+    if virials is not None:
+        virials = (virials + virials.transpose(-1, -2)) / 2
+    else:
+        # Handle the case when virials is None, perhaps by setting it to zero or some default value
+        virials = torch.zeros_like(displacement)
+
+
     stress = torch.zeros_like(displacement)
-    if compute_stress and virials is not None:
+    if  compute_stress and virials is not None:
         cell = cell.view(-1, 3, 3)
         volume = torch.einsum(
             "zi,zi->z",
@@ -64,12 +100,27 @@ def compute_forces_virials(
             torch.cross(cell[:, 1, :], cell[:, 2, :], dim=1),
         ).unsqueeze(-1)
         stress = virials / volume.view(-1, 1, 1)
+
+
+    if atom_virial is None:
+        atom_virial = torch.zeros_like(torch.empty((1, 3, 3)))
+
     if forces is None:
         forces = torch.zeros_like(positions)
+
     if virials is None:
         virials = torch.zeros((1, 3, 3))
 
-    return -1 * forces, -1 * virials, stress
+    if vector_force is None:
+        vector_force = torch.zeros((1,3))
+
+    if edge_virial is None:
+        edge_virial = torch.zeros((1,3,3))
+
+    if atom_virial is None:
+        atom_virial = torch.zeros((1,3,3))
+
+    return -1 * forces, -1 * virials, stress, -1 * atom_virial
 
 
 def get_symmetric_displacement(
@@ -113,32 +164,43 @@ def get_symmetric_displacement(
 def get_outputs(
     energy: torch.Tensor,
     positions: torch.Tensor,
-    displacement: Optional[torch.Tensor],
+    batch: torch.Tensor,
+    displacement: torch.Tensor,
+    edge_index: torch.Tensor,
+    vectors: torch.Tensor,
     cell: torch.Tensor,
     training: bool = False,
     compute_force: bool = True,
     compute_virials: bool = True,
     compute_stress: bool = True,
-) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
-    if (compute_virials or compute_stress) and displacement is not None:
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+
+    if (compute_virials or compute_stress) and vectors is not None:
         # forces come for free
-        forces, virials, stress = compute_forces_virials(
+        forces, virials, stress, atom_virial = compute_forces_virials(
             energy=energy,
             positions=positions,
+            batch=batch,
             displacement=displacement,
+            edge_index=edge_index,
+            vectors=vectors,
             cell=cell,
             compute_stress=compute_stress,
             training=training,
         )
+
     elif compute_force:
-        forces, virials, stress = (
+        forces, virials, stress, atom_virial = (
             compute_forces(energy=energy, positions=positions, training=training),
+            None,
             None,
             None,
         )
     else:
-        forces, virials, stress = (None, None, None)
-    return forces, virials, stress
+        forces, virials, stress, atom_virial = (None, None, None, None)
+
+
+    return forces, virials, stress, atom_virial
 
 
 def get_edge_vectors_and_lengths(


### PR DESCRIPTION
### Description
Calculate `virials` and `stress` with `vectors` instead of `displacement` .

### Motivation and Formula
Motivation
To get atomic virial for NPT simulations and `stress/atom` in LAMMPS .

### Formula
![image](https://github.com/user-attachments/assets/b11429a0-f25e-4fae-89d5-fb9127230720)

![image](https://github.com/user-attachments/assets/dd18227b-9b49-4db8-afb2-2cdf7d7e4e3a)


### How Has It Been Tested?
`virials` and `stress` ouput of `vectors` and `displacement` are consistent.

![image](https://github.com/user-attachments/assets/3d35d82a-61c6-4238-aceb-0a06c109862e)


based on MACE ver.0.3.4
You can use with this [code](https://github.com/pobo95/pair_mace) to pair LAMMPS