### PR TITLE
Evaluate test sets separately for different heads

### DIFF
--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -265,7 +265,6 @@ def load_from_xyz(
         atoms_without_iso_atoms = []
 
         for idx, atoms in enumerate(atoms_list):
-            atoms.info[head_key] = head_name
             isolated_atom_config = (
                 len(atoms) == 1 and atoms.info.get("config_type") == "IsolatedAtom"
             )
@@ -287,6 +286,9 @@ def load_from_xyz(
             logging.info("Using isolated atom energies from training file")
         if not keep_isolated_atoms:
             atoms_list = atoms_without_iso_atoms
+
+    for atoms in atoms_list:
+        atoms.info[head_key] = head_name
 
     configs = config_from_atoms_list(
         atoms_list,


### PR DESCRIPTION
See [issue](https://github.com/ACEsuit/mace/issues/680).

I am not sure what the desired behaviour is here. Do we want the user to be able to specify 'head_key'='head_name' in the input xyz files? This fix would override that.

Using the main branch, adding `head=MP2` to a configuration's info dict does indeed add a row 'Default_MP2' to the output table.

```
2024-11-25 11:54:00.502 INFO: Error-table on TEST:
+----------------+---------------------+------------------+-------------------+
|  config_type   | RMSE E / meV / atom | RMSE F / meV / A | relative F RMSE % |
+----------------+---------------------+------------------+-------------------+
| NaCl_8_Default |          425.1      |         59.0     |          7.43     |
|   NaCl_8_MP2   |          337.9      |         91.3     |         10.09     |
+----------------+---------------------+------------------+-------------------+
```