### PR TITLE
correct output of loss to log file when fine-tuning

### DIFF
--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -105,7 +105,7 @@ def configure_model(
         model_config = model_config_foundation
 
         logging.info("Model configuration extracted from foundation model")
-        logging.info("Using universal loss function for fine-tuning")
+        logging.info(f"Using {args.loss} loss function for fine-tuning")
         logging.info(
             f"Message passing with hidden irreps {model_config_foundation['hidden_irreps']})"
         )


### PR DESCRIPTION
Output actual loss to be used, rather than hard-wired string 'universal' when reporting on model to be used when fine-tuning is active

closes #972 