### PR TITLE
Steps towards removing the use of global dtype in code.

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -204,7 +204,9 @@ class MACECalculator(Calculator):
         if kwarg_head is not None:
             self.head = kwarg_head
         else:
-            self.head = [head for head in self.available_heads if head.lower() == "default"]
+            self.head = [
+                head for head in self.available_heads if head.lower() == "default"
+            ]
             if len(self.head) == 0:
                 raise ValueError(
                     "Head keyword was not provided, and no head in the model is 'default'. "

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -7,8 +7,8 @@ import argparse
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Tuple, Union
 from pathlib import Path
+from typing import List, Tuple, Union
 
 import ase.data
 import ase.io
@@ -358,8 +358,9 @@ def _maybe_save_descriptors(
     """
     if all("mace_descriptors" in x.info for x in atoms):
         output_path = Path(output_path)
-        descriptor_save_path = output_path.parent / (output_path.stem +
-                                                     "_descriptors.npy")
+        descriptor_save_path = output_path.parent / (
+            output_path.stem + "_descriptors.npy"
+        )
         logging.info(f"Saving descriptors at {descriptor_save_path}")
         descriptors_list = [x.info["mace_descriptors"] for x in atoms]
         np.save(descriptor_save_path, descriptors_list, allow_pickle=True)
@@ -460,8 +461,10 @@ def select_samples(
         calc,
     )
     if ase.io.formats.filetype(settings.output, read=False) != "extxyz":
-        raise ValueError(f"filename '{settings.output}' does no have "
-                          "suffix compatible with extxyz format")
+        raise ValueError(
+            f"filename '{settings.output}' does no have "
+            "suffix compatible with extxyz format"
+        )
     _maybe_save_descriptors(subsampled_atoms, settings.output)
 
     _write_metadata(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -621,8 +621,8 @@ class AtomicDipolesMACE(torch.nn.Module):
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
-        compute_edge_forces: bool = False, # pylint: disable=W0613
-        compute_atomic_stresses: bool = False, # pylint: disable=W0613
+        compute_edge_forces: bool = False,  # pylint: disable=W0613
+        compute_atomic_stresses: bool = False,  # pylint: disable=W0613
     ) -> Dict[str, Optional[torch.Tensor]]:
         assert compute_force is False
         assert compute_virials is False
@@ -823,8 +823,8 @@ class EnergyDipolesMACE(torch.nn.Module):
         compute_virials: bool = False,
         compute_stress: bool = False,
         compute_displacement: bool = False,
-        compute_edge_forces: bool = False, # pylint: disable=W0613
-        compute_atomic_stresses: bool = False, # pylint: disable=W0613
+        compute_edge_forces: bool = False,  # pylint: disable=W0613
+        compute_atomic_stresses: bool = False,  # pylint: disable=W0613
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         data["node_attrs"].requires_grad_(True)

--- a/tests/test_foundations.py
+++ b/tests/test_foundations.py
@@ -26,24 +26,25 @@ MODEL_PATH = (
 
 torch.set_default_dtype(torch.float64)
 
+
 @pytest.skip("Problem with the float type", allow_module_level=True)
 def test_foundations():
     # Create MACE model
     config = data.Configuration(
-    atomic_numbers=molecule("H2COH").numbers,
-    positions=molecule("H2COH").positions,
-    properties={
-        "forces": molecule("H2COH").positions,
-        "energy": -1.5,
-        "charges": molecule("H2COH").numbers,
-        "dipole": np.array([-1.5, 1.5, 2.0]),
-    },
-    property_weights={
-        "forces": 1.0,
-        "energy": 1.0,
-        "charges": 1.0,
-        "dipole": 1.0,
-    },
+        atomic_numbers=molecule("H2COH").numbers,
+        positions=molecule("H2COH").positions,
+        properties={
+            "forces": molecule("H2COH").positions,
+            "energy": -1.5,
+            "charges": molecule("H2COH").numbers,
+            "dipole": np.array([-1.5, 1.5, 2.0]),
+        },
+        property_weights={
+            "forces": 1.0,
+            "energy": 1.0,
+            "charges": 1.0,
+            "dipole": 1.0,
+        },
     )
 
     # Created the rotated environment
@@ -139,7 +140,6 @@ def test_multi_reference():
     table_multi = tools.AtomicNumberTable([1, 6, 8])
     atomic_energies_multi = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=float)
     table = tools.AtomicNumberTable([1, 6, 8])
-
 
     # Create MACE model
     model_config = dict(
@@ -241,20 +241,20 @@ def test_compile_foundation(calc):
 def test_extract_config(model):
     assert isinstance(model, modules.ScaleShiftMACE)
     config = data.Configuration(
-    atomic_numbers=molecule("H2COH").numbers,
-    positions=molecule("H2COH").positions,
-    properties={
-        "forces": molecule("H2COH").positions,
-        "energy": -1.5,
-        "charges": molecule("H2COH").numbers,
-        "dipole": np.array([-1.5, 1.5, 2.0]),
-    },
-    property_weights={
-        "forces": 1.0,
-        "energy": 1.0,
-        "charges": 1.0,
-        "dipole": 1.0,
-    },
+        atomic_numbers=molecule("H2COH").numbers,
+        positions=molecule("H2COH").positions,
+        properties={
+            "forces": molecule("H2COH").positions,
+            "energy": -1.5,
+            "charges": molecule("H2COH").numbers,
+            "dipole": np.array([-1.5, 1.5, 2.0]),
+        },
+        property_weights={
+            "forces": 1.0,
+            "energy": 1.0,
+            "charges": 1.0,
+            "dipole": 1.0,
+        },
     )
     model_copy = modules.ScaleShiftMACE(**extract_config_mace_model(model))
     model_copy.load_state_dict(model.state_dict())

--- a/tests/test_run_train_allkeys.py
+++ b/tests/test_run_train_allkeys.py
@@ -455,6 +455,7 @@ def test_multihead_finetuning_does_not_modify_default_keyspec(tmp_path):
     run_mace_train(args)
     assert args.key_specification == default_key_spec
 
+
 # for creating values
 def make_output():
     outputs = {}


### PR DESCRIPTION
There are several issues that now have come up due to the fact that mace uses the global dtype default in several places. https://github.com/ACEsuit/mace/issues/877, https://github.com/ACEsuit/mace/issues/328

This PR attempts to replace all those places with optional dtype kwargs that default to the old behavior. The PR also should close #877 and #328 per the new dtype switching test added for the MaceCalculator.

Also took liberty to make cosmetic changes to the CI runners to speed up the time to install (saves ~10, albeit free due to OSS, ci minutes), cancel older tests running on the same PR when new changes pushed etc.