### PR TITLE
Fix bug that prevents building 1-layer (no message passing) MACE models

### DIFF
--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -181,7 +181,6 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         if model.num_interactions.item() > 1
         else 1
     )
-    mlp_irreps = o3.Irreps(f"{model_mlp_irreps.count((0, 1)) // len(heads)}x0e")
     try:
         correlation = (
             len(model.products[0].symmetric_contractions.contractions[0].weights) + 1
@@ -198,7 +197,7 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         "num_interactions": model.num_interactions.item(),
         "num_elements": len(model.atomic_numbers),
         "hidden_irreps": o3.Irreps(str(model.products[0].linear.irreps_out)),
-        "MLP_irreps": (mlp_irreps if model.num_interactions.item() > 1 else 1),
+        "MLP_irreps": (o3.Irreps(f"{model_mlp_irreps.count((0, 1)) // len(heads)}x0e") if model.num_interactions.item() > 1 else 1),
         "gate": (
             model.readouts[-1]  # pylint: disable=protected-access
             .non_linearity._modules["acts"][0]


### PR DESCRIPTION
Fix bug for 1-layer MACE when model_mlp_irreps is 1 (int), for which calling .count() will raise error.