### PR TITLE
OpenEquivariance Integration

### DIFF
--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -32,7 +32,7 @@ def run(
     config["oeq_config"] = OEQConfig(
         enabled=False,
         optimize_all=True,
-        conv_fusion=None
+        conv_fusion="atomic"
     )
 
     # Create new model with oeq config

--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -1,0 +1,89 @@
+import argparse
+import logging
+import os
+from typing import Dict, List, Tuple
+
+import torch
+
+from mace.modules.wrapper_ops import OEQConfig 
+from mace.tools.scripts_utils import extract_config_mace_model
+
+def run(
+    input_model,
+    output_model="_oeq.model",
+    device="cpu",
+    return_model=True,
+):
+    # Setup logging
+
+    # Load original model
+    # logging.warning(f"Loading model")
+    # check if input_model is a path or a model
+    if isinstance(input_model, str):
+        source_model = torch.load(input_model, map_location=device)
+    else:
+        source_model = input_model
+    default_dtype = next(source_model.parameters()).dtype
+    torch.set_default_dtype(default_dtype)
+
+    config = extract_config_mace_model(source_model)
+
+    # Add OEQ config
+    config["oeq_config"] = OEQConfig(
+        enabled=False,
+        optimize_all=True,
+        conv_fusion=None
+    )
+
+    # Create new model with oeq config
+    logging.info("Creating new model with openequivariance settings")
+    target_model = source_model.__class__(**config).to(device)
+    source_dict = source_model.state_dict()
+    target_dict = target_model.state_dict()
+
+    for key in target_dict:
+        if '.conv_tp.' not in key:
+            target_dict[key] = source_dict[key]
+
+    target_model.load_state_dict(target_dict)
+
+    for i in range(2):
+        target_model.interactions[i].avg_num_neighbors = source_model.interactions[i].avg_num_neighbors
+
+    if return_model:
+        return target_model
+
+    if isinstance(input_model, str):
+        base = os.path.splitext(input_model)[0]
+        output_model = f"{base}.{output_model}"
+    logging.warning(f"Saving OEQ model to {output_model}")
+    torch.save(target_model, output_model)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_model", help="Path to input MACE model")
+    parser.add_argument(
+        "--output_model",
+        help="Path to output openequviariance model",
+        default="oeq_model.pt",
+    )
+    parser.add_argument("--device", default="cpu", help="Device to use")
+    parser.add_argument(
+        "--return_model",
+        action="store_false",
+        help="Return model instead of saving to file",
+    )
+    args = parser.parse_args()
+
+    run(
+        input_model=args.input_model,
+        output_model=args.output_model,
+        device=args.device,
+        return_model=args.return_model,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mace/cli/convert_oeq_e3nn.py
+++ b/mace/cli/convert_oeq_e3nn.py
@@ -1,0 +1,76 @@
+import argparse
+import logging
+import os
+from typing import Dict, List, Tuple
+
+import torch
+
+from mace.tools.scripts_utils import extract_config_mace_model
+
+def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True):
+    # Load OEQ model
+    if isinstance(input_model, str):
+        source_model = torch.load(input_model, map_location=device)
+    else:
+        source_model = input_model
+    default_dtype = next(source_model.parameters()).dtype
+    torch.set_default_dtype(default_dtype)
+    # Extract configuration
+    config = extract_config_mace_model(source_model)
+
+    # Remove OEQ config
+    config.pop("oeq_config", None)
+
+    # Create new model without CuEq config
+    logging.info("Creating new model without OEQ settings")
+    target_model = source_model.__class__(**config).to(device)
+     
+    source_dict = source_model.state_dict()
+    target_dict = target_model.state_dict()
+
+    for key in source_dict:
+        if '.conv_tp.' not in key:
+            target_dict[key] = source_dict[key]
+
+    for i in range(2):
+
+        target_model.interactions[i].avg_num_neighbors = source_model.interactions[i].avg_num_neighbors
+
+    target_model.load_state_dict(target_dict)
+
+    if return_model:
+        return target_model 
+
+    # Save model
+    if isinstance(input_model, str):
+        base = os.path.splitext(input_model)[0]
+        output_model = f"{base}.{output_model}"
+    logging.warning(f"Saving E3nn model to {output_model}")
+    torch.save(target_model, output_model)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_model", help="Path to input oeq model")
+    parser.add_argument(
+        "--output_model", help="Path to output E3nn model", default="e3nn_model.pt"
+    )
+    parser.add_argument("--device", default="cpu", help="Device to use")
+    parser.add_argument(
+        "--return_model",
+        action="store_false",
+        help="Return model instead of saving to file",
+    )
+    args = parser.parse_args()
+
+    run(
+        input_model=args.input_model,
+        output_model=args.output_model,
+        device=args.device,
+        return_model=args.return_model,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -455,7 +455,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
         )
         tp_weights = self.conv_tp_weights(edge_feats)
         message = self.conv_tp(
-            node_feats, edge_attrs, tp_weights, sender, receiver
+            node_feats, edge_attrs, tp_weights, edge_index 
         )  # [n_nodes, irreps]
         message = self.truncate_ghosts(message, n_real)
         node_attrs = self.truncate_ghosts(node_attrs, n_real)
@@ -547,7 +547,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
         )
         tp_weights = self.conv_tp_weights(edge_feats)
         message = self.conv_tp(
-            node_feats, edge_attrs, tp_weights, sender, receiver
+            node_feats, edge_attrs, tp_weights, edge_index 
         )  # [n_nodes, irreps]
         message = self.truncate_ghosts(message, n_real)
         node_attrs = self.truncate_ghosts(node_attrs, n_real)
