### PR TITLE
Preprocess: Fails if E0s Specified via JSON

### DIFF
--- a/mace/cli/preprocess_data.py
+++ b/mace/cli/preprocess_data.py
@@ -223,7 +223,7 @@ def run(args: argparse.Namespace):
 
     if args.compute_statistics:
         logging.info("Computing statistics")
-        if len(atomic_energies_dict) == 0:
+        if atomic_energies_dict is None or len(atomic_energies_dict) == 0:
             atomic_energies_dict = get_atomic_energies(args.E0s, collections.train, z_table)
 
         # Remove atomic energies if element not in z_table


### PR DESCRIPTION
**Error Message Before Fix**
```
/lustre/fsn1/worksf/projects/rech/gax/ums98bp/miniforge3/envs/mace/lib/python3.12/site-packages/e3nn/o3/_wigner.py:10: UserWarning: Environment variable TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD detected, since the`weights_only` argument was not explicitly passed to `torch.load`, forcing weights_only=False.
  _Jd, _W3j_flat, _W3j_indices = torch.load(os.path.join(os.path.dirname(__file__), 'constants.pt'))
2025-05-28 21:36:05 INFO     Training set 1/1 [energy: 1580395, stress: 1580395, virials: 0, dipole components: 0, head: 1580395, forces: 1580395, charges: 0]
2025-05-28 21:36:10 INFO     Total Training set [energy: 1580395, stress: 1580395, virials: 0, dipole components: 0, head: 1580395, forces: 1580395, charges: 0]
2025-05-28 21:36:10 INFO     No validation set provided, splitting training data instead.
2025-05-28 21:36:10 INFO     Using random 5% of training set for validation with indices saved in: ./valid_indices_1234.txt
2025-05-28 21:36:17 INFO     Random Split Training set [energy: 1501376, stress: 1501376, virials: 0, dipole components: 0, head: 1501376, forces: 1501376, charges: 0]
2025-05-28 21:36:17 INFO     Random Split Validation set [energy: 79019, stress: 79019, virials: 0, dipole components: 0, head: 79019, forces: 79019, charges: 0]
2025-05-28 21:36:22 INFO     Preparing training set
2025-05-28 21:37:23 INFO     Computing statistics
Traceback (most recent call last):
  File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/cli/preprocess_data.py", line 300, in <module>
    main()
  File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/cli/preprocess_data.py", line 139, in main
    run(args)
  File "/lustre/fswork/projects/rech/gax/ums98bp/maces/main/mace/cli/preprocess_data.py", line 226, in run
    if len(atomic_energies_dict) == 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

It appears `get_dataset_from_xyz` returns an `atomic_energies_dict` of `None` as opposed to `{}` when there are no IsolatedAtoms in the xyz.

I've made this change to mirror this line: https://github.com/ACEsuit/mace/blob/b5faaa076c49778fc17493edfecebcabeb960155/mace/cli/run_train.py#L406