### PR TITLE
pinned cuequivariance-torch & cuequivariance-ops-torch-cu12 to 0.1.0

### DIFF
--- a/docs/guide/cuda_acceleration.rst
+++ b/docs/guide/cuda_acceleration.rst
@@ -13,7 +13,7 @@ The `cuEquivariance <https://github.com/NVIDIA/cuEquivariance>`_ library is a CU
 Installation
 ############
 
-To install the cuEquivariance library, follow the instructions on the `pip install cuequivariance==0.1.0 cuequivariance-torch cuequivariance-ops-torch-cu12` (or cu11 depending on your cuda version) repository. 
+To install the cuEquivariance library, follow the instructions on the `pip install cuequivariance==0.1.0 cuequivariance-torch==0.1.0 cuequivariance-ops-torch-cu12==0.1.0` (or cu11 depending on your cuda version) repository. 
 **NOTE:** The acceleration is only available for GPU devices with CUDA support. Make sure to use PyTorch 2.4.0 or higher.
 
 Install the MACE code from source using the following command:


### PR DESCRIPTION
`pip install cuequivariance==0.1.0 cuequivariance-torch cuequivariance-ops-torch-cu12`

installs cuequivariance==0.1.0,  cuequivariance-torch==0.2.0, and  cuequivariance-ops-torch-cu12==0.2.0

It must be `pip install cuequivariance==0.1.0 cuequivariance-torch==0.1.0 cuequivariance-ops-torch-cu12==0.1.0` until `cuequivariance=0.2.0` is supported in MACE.