@@ -652,7 +652,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             src=edge_density, index=receiver, dim=0, dim_size=num_nodes
         )  # [n_nodes, 1]
         message = self.conv_tp(
-            node_feats, edge_attrs, tp_weights, sender, receiver
+            node_feats, edge_attrs, tp_weights, edge_index 
         )  # [n_nodes, irreps]
 
         message = self.truncate_ghosts(message, n_real)
@@ -762,7 +762,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             src=edge_density, index=receiver, dim=0, dim_size=num_nodes
         )  # [n_nodes, 1]
         message = self.conv_tp(
-            node_feats, edge_attrs, tp_weights, sender, receiver
+            node_feats, edge_attrs, tp_weights, edge_index 
         )  # [n_nodes, irreps]
         message = self.truncate_ghosts(message, n_real)
         node_attrs = self.truncate_ghosts(node_attrs, n_real)
@@ -867,7 +867,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
         )
         tp_weights = self.conv_tp_weights(augmented_edge_feats)
         message = self.conv_tp(
-            node_feats_up, edge_attrs, tp_weights, sender, receiver
+            node_feats_up, edge_attrs, tp_weights, edge_index 
         )  # [n_nodes, irreps]
 
         message = self.linear(message) / self.avg_num_neighbors

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -14,6 +14,7 @@ from e3nn.util.jit import compile_mode
 
 from mace.modules.wrapper_ops import (
     CuEquivarianceConfig,
+    OEQConfig,
     FullyConnectedTensorProduct,
     Linear,
     SymmetricContractionWrapper,
@@ -40,7 +41,7 @@ class LinearNodeEmbeddingBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         irreps_out: o3.Irreps,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[OEQConfig] = None
     ):
         super().__init__()
         self.linear = Linear(
@@ -61,7 +62,7 @@ class LinearReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+        oeq_config: Optional[OEQConfig] = None # pylint: disable=unused-argument
 
     ):
         super().__init__()
@@ -88,7 +89,7 @@ class NonLinearReadoutBlock(torch.nn.Module):
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         num_heads: int = 1,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+        oeq_config: Optional[OEQConfig] = None # pylint: disable=unused-argument
 
     ):
         super().__init__()
