### PR TITLE
make run_train.cli consistent with the one in the main branch.

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -4,6 +4,7 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+import argparse
 import ast
 import glob
 import json

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -45,11 +45,18 @@ from mace.tools.finetuning_utils import (
 )
 from mace.tools.utils import AtomicNumberTable
 
-
 def main() -> None:
+    """
+    This script runs the training/fine tuning for mace
+    """
     args = tools.build_default_arg_parser().parse_args()
-    tag = tools.get_tag(name=args.name, seed=args.seed)
+    run(args)
 
+
+def run(args: argparse.Namespace) -> None:
+
+    tag = tools.get_tag(name=args.name, seed=args.seed)
+    
     if args.device == "xpu":
         try:
             import intel_extension_for_pytorch as ipex


### PR DESCRIPTION
simple cosmetic change to make the run_cli interface consistent with what is currently in the main... prevents breaking workflows based on the main branch.