### PR TITLE
Update training.rst

### DIFF
--- a/docs/guide/training.rst
+++ b/docs/guide/training.rst
@@ -35,7 +35,7 @@ mace, you can also use the executable `mace_run_train` entry point which should 
 Training files
 ---------------
 
-To train a MACE model, you will use the `run_train.py`command which takes the following arguments:
+To train a MACE model, you will use the `run_train.py` command which takes the following arguments:
 
 First specify the name of your model and final log file using the `--name` flag.
 


### PR DESCRIPTION
Add missing space. I noticed this while reading the web page that it is not rendered properly:

https://mace-docs.readthedocs.io/en/latest/guide/training.html#id2

<img width="673" alt="Screenshot 2024-10-14 at 9 29 38 PM" src="https://github.com/user-attachments/assets/8b1dffc6-7909-468d-85a9-bf7289192712">