@@ -119,7 +120,7 @@ class LinearDipoleReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+        oeq_config: Optional[OEQConfig] = None # pylint: disable=unused-argument
 
     ):
         super().__init__()
@@ -144,7 +145,7 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
         gate: Callable,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+        oeq_config: Optional[OEQConfig] = None # pylint: disable=unused-argument
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
@@ -259,7 +260,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         use_sc: bool = True,
         num_elements: Optional[int] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None 
+        oeq_config: Optional[OEQConfig] = None 
     ) -> None:
         super().__init__()
 
@@ -326,7 +327,7 @@ class InteractionBlock(torch.nn.Module):
         avg_num_neighbors: float,
         radial_MLP: Optional[List[int]] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None 
+        oeq_config: Optional[OEQConfig] = None 
     ) -> None:
         super().__init__()
         self.node_attrs_irreps = node_attrs_irreps

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -33,7 +33,6 @@ from .radial import (
     SoftTransform,
 )
 
-
 @compile_mode("script")
 class LinearNodeEmbeddingBlock(torch.nn.Module):
     def __init__(
@@ -41,6 +40,7 @@ class LinearNodeEmbeddingBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         irreps_out: o3.Irreps,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         super().__init__()
         self.linear = Linear(
@@ -61,6 +61,7 @@ class LinearReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         super().__init__()
         self.linear = Linear(
@@ -86,6 +87,7 @@ class NonLinearReadoutBlock(torch.nn.Module):
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         num_heads: int = 1,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
@@ -115,6 +117,7 @@ class LinearDipoleReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         super().__init__()
         if dipole_only:
@@ -138,6 +141,7 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
         gate: Callable,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
@@ -252,6 +256,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         use_sc: bool = True,
         num_elements: Optional[int] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ) -> None:
         super().__init__()
 
@@ -317,6 +322,7 @@ class InteractionBlock(torch.nn.Module):
         avg_num_neighbors: float,
         radial_MLP: Optional[List[int]] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ) -> None:
         super().__init__()
         self.node_attrs_irreps = node_attrs_irreps
@@ -381,6 +387,9 @@ class RealAgnosticInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
+        if not hasattr(self, "oeq_config"):
+            self.oeq_config = None
+
         # First linear
         self.linear_up = Linear(
             self.node_feats_irreps,
@@ -403,6 +412,7 @@ class RealAgnosticInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config
         )
 
         # Convolution weights
@@ -472,6 +482,9 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
+        if not hasattr(self, "oeq_config"):
+            self.oeq_config = None
+
         # First linear
         self.linear_up = Linear(
             self.node_feats_irreps,
@@ -494,6 +507,7 @@ class RealAgnosticResidualInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config
         )
 
         # Convolution weights
@@ -564,6 +578,9 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
+        if not hasattr(self, "oeq_config"):
+            self.oeq_config = None
+
         # First linear
         self.linear_up = Linear(
             self.node_feats_irreps,
@@ -586,6 +603,7 @@ class RealAgnosticDensityInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config
         )
 
         # Convolution weights
@@ -671,6 +689,8 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
+        if not hasattr(self, "oeq_config"):
+            self.oeq_config = None
 
         # First linear
         self.linear_up = Linear(
@@ -694,6 +714,7 @@ class RealAgnosticDensityResidualInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config
         )
 
         # Convolution weights
@@ -780,6 +801,9 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
     def _setup(self) -> None:
         if not hasattr(self, "cueq_config"):
             self.cueq_config = None
+        if not hasattr(self, "oeq_config"):
+            self.oeq_config = None
+
         self.node_feats_down_irreps = o3.Irreps("64x0e")
         # First linear
         self.linear_up = Linear(
@@ -803,6 +827,7 @@ class RealAgnosticAttResidualInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config
         )
 
         # Convolution weights

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -61,7 +61,8 @@ class LinearReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+
     ):
         super().__init__()
         self.linear = Linear(
@@ -87,7 +88,8 @@ class NonLinearReadoutBlock(torch.nn.Module):
         irrep_out: o3.Irreps = o3.Irreps("0e"),
         num_heads: int = 1,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
@@ -117,7 +119,8 @@ class LinearDipoleReadoutBlock(torch.nn.Module):
         irreps_in: o3.Irreps,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
+
     ):
         super().__init__()
         if dipole_only:
