### PR TITLE
Allow creation of MACECalculator without needing to write a checkpoint to disk.

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -227,4 +227,6 @@ def mace_anicc(
         print(
             "Using ANI couple cluster model for MACECalculator, see https://doi.org/10.1063/5.0155322"
         )
-    return MACECalculator(model_path, device=device, default_dtype="float64")
+    return MACECalculator(
+        model_paths=model_path, device=device, default_dtype="float64"
+    )

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -5,6 +5,7 @@
 ###########################################################################################
 
 
+import logging
 from glob import glob
 from pathlib import Path
 from typing import Union
@@ -64,12 +65,15 @@ class MACECalculator(Calculator):
         Calculator.__init__(self, **kwargs)
 
         if "model_path" in kwargs:
+            deprecation_message = (
+                "'model_path' argument is deprecated, please use 'model_paths'"
+            )
             if model_paths is None:
-                print("model_path argument deprecated, use model_paths")
+                logging.warning(f"{deprecation_message} in the future.")
                 model_paths = kwargs["model_path"]
             else:
                 raise ValueError(
-                    "both 'model_path' and 'model_paths' argument give, please only pass model_paths"
+                    f"both 'model_path' and 'model_paths' given, {deprecation_message} only."
                 )
 
         if (model_paths is None) == (models is None):

--- a/mace/cli/active_learning_md.py
+++ b/mace/cli/active_learning_md.py
@@ -149,8 +149,8 @@ def run(args: argparse.Namespace) -> None:
     atoms_index = args.config_index
 
     mace_calc = MACECalculator(
-        mace_fname,
-        args.device,
+        model_paths=mace_fname,
+        device=args.device,
         default_dtype=args.default_dtype,
     )
 

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -218,10 +218,9 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
 
 
 def extract_load(f: str, map_location: str = "cpu") -> torch.nn.Module:
-    model = torch.load(f=f, map_location=map_location)
-    model_copy = model.__class__(**extract_config_mace_model(model))
-    model_copy.load_state_dict(model.state_dict())
-    return model_copy.to(map_location)
+    return extract_model(
+        torch.load(f=f, map_location=map_location), map_location=map_location
+    )
 
 
 def extract_model(model: torch.nn.Module, map_location: str = "cpu") -> torch.nn.Module:

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -111,7 +111,7 @@ def trained_model_fixture(tmp_path_factory, fitting_configs):
 
     assert p.returncode == 0
 
-    return MACECalculator(tmp_path / "MACE.model", device="cpu")
+    return MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
 
 
 @pytest.fixture(scope="module", name="trained_equivariant_model")
@@ -174,7 +174,7 @@ def trained_model_equivariant_fixture(tmp_path_factory, fitting_configs):
 
     assert p.returncode == 0
 
-    return MACECalculator(tmp_path / "MACE.model", device="cpu")
+    return MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
 
 
 @pytest.fixture(scope="module", name="trained_dipole_model")
@@ -239,7 +239,7 @@ def trained_dipole_fixture(tmp_path_factory, fitting_configs):
     assert p.returncode == 0
 
     return MACECalculator(
-        tmp_path / "MACE.model", device="cpu", model_type="DipoleMACE"
+        model_paths=tmp_path / "MACE.model", device="cpu", model_type="DipoleMACE"
     )
 
 
@@ -305,7 +305,7 @@ def trained_energy_dipole_fixture(tmp_path_factory, fitting_configs):
     assert p.returncode == 0
 
     return MACECalculator(
-        tmp_path / "MACE.model", device="cpu", model_type="EnergyDipoleMACE"
+        model_paths=tmp_path / "MACE.model", device="cpu", model_type="EnergyDipoleMACE"
     )
 
 
@@ -374,7 +374,7 @@ def trained_committee_fixture(tmp_path_factory, fitting_configs):
 
         _model_paths.append(tmp_path / f"MACE{seed}.model")
 
-    return MACECalculator(_model_paths, device="cpu")
+    return MACECalculator(model_paths=_model_paths, device="cpu")
 
 
 def test_calculator_node_energy(fitting_configs, trained_model):
@@ -430,6 +430,20 @@ def test_calculator_committee(fitting_configs, trained_committee):
     assert np.allclose(E, np.mean(energies))
     assert np.allclose(energies_var, np.var(energies))
     assert forces_var.shape == at.calc.results["forces"].shape
+
+
+def test_calculator_from_model(fitting_configs, trained_committee):
+    # test single model
+    test_calculator_forces(
+        fitting_configs,
+        trained_model=MACECalculator(models=trained_committee.models[0], device="cpu"),
+    )
+
+    # test committee model
+    test_calculator_committee(
+        fitting_configs,
+        trained_committee=MACECalculator(models=trained_committee.models, device="cpu"),
+    )
 
 
 def test_calculator_dipole(fitting_configs, trained_dipole_model):

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -100,7 +100,7 @@ def test_run_train(tmp_path, fitting_configs):
     p = subprocess.run(cmd.split(), env=run_env, check=True)
     assert p.returncode == 0
 
-    calc = MACECalculator(tmp_path / "MACE.model", device="cpu")
+    calc = MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
 
     Es = []
     for at in fitting_configs:
@@ -171,7 +171,7 @@ def test_run_train_missing_data(tmp_path, fitting_configs):
     p = subprocess.run(cmd.split(), env=run_env, check=True)
     assert p.returncode == 0
 
-    calc = MACECalculator(tmp_path / "MACE.model", device="cpu")
+    calc = MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
 
     Es = []
     for at in fitting_configs:
@@ -242,7 +242,7 @@ def test_run_train_no_stress(tmp_path, fitting_configs):
     p = subprocess.run(cmd.split(), env=run_env, check=True)
     assert p.returncode == 0
 
-    calc = MACECalculator(tmp_path / "MACE.model", device="cpu")
+    calc = MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
 
     Es = []
     for at in fitting_configs:
@@ -349,7 +349,7 @@ def test_run_train_multihead(tmp_path, fitting_configs):
     assert p.returncode == 0
 
     calc = MACECalculator(
-        tmp_path / "MACE.model", device="cpu", default_dtype="float64"
+        model_paths=tmp_path / "MACE.model", device="cpu", default_dtype="float64"
     )
 
     Es = []
@@ -427,7 +427,7 @@ def test_run_train_foundation(tmp_path, fitting_configs):
     assert p.returncode == 0
 
     calc = MACECalculator(
-        tmp_path / "MACE.model", device="cpu", default_dtype="float64"
+        model_paths=tmp_path / "MACE.model", device="cpu", default_dtype="float64"
     )
 
     Es = []
@@ -536,7 +536,7 @@ def test_run_train_foundation_multihead(tmp_path, fitting_configs):
     assert p.returncode == 0
 
     calc = MACECalculator(
-        tmp_path / "MACE.model", device="cpu", default_dtype="float64"
+        model_paths=tmp_path / "MACE.model", device="cpu", default_dtype="float64"
     )
 
     Es = []


### PR DESCRIPTION
The current `MACECalculator` requires you to load from a particular structure of checkpoint file. If we use a different training framework our checkpoints are not compatible and so it would be nice to be able to just pass in models.

~~Still needs tests.~~