### PR TITLE
Correct assignment of head

### DIFF
--- a/mace/data/hdf5_dataset.py
+++ b/mace/data/hdf5_dataset.py
@@ -66,8 +66,7 @@ class HDF5Dataset(Dataset):
             pbc=unpack_value(subgrp["pbc"][()]),
             cell=unpack_value(subgrp["cell"][()]),
         )
-        if config.head is None:
-            config.head = self.kwargs.get("head")
+        config.head = self.kwargs.get("head", "Default")
         atomic_data = AtomicData.from_config(
             config,
             z_table=self.z_table,


### PR DESCRIPTION
There seems to be a problem when using preprocessed datasets in combination with multiheads.
When getting a structure from `HDF5Dataset`, it is first loaded into a `Configuration`. When initializing the `Configuration`, the head is not specified and, therefore, is set to "Default" by default. Currently, the correct head saved to the `HDF5Dataset` is then only set, if `configuration.head is None`, which currently is never the case.

This pull request should fix that by always setting the head to the value saved in the `HDF5Dataset` and to `Default`, if it isn't specified (in line with how `heads` are set when turning the configuration into `AtomicData`).
In principle, this assignment can also be moved into the initialization of the `Configuration`.