### PR TITLE
Add functionality to select heads to evaluate error tables on and perform dry runs.

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -431,8 +431,8 @@ def run(args) -> None:
         eval_heads = list(args.eval_heads.split(","))
         for eval_head in eval_heads:
             if eval_head not in heads:
-                logging.error(f"Head {eval_head} not found in the list of heads: {heads}.")
-                raise KeyError(f"Head {eval_head} not found in the list of heads: {heads}.")
+                logging.error(f"Head '{eval_head}' not found in the list of heads: {heads}.")
+                raise ValueError(f"Head '{eval_head}' not found in the list of heads: {heads}.")
 
     logging.info(f"Will evalute error table on heads: {eval_heads}")
 
@@ -817,6 +817,11 @@ def run(args) -> None:
             logging.debug(f"Creating Plotter failed: {e}")
     else:
         plotter = None
+
+    #DRY RUN - stop before training starts
+    if args.dry_run:
+        logging.info("DRY RUN mode enabled. Stopping now.")
+        return
 
     tools.train(
         model=model,

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -431,9 +431,12 @@ def run(args) -> None:
         eval_heads = list(args.eval_heads.split(","))
         for eval_head in eval_heads:
             if eval_head not in heads:
-                logging.error(f"Head '{eval_head}' not found in the list of heads: {heads}.")
-                raise ValueError(f"Head '{eval_head}' not found in the list of heads: {heads}.")
-
+                logging.error(
+                    f"Head '{eval_head}' not found in the list of heads: {heads}."
+                )
+                raise ValueError(
+                    f"Head '{eval_head}' not found in the list of heads: {heads}."
+                )
     logging.info(f"Will evalute error table on heads: {eval_heads}")
 
     # Atomic number table
@@ -856,14 +859,14 @@ def run(args) -> None:
 
     train_valid_data_loader = {}
     for head_config in head_configs:
-        if head_config.head_name not in eval_heads: 
+        if head_config.head_name not in eval_heads:
             logging.debug(f"Not evaluating head {head_config.head_name} in training set as not user requested. SKIP")
             continue
         data_loader_name = "train_" + head_config.head_name
         train_valid_data_loader[data_loader_name] = head_config.train_loader
 
     for head, valid_loader in valid_loaders.items():
-        if head not in eval_heads: 
+        if head not in eval_heads:
             logging.debug(f"Not evaluating head {head} in validation set as not user requesedt. SKIP")
             continue
         data_load_name = "valid_" + head
@@ -882,7 +885,7 @@ def run(args) -> None:
     ) and head_configs[0].test_dir is not None:
         stop_first_test = True
     for head_config in head_configs:
-        if head_config.head_name not in eval_heads: 
+        if head_config.head_name not in eval_heads:
             logging.debug(f"Not evaluating head {head_config.head_name} for test set as not user requested. SKIP")
             continue
         if all(check_path_ase_read(f) for f in head_config.train_file):

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -721,6 +721,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=False,
     )
     parser.add_argument(
+        "--dry_run",
+        help="Run all steps upto training to test settings.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
         "--save_cpu",
         help="Save a model to be loaded on cpu",
         action="store_true",

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -695,10 +695,9 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--eval_interval", help="evaluate model every <n> epochs", type=int, default=1
     )
     parser.add_argument(
-        "--eval_heads", 
-        help="Select the heads the user wants to evaluate at end of training. Default is to evaluate all heads. " \
-            "Enter as comma seperated string. Example: 'default,pt_head,head3,...'", 
-        type=str, 
+        "--eval_heads",
+        help="Specify heads to evaluate error table for as comma seperated string. Default to evaluate all heads. Example: 'head1,head2,...'",
+        type=str,
         default=None,
         required=False,
     )

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -695,6 +695,14 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--eval_interval", help="evaluate model every <n> epochs", type=int, default=1
     )
     parser.add_argument(
+        "--eval_heads", 
+        help="Select the heads the user wants to evaluate at end of training. Default is to evaluate all heads. " \
+            "Enter as comma seperated string. Example: 'default,pt_head,head3,...'", 
+        type=str, 
+        default=None,
+        required=False,
+    )
+    parser.add_argument(
         "--keep_checkpoints",
         help="keep all checkpoints",
         action="store_true",

--- a/mace/tools/tables_utils.py
+++ b/mace/tools/tables_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict,List
 
 import torch
 from prettytable import PrettyTable
@@ -28,6 +28,7 @@ def create_error_table(
     output_args: Dict[str, bool],
     log_wandb: bool,
     device: str,
+    eval_heads: List[str],
     distributed: bool = False,
 ) -> PrettyTable:
     if log_wandb:
@@ -100,6 +101,9 @@ def create_error_table(
         ]
 
     for name in sorted(all_data_loaders, key=custom_key):
+        #if name not in eval_heads: 
+        #    logging.debug(f"Not evaluating {name} as not user request. SKIP")
+        #    continue
         data_loader = all_data_loaders[name]
         logging.info(f"Evaluating {name} ...")
         _, metrics = evaluate(

--- a/mace/tools/tables_utils.py
+++ b/mace/tools/tables_utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict,List
+from typing import Dict
 
 import torch
 from prettytable import PrettyTable
@@ -28,7 +28,6 @@ def create_error_table(
     output_args: Dict[str, bool],
     log_wandb: bool,
     device: str,
-    eval_heads: List[str],
     distributed: bool = False,
 ) -> PrettyTable:
     if log_wandb:
@@ -101,9 +100,6 @@ def create_error_table(
         ]
 
     for name in sorted(all_data_loaders, key=custom_key):
-        #if name not in eval_heads: 
-        #    logging.debug(f"Not evaluating {name} as not user request. SKIP")
-        #    continue
         data_loader = all_data_loaders[name]
         logging.info(f"Evaluating {name} ...")
         _, metrics = evaluate(


### PR DESCRIPTION
Added 2 new arguments:

`--eval_heads` 
This allows the user to specify which heads they want to evaluate / print an error table for at the end of training. If not set, will default evaluate all heads.
Usage: Specify all heads you want to evaluate on as a string with heads separated by commas. For example:
`--eval_heads='default,pt_head,head3'`
Example use scenario would be for replay fine-tuning if the user doesn't want to evaluate the large foundation model database on the `pt_head`.

`--dry_run` 
Adding this argument will stop the `run_train.py` script just before the model training is about to begin (calls the `tools.train()` function. This allows the user to check if they've set their parameters correctly before beginning an expensive training run.

I have tested:

- If dry run works.
- If I can select heads to turn off.
- If code evaluates on all heads if none specified.
- If code stops if user specifies a head to evaluate on that doesn't exist.

Let me know if any changes needed.