@@ -141,7 +144,7 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
         gate: Callable,
         dipole_only: bool = False,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None # pylint: disable=unused-argument
     ):
         super().__init__()
         self.hidden_irreps = MLP_irreps
@@ -256,7 +259,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         use_sc: bool = True,
         num_elements: Optional[int] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None 
     ) -> None:
         super().__init__()
 
@@ -267,6 +270,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
             correlation=correlation,
             num_elements=num_elements,
             cueq_config=cueq_config,
+            oeq_config=oeq_config
         )
         # Update linear
         self.linear = Linear(
@@ -322,7 +326,7 @@ class InteractionBlock(torch.nn.Module):
         avg_num_neighbors: float,
         radial_MLP: Optional[List[int]] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
-        oeq_config: Optional[dict] = None
+        oeq_config: Optional[dict] = None 
     ) -> None:
         super().__init__()
         self.node_attrs_irreps = node_attrs_irreps
@@ -336,6 +340,7 @@ class InteractionBlock(torch.nn.Module):
             radial_MLP = [64, 64, 64]
         self.radial_MLP = radial_MLP
         self.cueq_config = cueq_config
+        self.oeq_config = oeq_config
         self._setup()
 
     @abstractmethod

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -63,6 +63,7 @@ class MACE(torch.nn.Module):
         radial_type: Optional[str] = "bessel",
         heads: Optional[List[str]] = None,
         cueq_config: Optional[Dict[str, Any]] = None,
+        oeq_config: Optional[Dict[str, Any]] = None,
         lammps_mliap: Optional[bool] = False,
     ):
         super().__init__()
@@ -88,6 +89,7 @@ class MACE(torch.nn.Module):
             irreps_in=node_attr_irreps,
             irreps_out=node_feats_irreps,
             cueq_config=cueq_config,
+            oeq_config=oeq_config
         )
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
@@ -122,6 +124,7 @@ class MACE(torch.nn.Module):
             avg_num_neighbors=avg_num_neighbors,
             radial_MLP=radial_MLP,
             cueq_config=cueq_config,
+            oeq_config=oeq_config
         )
         self.interactions = torch.nn.ModuleList([inter])
 
@@ -138,13 +141,14 @@ class MACE(torch.nn.Module):
             num_elements=num_elements,
             use_sc=use_sc_first,
             cueq_config=cueq_config,
+            oeq_config=oeq_config
         )
         self.products = torch.nn.ModuleList([prod])
 
         self.readouts = torch.nn.ModuleList()
         self.readouts.append(
             LinearReadoutBlock(
-                hidden_irreps, o3.Irreps(f"{len(heads)}x0e"), cueq_config
+                hidden_irreps, o3.Irreps(f"{len(heads)}x0e"), cueq_config, oeq_config
             )
         )
 
@@ -165,6 +169,7 @@ class MACE(torch.nn.Module):
                 avg_num_neighbors=avg_num_neighbors,
                 radial_MLP=radial_MLP,
                 cueq_config=cueq_config,
+                oeq_config=oeq_config,
             )
             self.interactions.append(inter)
             prod = EquivariantProductBasisBlock(
@@ -174,6 +179,7 @@ class MACE(torch.nn.Module):
                 num_elements=num_elements,
                 use_sc=True,
                 cueq_config=cueq_config,
+                oeq_config=oeq_config
             )
             self.products.append(prod)
             if i == num_interactions - 2:
