### PR TITLE
Making MACE using cuEquivariance work with Torch Script

### DIFF
--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -275,7 +275,16 @@ class EquivariantProductBasisBlock(torch.nn.Module):
             shared_weights=True,
             cueq_config=cueq_config,
         )
-        self.cueq_config = cueq_config
+        self.cueq_enabled = False
+        self.cueq_layout_str = "mul_ir"
+        self.cueq_optimize_all = False
+        self.cueq_optimize_symmetric = False
+
+        if cueq_config is not None:
+            self.cueq_enabled = cueq_config.enabled
+            self.cueq_layout_str = cueq_config.layout_str
+            self.cueq_optimize_symmetric = cueq_config.optimize_symmetric
+            self.cueq_optimize_all = cueq_config.optimize_all
 
     def forward(
         self,
@@ -285,14 +294,11 @@ class EquivariantProductBasisBlock(torch.nn.Module):
     ) -> torch.Tensor:
         use_cueq = False
         use_cueq_mul_ir = False
-        if hasattr(self, "cueq_config"):
-            if self.cueq_config is not None:
-                if self.cueq_config.enabled and (
-                    self.cueq_config.optimize_all or self.cueq_config.optimize_symmetric
-                ):
-                    use_cueq = True
-                if self.cueq_config.layout_str == "mul_ir":
-                    use_cueq_mul_ir = True
+        if self.cueq_enabled:
+            if self.cueq_optimize_all or self.cueq_optimize_symmetric:
+                use_cueq = True
+            if self.cueq_layout_str == "mul_ir":
+                use_cueq_mul_ir = True
         if use_cueq:
             if use_cueq_mul_ir:
                 node_feats = torch.transpose(node_feats, 1, 2)


### PR DESCRIPTION
I have an application where I need to use TorchScript, and noticed that it wasn't working with cuEquivariance in the latest version. I have isolated it down to the two instances in the code where a "self.cueq_config" variable is set, with TorchScript not being compatible with the CuEquivarianceConfig class. I have replaced the "self.cueq_config" values with flags taken from cueq_config. A small working example is attached that is runnable with "python test.py --xyz_file=carbon.xyz", which should fail in the current version of MACE but work with the proposed changes.

[test_mace_script.tar.gz](https://github.com/user-attachments/files/19269280/test_mace_script.tar.gz)
