### PR TITLE
Fix oeq import handling on macos without cuda

### DIFF
--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -25,7 +25,7 @@ try:
     import openequivariance as oeq
 
     OEQ_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     OEQ_AVAILABLE = False
 
 

--- a/tests/test_cueq_oeq.py
+++ b/tests/test_cueq_oeq.py
@@ -28,7 +28,7 @@ try:
     import openequivariance as oeq  # pylint: disable=unused-import
 
     OEQ_AVAILABLE = True
-except ImportError:
+except (ImportError, OSError):
     OEQ_AVAILABLE = False
 
 CUDA_AVAILABLE = torch.cuda.is_available()


### PR DESCRIPTION
Various tests fail when oeq installed but cuda not available.

See https://github.com/PASSIONLab/OpenEquivariance/issues/121