### PR TITLE
Allow other schedulers for distributed training

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -82,7 +82,7 @@ def run(args: argparse.Namespace) -> None:
             ) from e
     if args.distributed:
         try:
-            distr_env = get_distributed_environment(args.scheduler)
+            distr_env = get_distributed_environment(args.batch_scheduler)
         except Exception as e:  # pylint: disable=W0703
             logging.error(f"Failed to initialize distributed environment: {e}")
             return

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -27,6 +27,7 @@ from mace.calculators.foundations_models import mace_mp, mace_off
 from mace.cli.convert_cueq_e3nn import run as run_cueq_to_e3nn
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.tools import torch_geometric
+from mace.tools.distributed import get_distributed_environment
 from mace.tools.model_script_utils import configure_model
 from mace.tools.multihead_tools import (
     HeadConfig,
@@ -53,7 +54,6 @@ from mace.tools.scripts_utils import (
     remove_pt_head,
     setup_wandb,
 )
-from mace.tools.slurm_distributed import DistributedEnvironment
 from mace.tools.tables_utils import create_error_table
 from mace.tools.utils import AtomicNumberTable
 
@@ -82,7 +82,7 @@ def run(args: argparse.Namespace) -> None:
             ) from e
     if args.distributed:
         try:
-            distr_env = DistributedEnvironment()
+            distr_env = get_distributed_environment(args.scheduler)
         except Exception as e:  # pylint: disable=W0703
             logging.error(f"Failed to initialize distributed environment: {e}")
             return

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -80,7 +80,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=False,
     )
     parser.add_argument(
-        "--scheduler",
+        "--batch_scheduler",
         help="select scheduler used to infer distributed training parameters",
         type=str,
         choices=["slurm", "none"],

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -79,6 +79,13 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--scheduler",
+        help="select scheduler used to infer distributed training parameters",
+        type=str,
+        choices=["slurm", "none"],
+        default="slurm",
+    )
     parser.add_argument("--log_level", help="log level", type=str, default="INFO")
 
     parser.add_argument(


### PR DESCRIPTION
Add an argument to disable automatically inferring distributed parameters from the SLURM scheduler, as discussed in #828. The default behavior should remain unchanged