### PR TITLE
Fix multihead prediction for eval_configs.py

### DIFF
--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -80,10 +80,15 @@ def run(args: argparse.Namespace) -> None:
 
     z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
 
+    try:
+        heads = model.heads
+    except AttributeError:
+        heads = None
+        
     data_loader = torch_geometric.dataloader.DataLoader(
         dataset=[
             data.AtomicData.from_config(
-                config, z_table=z_table, cutoff=float(model.r_max)
+                config, z_table=z_table, cutoff=float(model.r_max), heads=heads
             )
             for config in configs
         ],

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -53,6 +53,13 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="MACE_",
     )
+    parser.add_argument(
+        "--head",
+        help="Model head used for evaluation",
+        type=str,
+        required=False,
+        default=None
+    )
     return parser.parse_args()
 
 
@@ -76,6 +83,9 @@ def run(args: argparse.Namespace) -> None:
 
     # Load data and prepare input
     atoms_list = ase.io.read(args.configs, index=":")
+    if args.head is not None:
+        for atoms in atoms_list:
+            atoms.info["head"] = args.head
     configs = [data.config_from_atoms(atoms) for atoms in atoms_list]
 
     z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])


### PR DESCRIPTION
When constructing the `DataLoader`, it appears that the keyword passing the `heads` of the model to the function was missing, so I added it in the PR.

I also added an additional argument to the CL function, that should make it much more convenient to evaluate all structures on a single head. Specifying it for every structure in the extxyz file is a bit clunky, if that flexibility is not required.

Let me know, what you think or if I got something wrong and it was indeed working all along (it didn't for me).