### PR TITLE
Fix file name of swa checkpoints

### DIFF
--- a/mace/tools/checkpoint.py
+++ b/mace/tools/checkpoint.py
@@ -64,7 +64,7 @@ class CheckpointIO:
         self._filename_extension = "pt"
 
     def _get_checkpoint_filename(self, epochs: int, swa_start=None) -> str:
-        if swa_start is not None and epochs => swa_start:
+        if swa_start is not None and epochs >= swa_start:
             return (
                 self.tag
                 + self._epochs_string

--- a/mace/tools/checkpoint.py
+++ b/mace/tools/checkpoint.py
@@ -64,7 +64,7 @@ class CheckpointIO:
         self._filename_extension = "pt"
 
     def _get_checkpoint_filename(self, epochs: int, swa_start=None) -> str:
-        if swa_start is not None and epochs > swa_start:
+        if swa_start is not None and epochs => swa_start:
             return (
                 self.tag
                 + self._epochs_string


### PR DESCRIPTION
This should fix a the file name given to the checkpoint after the very first swa epoch.

Currently, swa is started in `train.py` when `epoch == swa_start`, but the checkpoint file name only adds "swa" to the file name when `epoch > swa_start`.

This leads to a problem, when the first swa epoch has the lowest loss of all validated swa epochs. The checkpoint is saved under the wrong name, never overwritten and, at the end of the training, this checkpoint is saved as the best non-swa checkpoint (if the loss is lower then for any stage-one checkpoint), whereas the swa checkpoint is not found and an error is thrown.