@@ -185,12 +191,13 @@ class MACE(torch.nn.Module):
                         o3.Irreps(f"{len(heads)}x0e"),
                         len(heads),
                         cueq_config,
+                        oeq_config
                     )
                 )
             else:
                 self.readouts.append(
                     LinearReadoutBlock(
-                        hidden_irreps, o3.Irreps(f"{len(heads)}x0e"), cueq_config
+                        hidden_irreps, o3.Irreps(f"{len(heads)}x0e"), cueq_config, oeq_config
                     )
                 )
 
@@ -508,6 +515,7 @@ class AtomicDipolesMACE(torch.nn.Module):
         radial_type: Optional[str] = "bessel",
         radial_MLP: Optional[List[int]] = None,
         cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
     ):
         super().__init__()
         self.register_buffer(
@@ -712,6 +720,7 @@ class EnergyDipolesMACE(torch.nn.Module):
         atomic_energies: Optional[np.ndarray],
         radial_MLP: Optional[List[int]] = None,
         cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
     ):
         super().__init__()
         self.register_buffer(

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -114,7 +114,8 @@ class TensorProductScatterSum:
         instructions: Optional[List] = None,
         shared_weights: bool = False,
         internal_weights: bool = False,
-        cueq_config: Optional[CuEquivarianceConfig] = None
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         if (
             CUET_AVAILABLE
@@ -153,7 +154,7 @@ class FullyConnectedTensorProduct:
         irreps_out: o3.Irreps,
         shared_weights: bool = True,
         internal_weights: bool = True,
-        cueq_config: Optional[CuEquivarianceConfig] = None,
+        cueq_config: Optional[CuEquivarianceConfig] = None
     ):
         if (
             CUET_AVAILABLE
@@ -190,6 +191,7 @@ class SymmetricContractionWrapper:
         correlation: int,
         num_elements: Optional[int] = None,
         cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[dict] = None
     ):
         if (
             CUET_AVAILABLE

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -80,15 +80,19 @@ class Linear:
 
 class TPScatterSumUnfused(torch.nn.Module):
     def __init__(self, conv_tp: Union[o3.TensorProduct, cuet.ChannelWiseTensorProduct]):
-        self.conv_tp = conv_tp 
+        super().__init__()
+        self.conv_tp = conv_tp
+        self.weight_numel = self.conv_tp.weight_numel
 
     def forward(self, node_feats: torch.Tensor, 
                 edge_attrs: torch.Tensor, 
                 tp_weights: torch.Tensor, 
-                sender: torch.Tensor,
-                receiver: torch.Tensor
+                edge_index: torch.Tensor
                 ):
+        sender = edge_index[0]
+        receiver = edge_index[1]
         num_nodes = node_feats.shape[0]
+
         mji = self.conv_tp(
             node_feats[sender], edge_attrs, tp_weights
         )  # [n_edges, irreps]

--- a/tests/test_cueq_oeq.py
+++ b/tests/test_cueq_oeq.py
@@ -195,7 +195,7 @@ class TestCueq(BackendTestBase):
     def conversion_functions(self):
         return run_e3nn_to_cueq, run_cueq_to_e3nn
 
-    @pytest.fixture(params=['cpu'] + (['cuda'] if CUDA_AVAILABLE else []))
+    @pytest.fixture(params=(['cuda'] if CUDA_AVAILABLE else []))
     def device(self, request):
         return request.param
 
@@ -205,7 +205,7 @@ class TestOeq(BackendTestBase):
     @pytest.fixture
     def conversion_functions(self):
         return run_e3nn_to_oeq, run_oeq_to_e3nn
-    
+   
     @pytest.fixture(params=(['cuda'] if CUDA_AVAILABLE else []))
     def device(self, request):
         return request.param

--- a/tests/test_cueq_oeq.py
+++ b/tests/test_cueq_oeq.py
@@ -13,6 +13,10 @@ from e3nn import o3
 from mace import data, modules, tools
 from mace.cli.convert_cueq_e3nn import run as run_cueq_to_e3nn
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
+
+from mace.cli.convert_oeq_e3nn import run as run_oeq_to_e3nn
+from mace.cli.convert_e3nn_oeq import run as run_e3nn_to_oeq
+
 from mace.tools import torch_geometric
 
 try:
@@ -22,11 +26,16 @@ try:
 except ImportError:
     CUET_AVAILABLE = False
 
+try:
+    import openequivariance as oeq  # pylint: disable=unused-import
+
+    OEQ_AVAILABLE = True
+except ImportError:
+    OEQ_AVAILABLE = False
+
 CUDA_AVAILABLE = torch.cuda.is_available()
 
-
-@pytest.mark.skipif(not CUET_AVAILABLE, reason="cuequivariance not installed")
-class TestCueq:
+class BackendTestBase:
     @pytest.fixture
     def model_config(self, interaction_cls_first, hidden_irreps) -> Dict[str, Any]:
         table = tools.AtomicNumberTable([6])
@@ -82,10 +91,6 @@ class TestCueq:
         return batch.to(device).to_dict()
 
     @pytest.mark.parametrize(
-        "device",
-        ["cpu"] + (["cuda"] if CUDA_AVAILABLE else []),
-    )
-    @pytest.mark.parametrize(
         "interaction_cls_first",
         [
             modules.interaction_classes["RealAgnosticResidualInteractionBlock"],
@@ -108,7 +113,10 @@ class TestCueq:
         batch: Dict[str, torch.Tensor],
         device: str,
         default_dtype: torch.dtype,
+        conversion_functions: tuple 
     ):
+        run_e3nn_to_backend, run_backend_to_e3nn = conversion_functions
+
         if device == "cuda" and not CUDA_AVAILABLE:
             pytest.skip("CUDA not available")
         torch.manual_seed(42)
@@ -117,33 +125,34 @@ class TestCueq:
         model_e3nn = modules.ScaleShiftMACE(**model_config).to(device)
 
         # Convert E3nn to CuEq
-        model_cueq = run_e3nn_to_cueq(model_e3nn).to(device)
+        model_backend = run_e3nn_to_backend(model_e3nn).to(device)
 
         # Convert CuEq back to E3nn
-        model_e3nn_back = run_cueq_to_e3nn(model_cueq).to(device)
+        model_e3nn_back = run_backend_to_e3nn(model_backend).to(device)
 
         # Test forward pass equivalence
         out_e3nn = model_e3nn(deepcopy(batch), training=True, compute_stress=True)
-        out_cueq = model_cueq(deepcopy(batch), training=True, compute_stress=True)
+        out_backend = model_backend(deepcopy(batch), training=True, compute_stress=True)
+
         out_e3nn_back = model_e3nn_back(
             deepcopy(batch), training=True, compute_stress=True
         )
 
         # Check outputs match for both conversions
-        torch.testing.assert_close(out_e3nn["energy"], out_cueq["energy"])
-        torch.testing.assert_close(out_cueq["energy"], out_e3nn_back["energy"])
-        torch.testing.assert_close(out_e3nn["forces"], out_cueq["forces"])
-        torch.testing.assert_close(out_cueq["forces"], out_e3nn_back["forces"])
-        torch.testing.assert_close(out_e3nn["stress"], out_cueq["stress"])
-        torch.testing.assert_close(out_cueq["stress"], out_e3nn_back["stress"])
+        torch.testing.assert_close(out_e3nn["energy"], out_backend["energy"])
+        torch.testing.assert_close(out_backend["energy"], out_e3nn_back["energy"])
+        torch.testing.assert_close(out_e3nn["forces"], out_backend["forces"])
+        torch.testing.assert_close(out_backend["forces"], out_e3nn_back["forces"])
+        torch.testing.assert_close(out_e3nn["stress"], out_backend["stress"])
+        torch.testing.assert_close(out_backend["stress"], out_e3nn_back["stress"])
 
         # Test backward pass equivalence
         loss_e3nn = out_e3nn["energy"].sum()
-        loss_cueq = out_cueq["energy"].sum()
+        loss_backend = out_backend["energy"].sum()
         loss_e3nn_back = out_e3nn_back["energy"].sum()
 
         loss_e3nn.backward()
-        loss_cueq.backward()
+        loss_backend.backward()
         loss_e3nn_back.backward()
 
         # Compare gradients for all conversions
@@ -159,17 +168,17 @@ class TestCueq:
                     torch.testing.assert_close(p1.grad, p2.grad, atol=tol, rtol=tol)
 
         # E3nn to CuEq gradients
-        for (name_e3nn, p_e3nn), (name_cueq, p_cueq) in zip(
-            model_e3nn.named_parameters(), model_cueq.named_parameters()
+        for (name_e3nn, p_e3nn), (name_backend, p_backend) in zip(
+            model_e3nn.named_parameters(), model_backend.named_parameters()
         ):
-            print_gradient_diff(name_e3nn, p_e3nn, name_cueq, p_cueq, "E3nn->CuEq")
+            print_gradient_diff(name_e3nn, p_e3nn, name_backend, p_backend, "E3nn->CuEq")
 
         # CuEq to E3nn gradients
-        for (name_cueq, p_cueq), (name_e3nn_back, p_e3nn_back) in zip(
-            model_cueq.named_parameters(), model_e3nn_back.named_parameters()
+        for (name_backend, p_backend), (name_e3nn_back, p_e3nn_back) in zip(
+            model_backend.named_parameters(), model_e3nn_back.named_parameters()
         ):
             print_gradient_diff(
-                name_cueq, p_cueq, name_e3nn_back, p_e3nn_back, "CuEq->E3nn"
+                name_backend, p_backend, name_e3nn_back, p_e3nn_back, "CuEq->E3nn"
             )
 
         # Full circle comparison (E3nn -> E3nn)
@@ -179,3 +188,24 @@ class TestCueq:
             print_gradient_diff(
                 name_e3nn, p_e3nn, name_e3nn_back, p_e3nn_back, "Full circle"
             )
+
+@pytest.mark.skipif(not CUET_AVAILABLE, reason="cuequivariance not installed")
+class TestCueq(BackendTestBase):
+    @pytest.fixture
+    def conversion_functions(self):
+        return run_e3nn_to_cueq, run_cueq_to_e3nn
+
+    @pytest.fixture(params=['cpu'] + (['cuda'] if CUDA_AVAILABLE else []))
+    def device(self, request):
+        return request.param
+
+
+@pytest.mark.skipif(not OEQ_AVAILABLE, reason="openequivariance not installed") 
+class TestOeq(BackendTestBase):
+    @pytest.fixture
+    def conversion_functions(self):
+        return run_e3nn_to_oeq, run_oeq_to_e3nn
+    
+    @pytest.fixture(params=(['cuda'] if CUDA_AVAILABLE else []))
+    def device(self, request):
+        return request.param


### PR DESCRIPTION
Adds support for OpenEquivariance in MACE (in particular, unlocks acceleration on AMD architectures). Integration follows a similar pattern to CUEQ. Adds options for a fused TP + scattersum with atomics or the unfused operation, for now.

Major diffs:
1. Scatter sum moved to wrapper_ops and combined with conv_tp. With this change of interface (which should not affect model loading from a saved state), we gain the ability to fuse the convolution with the TP and achieve significant memory savings.
2. test_cue.py renamed to test_cue_oeq.py and runs the roundtrip comparisons for both kernel providers.

This is a prototype, and we are open to any changes and will adapt to your needs. We do not provide a CPU backend for our kernels, in particular, but we could provide a fallback if this is needed.

@asglover
