### PR TITLE
Remove entries from atomic_energies_dict if not in z_table

### DIFF
--- a/mace/cli/preprocess_data.py
+++ b/mace/cli/preprocess_data.py
@@ -224,6 +224,17 @@ def run(args: argparse.Namespace):
         logging.info("Computing statistics")
         if len(atomic_energies_dict) == 0:
             atomic_energies_dict = get_atomic_energies(args.E0s, collections.train, z_table)
+
+        # Remove atomic energies if element not in z_table
+        removed_atomic_energies = {}
+        for z in list(atomic_energies_dict):
+            if z not in z_table.zs:
+                removed_atomic_energies[z] = atomic_energies_dict.pop(z)
+        if len(removed_atomic_energies) > 0:
+            logging.warning("Atomic energies for elements not present in the atomic number table have been removed.")
+            logging.warning(f"Removed atomic energies (eV): {str(removed_atomic_energies)}")
+            logging.warning("To include these elements in the model, specify all atomic numbers explicitly using the --atomic_numbers argument.")
+
         atomic_energies: np.ndarray = np.array(
             [atomic_energies_dict[z] for z in z_table.zs]
         )


### PR DESCRIPTION
If the input `.xyz` for preprocessing has more `IsolatedAtom`s than elements in the training configs, training with the generated statistics.json fails.

```
[rank4]: Traceback (most recent call last):
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/scripts/run_train.py", line 6, in <module>
[rank4]:     main()
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/cli/run_train.py", line 66, in main
[rank4]:     run(args)
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/cli/run_train.py", line 572, in run
[rank4]:     model, output_args = configure_model(args, train_loader, atomic_energies, model_foundation, heads, z_table)
[rank4]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/tools/model_script_utils.py", line 38, in configure_model
[rank4]:     args.mean, args.std = modules.scaling_classes[args.scaling](
[rank4]:  
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/modules/utils.py", line 312, in compute_mean_rms_energy_forces
[rank4]:     node_e0 = atomic_energies_fn(batch.node_attrs)
[rank4]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/linkhome/rech/genrre01/ums98bp/.conda/envs/mace/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank4]:     return self._call_impl(*args, **kwargs)
[rank4]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/linkhome/rech/genrre01/ums98bp/.conda/envs/mace/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank4]:     return forward_call(*args, **kwargs)
[rank4]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]:   File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/modules/blocks.py", line 197, in forward
[rank4]:     return torch.matmul(x, torch.atleast_2d(self.atomic_energies).T)
[rank4]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank4]: RuntimeError: mat1 and mat2 shapes cannot be multiplied (605x85 and 89x1)
```

Running with the same inputs now works, with the following warning given during preprocessing:
```
2025-01-27 18:10:45 INFO     Computing statistics
2025-01-27 18:10:45 WARNING  Atomic energies for elements not present in the atomic number table have been removed.
2025-01-27 18:10:45 WARNING  Removed atomic energies (eV): {10: -0.01241601, 18: -0.04925973, 2: 0.00096759, 36: -0.0335879}
2025-01-27 18:10:45 WARNING  To include these elements in the model, specify all atomic numbers explicitly using the --atomic_numbers argument.
```