### PR TITLE
Change type hint syntax in MACECalculator to work with python39

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
           '--disable=missing-class-docstring',
           '--disable=missing-function-docstring',
           '--disable=too-many-arguments',
+          '--disable=too-many-positional-arguments',
           '--disable=too-many-locals',
           '--disable=not-callable',
           '--disable=logging-fstring-interpolation',

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@
   - [About MACE](#about-mace)
   - [Documentation](#documentation)
   - [Installation](#installation)
-    - [pip installation](#pip-installation)
-    - [conda installation](#conda-installation)
-    - [pip installation from source](#pip-installation-from-source)
+    - [pip installation](#installation-from-pypi)
+    - [pip installation from source](#installation-from-source)
   - [Usage](#usage)
     - [Training](#training)
     - [Evaluation](#evaluation)
-  - [Tutorial](#tutorial)
+  - [Tutorials](#tutorials)
   - [Weights and Biases for experiment tracking](#weights-and-biases-for-experiment-tracking)
   - [Pretrained Foundation Models](#pretrained-foundation-models)
     - [MACE-MP: Materials Project Force Fields](#mace-mp-materials-project-force-fields)
@@ -57,7 +56,7 @@ A partial documentation is available at: https://mace-docs.readthedocs.io
 
 **Make sure to install PyTorch.** Please refer to the [official PyTorch installation](https://pytorch.org/get-started/locally/) for the installation instructions. Select the appropriate options for your system.
 
-### 2a. Installation from PyPI
+### Installation from PyPI
 This is the recommended way to install MACE. 
 
 ```sh
@@ -67,7 +66,7 @@ pip install mace-torch
 **Note:** The homonymous package on [PyPI](https://pypi.org/project/MACE/) has nothing to do with this one.
 
 
-### 2b. Installation from source
+### Installation from source
 
 
 ```sh
@@ -162,11 +161,15 @@ mace_eval_configs \
     --output="./your_output.xyz"
 ```
 
-## Tutorial
+## Tutorials
 
 You can run our [Colab tutorial](https://colab.research.google.com/drive/1D6EtMUjQPey_GkuxUAbPgld6_9ibIa-V?authuser=1#scrollTo=Z10787RE1N8T) to quickly get started with MACE.
 
-We also have a more detailed user and developer tutorial at https://github.com/ilyes319/mace-tutorials
+We also have a more detailed Colab tutorials on:
+ - [Introduction to MACE training and evaluation](https://colab.research.google.com/drive/1ZrTuTvavXiCxTFyjBV4GqlARxgFwYAtX)
+ - [Introduction to MACE active learning and fine-tuning](https://colab.research.google.com/drive/1oCSVfMhWrqHTeHbKgUSQN9hTKxLzoNyb)
+ - [MACE theory and code (advanced)](https://colab.research.google.com/drive/1AlfjQETV_jZ0JQnV5M3FGwAM2SGCl2aU)
+
 
 ## On-line data loading for large datasets
 

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -50,9 +50,9 @@ class MACECalculator(Calculator):
 
     def __init__(
         self,
-        model_paths: Union[list, str] | None = None,
-        device: str | None = None,
-        models: Union[list[torch.nn.Module], torch.nn.Module] | None = None,
+        model_paths: Union[list, str, None] = None,
+        device: Union[str, None] = None,
+        models: Union[list[torch.nn.Module], torch.nn.Module, None] = None,
         energy_units_to_eV: float = 1.0,
         length_units_to_A: float = 1.0,
         default_dtype="",


### PR DESCRIPTION
Remove the `|` in the type hint syntax that is incompatible with python 3.9.  I don't know if there are other places where this syntax is being used - if there is auto testing (esp. in a github CI), perhaps it could automatically be run with python 3.9 in addition to whatever version is being used now?  Maybe run on 3.9, for backward compatibility, and some new-ish version (3.12 now?) for cutting edge support?

closes #617 