### PR TITLE
Updated MACE mu alpha

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -386,7 +386,11 @@ class MACECalculator(Calculator):
                 ret_tensors["forces"][i] = out["forces"].detach()
                 if out["stress"] is not None:
                     ret_tensors["stress"][i] = out["stress"].detach()
-            if self.model_type in ["DipoleMACE", "EnergyDipoleMACE", "DipolePolarizabilityMACE"]:
+            if self.model_type in [
+                "DipoleMACE",
+                "EnergyDipoleMACE",
+                "DipolePolarizabilityMACE",
+            ]:
                 ret_tensors["dipole"][i] = out["dipole"].detach()
             if self.model_type == "DipolePolarizabilityMACE":
                 ret_tensors["charges"][i] = out["charges"].detach()
@@ -461,7 +465,11 @@ class MACECalculator(Calculator):
                     .numpy()
                     * self.energy_units_to_eV
                 )
-        if self.model_type in ["DipoleMACE", "EnergyDipoleMACE","DipolePolarizabilityMACE"]:
+        if self.model_type in [
+            "DipoleMACE",
+            "EnergyDipoleMACE",
+            "DipolePolarizabilityMACE",
+        ]:
             self.results["dipole"] = (
                 torch.mean(ret_tensors["dipole"], dim=0).cpu().numpy()
             )
@@ -483,6 +491,7 @@ class MACECalculator(Calculator):
             self.results["polarizability_sh"] = (
                 torch.mean(ret_tensors["polarizability_sh"], dim=0).cpu().numpy()
             )
+
     def get_dielectric_derivatives(self, atoms=None):
         if atoms is None and self.atoms is None:
             raise ValueError("atoms not set")
@@ -517,7 +526,7 @@ class MACECalculator(Calculator):
             return dipole_derivatives[0]
         del outputs, batch, atoms
         return dipole_derivatives
-    
+
     def get_hessian(self, atoms=None):
         if atoms is None and self.atoms is None:
             raise ValueError("atoms not set")

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -131,6 +131,13 @@ class MACECalculator(Calculator):
                 self.compute_atomic_stresses = True
         elif model_type == "DipoleMACE":
             self.implemented_properties = ["dipole"]
+        elif model_type == "DipolePolarizabilityMACE":
+            self.implemented_properties = [
+                "charges",
+                "dipole",
+                "polarizability",
+                "polarizability_sh",
+            ]
         elif model_type == "EnergyDipoleMACE":
             self.implemented_properties = [
                 "energy",
@@ -142,7 +149,7 @@ class MACECalculator(Calculator):
             ]
         else:
             raise ValueError(
-                f"Give a valid model_type: [MACE, DipoleMACE, EnergyDipoleMACE], {model_type} not supported"
+                f"Give a valid model_type: [MACE, DipoleMACE, DipolePolarizabilityMACE, EnergyDipoleMACE], {model_type} not supported"
             )
 
         if model_paths is not None:
@@ -289,9 +296,20 @@ class MACECalculator(Calculator):
                     "stress": stress,
                 }
             )
-        if model_type in ["EnergyDipoleMACE", "DipoleMACE"]:
+        if model_type in ["EnergyDipoleMACE", "DipoleMACE", "DipolePolarizabilityMACE"]:
             dipole = torch.zeros(num_models, 3, device=self.device)
             dict_of_tensors.update({"dipole": dipole})
+        if model_type in ["DipolePolarizabilityMACE"]:
+            charges = torch.zeros(num_models, num_atoms, device=self.device)
+            polarizability = torch.zeros(num_models, 3, 3, device=self.device)
+            polarizability_sh = torch.zeros(num_models, 6, device=self.device)
+            dict_of_tensors.update(
+                {
+                    "charges": charges,
+                    "polarizability": polarizability,
+                    "polarizability_sh": polarizability_sh,
+                }
+            )
         return dict_of_tensors
 
     def _atoms_to_batch(self, atoms):
@@ -368,8 +386,12 @@ class MACECalculator(Calculator):
                 ret_tensors["forces"][i] = out["forces"].detach()
                 if out["stress"] is not None:
                     ret_tensors["stress"][i] = out["stress"].detach()
-            if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
+            if self.model_type in ["DipoleMACE", "EnergyDipoleMACE", "DipolePolarizabilityMACE"]:
                 ret_tensors["dipole"][i] = out["dipole"].detach()
+            if self.model_type == "DipolePolarizabilityMACE":
+                ret_tensors["charges"][i] = out["charges"].detach()
+                ret_tensors["polarizability"][i] = out["polarizability"].detach()
+                ret_tensors["polarizability_sh"][i] = out["polarizability_sh"].detach()
             if self.model_type in ["MACE"]:
                 if out["atomic_stresses"] is not None:
                     ret_tensors.setdefault("atomic_stresses", []).append(
@@ -439,7 +461,7 @@ class MACECalculator(Calculator):
                     .numpy()
                     * self.energy_units_to_eV
                 )
-        if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
+        if self.model_type in ["DipoleMACE", "EnergyDipoleMACE","DipolePolarizabilityMACE"]:
             self.results["dipole"] = (
                 torch.mean(ret_tensors["dipole"], dim=0).cpu().numpy()
             )
@@ -449,7 +471,53 @@ class MACECalculator(Calculator):
                     .cpu()
                     .numpy()
                 )
-
+        if self.model_type in [
+            "DipolePolarizabilityMACE",
+        ]:
+            self.results["charges"] = (
+                torch.mean(ret_tensors["charges"], dim=0).cpu().numpy()
+            )
+            self.results["polarizability"] = (
+                torch.mean(ret_tensors["polarizability"], dim=0).cpu().numpy()
+            )
+            self.results["polarizability_sh"] = (
+                torch.mean(ret_tensors["polarizability_sh"], dim=0).cpu().numpy()
+            )
+    def get_dielectric_derivatives(self, atoms=None):
+        if atoms is None and self.atoms is None:
+            raise ValueError("atoms not set")
+        if atoms is None:
+            atoms = self.atoms
+        if self.model_type not in ["DipoleMACE", "DipolePolarizabilityMACE"]:
+            raise NotImplementedError(
+                "Only implemented for DipoleMACE or DipolePolarizabilityMACE models"
+            )
+        batch = self._atoms_to_batch(atoms)
+        outputs = [
+            model(
+                self._clone_batch(batch).to_dict(),
+                compute_dielectric_derivatives=True,
+                training=self.use_compile,
+            )
+            for model in self.models
+        ]
+        dipole_derivatives = [
+            output["dmu_dr"].clone().detach().cpu().numpy() for output in outputs
+        ]
+        if self.models[0].use_polarizability:
+            polarizability_derivatives = [
+                output["dalpha_dr"].clone().detach().cpu().numpy() for output in outputs
+            ]
+            if self.num_models == 1:
+                dipole_derivatives = dipole_derivatives[0]
+                polarizability_derivatives = polarizability_derivatives[0]
+            del outputs, batch, atoms
+            return dipole_derivatives, polarizability_derivatives
+        if self.num_models == 1:
+            return dipole_derivatives[0]
+        del outputs, batch, atoms
+        return dipole_derivatives
+    
     def get_hessian(self, atoms=None):
         if atoms is None and self.atoms is None:
             raise ValueError("atoms not set")

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -456,6 +456,16 @@ def run(args) -> None:
         args.compute_forces = False
         args.compute_virials = False
         args.compute_stress = False
+        args.compute_polarizability = False
+    elif args.model == "AtomicDielectricMACE":
+        atomic_energies = None
+        dipole_only = False
+        args.compute_dipole = True
+        args.compute_energy = False
+        args.compute_forces = False
+        args.compute_virials = False
+        args.compute_stress = False
+        args.compute_polarizability = True
     else:
         dipole_only = False
         if args.model == "EnergyDipolesMACE":
@@ -464,9 +474,11 @@ def run(args) -> None:
             args.compute_forces = True
             args.compute_virials = False
             args.compute_stress = False
+            args.compute_polarizability = False
         else:
             args.compute_energy = True
             args.compute_dipole = False
+            args.compute_polarizability = False
         # atomic_energies: np.ndarray = np.array(
         #     [atomic_energies_dict[z] for z in z_table.zs]
         # )

--- a/mace/cli/visualise_train.py
+++ b/mace/cli/visualise_train.py
@@ -78,6 +78,18 @@ error_type = {
         [("mae_mu", "MAE MU [mDebye]"), ("rel_mae_f", "Relative MU MAE [%]")],
         [("dipole", "Dipole per atom [Debye]")],
     ),
+    "DipolePolarRMSE": (
+        [
+            ("rmse_mu_per_atom", "RMSE MU/atom [me AA]"),
+            ("rmse_alpha_per_atom", "RMSE ALPHA/atom [me AA^2/V]"),
+            ("rel_rmse_f", "Relative MU RMSE [%]"),
+            ("rmse_polarizability_per_atom", "Relative ALPHA RMSE [%]"),  # check that
+        ],
+        [
+            ("dipole", "Dipole per atom [me AA]]"),
+            ("polarizability", "Polarizability per atom [e AA^2/V]"),
+        ],
+    ),
     "EnergyDipoleRMSE": (
         [
             ("rmse_e_per_atom", "RMSE E/atom [meV]"),

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -38,6 +38,7 @@ class AtomicData(torch_geometric.data.Data):
     virials: torch.Tensor
     dipole: torch.Tensor
     charges: torch.Tensor
+    polarizability:torch.Tensor
     total_charge: torch.Tensor
     total_spin: torch.Tensor
     weight: torch.Tensor
@@ -47,6 +48,7 @@ class AtomicData(torch_geometric.data.Data):
     virials_weight: torch.Tensor
     dipole_weight: torch.Tensor
     charges_weight: torch.Tensor
+    polarizability_weight: torch.Tensor
 
     def __init__(
         self,
@@ -64,12 +66,14 @@ class AtomicData(torch_geometric.data.Data):
         virials_weight: Optional[torch.Tensor],  # [,]
         dipole_weight: Optional[torch.Tensor],  # [,]
         charges_weight: Optional[torch.Tensor],  # [,]
+        polarizability_weight: Optional[torch.Tensor],  # [,]
         forces: Optional[torch.Tensor],  # [n_nodes, 3]
         energy: Optional[torch.Tensor],  # [, ]
         stress: Optional[torch.Tensor],  # [1,3,3]
         virials: Optional[torch.Tensor],  # [1,3,3]
         dipole: Optional[torch.Tensor],  # [, 3]
         charges: Optional[torch.Tensor],  # [n_nodes, ]
+        polarizability: Optional[torch.Tensor],  # [1, 3, 3]
         elec_temp: Optional[torch.Tensor],  # [,]
         total_charge: Optional[torch.Tensor] = None,  # [,]
         total_spin: Optional[torch.Tensor] = None,  # [,]
@@ -100,6 +104,7 @@ class AtomicData(torch_geometric.data.Data):
         assert elec_temp is None or len(elec_temp.shape) == 0
         assert total_charge is None or len(total_charge.shape) == 0
         assert total_spin is None or len(total_spin.shape) == 0
+        assert polarizability is None or polarizability.shape == (1, 3, 3)
         # Aggregate data
         data = {
             "num_nodes": num_nodes,
@@ -117,12 +122,14 @@ class AtomicData(torch_geometric.data.Data):
             "virials_weight": virials_weight,
             "dipole_weight": dipole_weight,
             "charges_weight": charges_weight,
+            "polarizability_weight": polarizability_weight,
             "forces": forces,
             "energy": energy,
             "stress": stress,
             "virials": virials,
             "dipole": dipole,
             "charges": charges,
+            "polarizability": polarizability,
             "elec_temp": elec_temp,
             "total_charge": total_charge,
             "total_spin": total_spin,
@@ -225,7 +232,13 @@ class AtomicData(torch_geometric.data.Data):
             if config.property_weights.get("charges") is not None
             else torch.tensor(1.0, dtype=torch.get_default_dtype())
         )
-
+        polarizability_weight = (
+            torch.tensor(
+                config.property_weights.get("polarizability"), dtype=torch.get_default_dtype(),
+            )
+            if config.property_weights.get("polarizability") is not None
+            else torch.tensor(1.0, dtype=torch.get_default_dtype()) ### Might need to be updated
+        )
         forces = (
             torch.tensor(
                 config.properties.get("forces"), dtype=torch.get_default_dtype()
@@ -288,6 +301,15 @@ class AtomicData(torch_geometric.data.Data):
             if config.properties.get("total_charge") is not None
             else torch.tensor(0.0, dtype=torch.get_default_dtype())
         )
+        
+        polarizability = (
+            torch.tensor(
+                config.properties.get("polarizability"), dtype=torch.get_default_dtype()
+            ).view(1, 3, 3)
+            if config.properties.get("polarizability") is not None
+            else torch.zeros(1, 3, 3, dtype=torch.get_default_dtype())
+        )
+                
         total_spin = (
             torch.tensor(
                 config.properties.get("total_spin"), dtype=torch.get_default_dtype()
@@ -311,6 +333,7 @@ class AtomicData(torch_geometric.data.Data):
             virials_weight=virials_weight,
             dipole_weight=dipole_weight,
             charges_weight=charges_weight,
+            polarizability_weight=polarizability_weight,
             forces=forces,
             energy=energy,
             stress=stress,
@@ -319,6 +342,7 @@ class AtomicData(torch_geometric.data.Data):
             charges=charges,
             elec_temp=elec_temp,
             total_charge=total_charge,
+            polarizability=polarizability,
             total_spin=total_spin,
         )
 

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -38,7 +38,7 @@ class AtomicData(torch_geometric.data.Data):
     virials: torch.Tensor
     dipole: torch.Tensor
     charges: torch.Tensor
-    polarizability:torch.Tensor
+    polarizability: torch.Tensor
     total_charge: torch.Tensor
     total_spin: torch.Tensor
     weight: torch.Tensor
@@ -234,10 +234,13 @@ class AtomicData(torch_geometric.data.Data):
         )
         polarizability_weight = (
             torch.tensor(
-                config.property_weights.get("polarizability"), dtype=torch.get_default_dtype(),
+                config.property_weights.get("polarizability"),
+                dtype=torch.get_default_dtype(),
             )
             if config.property_weights.get("polarizability") is not None
-            else torch.tensor(1.0, dtype=torch.get_default_dtype()) ### Might need to be updated
+            else torch.tensor(
+                1.0, dtype=torch.get_default_dtype()
+            )  ### Might need to be updated
         )
         forces = (
             torch.tensor(
@@ -301,7 +304,7 @@ class AtomicData(torch_geometric.data.Data):
             if config.properties.get("total_charge") is not None
             else torch.tensor(0.0, dtype=torch.get_default_dtype())
         )
-        
+
         polarizability = (
             torch.tensor(
                 config.properties.get("polarizability"), dtype=torch.get_default_dtype()
@@ -309,7 +312,7 @@ class AtomicData(torch_geometric.data.Data):
             if config.properties.get("polarizability") is not None
             else torch.zeros(1, 3, 3, dtype=torch.get_default_dtype())
         )
-                
+
         total_spin = (
             torch.tensor(
                 config.properties.get("total_spin"), dtype=torch.get_default_dtype()

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -57,6 +57,7 @@ def update_keyspec_from_kwargs(
         "head_key",
         "elec_temp_key",
         "total_charge_key",
+        "polarizability_key",
         "total_spin_key",
     ]
     arrays = ["forces_key", "charges_key"]
@@ -353,6 +354,7 @@ def save_AtomicData_to_HDF5(data, i, h5_file) -> None:
     grp["virials"] = data.virials
     grp["dipole"] = data.dipole
     grp["charges"] = data.charges
+    grp["polarizability"] = data.polarizability
     grp["head"] = data.head
 
 

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -6,10 +6,12 @@ from .blocks import (
     AtomicEnergiesBlock,
     EquivariantProductBasisBlock,
     InteractionBlock,
+    LinearDipolePolarReadoutBlock,
     LinearDipoleReadoutBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
     NonLinearBiasReadoutBlock,
+    NonLinearDipolePolarReadoutBlock,
     NonLinearDipoleReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
@@ -22,6 +24,7 @@ from .blocks import (
     ScaleShiftBlock,
 )
 from .loss import (
+    DipolePolarLoss,
     DipoleSingleLoss,
     UniversalLoss,
     WeightedEnergyForcesDipoleLoss,
@@ -32,12 +35,20 @@ from .loss import (
     WeightedForcesLoss,
     WeightedHuberEnergyForcesStressLoss,
 )
-from .models import MACE, AtomicDipolesMACE, EnergyDipolesMACE, ScaleShiftMACE
+from .models import (
+    MACE,
+    AtomicDielectricMACE,
+    AtomicDipolesMACE,
+    EnergyDipolesMACE,
+    ScaleShiftMACE,
+)
 from .radial import BesselBasis, GaussianBasis, PolynomialCutoff, ZBLBasis
 from .symmetric_contraction import SymmetricContraction
 from .utils import (
     compute_avg_num_neighbors,
+    compute_dielectric_gradients,
     compute_fixed_charge_dipole,
+    compute_fixed_charge_dipole_polar,
     compute_mean_rms_energy_forces,
     compute_mean_std_atomic_inter_energy,
     compute_rms_dipoles,
@@ -83,7 +94,9 @@ __all__ = [
     "EquivariantProductBasisBlock",
     "ScaleShiftBlock",
     "LinearDipoleReadoutBlock",
+    "LinearDipolePolarReadoutBlock",
     "NonLinearDipoleReadoutBlock",
+    "NonLinearDipolePolarReadoutBlock",
     "InteractionBlock",
     "NonLinearReadoutBlock",
     "PolynomialCutoff",
@@ -92,6 +105,7 @@ __all__ = [
     "MACE",
     "ScaleShiftMACE",
     "AtomicDipolesMACE",
+    "AtomicDielectricMACE",
     "EnergyDipolesMACE",
     "WeightedEnergyForcesLoss",
     "WeightedForcesLoss",
@@ -108,4 +122,6 @@ __all__ = [
     "compute_avg_num_neighbors",
     "compute_statistics",
     "compute_fixed_charge_dipole",
+    "compute_fixed_charge_dipole_polar",
+    "compute_dielectric_gradients",
 ]

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -219,6 +219,86 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
 
 
 @compile_mode("script")
+class LinearDipolePolarReadoutBlock(torch.nn.Module):
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        use_polarizability: bool = True,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[OEQConfig] = None,  # pylint: disable=unused-argument
+    ):
+        super().__init__()
+        if use_polarizability:
+            print("You will calculate the polarizability and dipole.")
+            self.irreps_out = o3.Irreps("2x0e + 1x1o + 1x2e")
+        else:
+            raise ValueError(
+                "Invalid configuration for LinearDipolePolarReadoutBlock: "
+                "use_polarizability must be either True."
+                "If you want to calculate only the dipole, use AtomicDipolesMACE."
+            )
+
+        self.linear = Linear(
+            irreps_in=irreps_in, irreps_out=self.irreps_out, cueq_config=cueq_config
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
+        y = self.linear(x)  # [n_nodes, 1]
+        return y  # [n_nodes, 1]
+
+
+@compile_mode("script")
+class NonLinearDipolePolarReadoutBlock(torch.nn.Module):
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        MLP_irreps: o3.Irreps,
+        gate: Callable,
+        use_polarizability: bool = True,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+        oeq_config: Optional[OEQConfig] = None,  # pylint: disable=unused-argument
+    ):
+        super().__init__()
+        self.hidden_irreps = MLP_irreps
+        if use_polarizability:
+            print("You will calculate the polarizability and dipole.")
+            self.irreps_out = o3.Irreps("2x0e + 1x1o + 1x2e")
+        else:
+            raise ValueError(
+                "Invalid configuration for NonLinearDipolePolarReadoutBlock: "
+                "use_polarizability must be either True."
+                "If you want to calculate only the dipole, use AtomicDipolesMACE."
+            )
+        irreps_scalars = o3.Irreps(
+            [(mul, ir) for mul, ir in MLP_irreps if ir.l == 0 and ir in self.irreps_out]
+        )
+        irreps_gated = o3.Irreps(
+            [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
+        )
+        irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
+        self.equivariant_nonlin = nn.Gate(
+            irreps_scalars=irreps_scalars,
+            act_scalars=[gate for _, ir in irreps_scalars],
+            irreps_gates=irreps_gates,
+            act_gates=[gate] * len(irreps_gates),
+            irreps_gated=irreps_gated,
+        )
+        self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
+        self.linear_1 = Linear(
+            irreps_in=irreps_in, irreps_out=self.irreps_nonlin, cueq_config=cueq_config
+        )
+        self.linear_2 = Linear(
+            irreps_in=self.hidden_irreps,
+            irreps_out=self.irreps_out,
+            cueq_config=cueq_config,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
+        x = self.equivariant_nonlin(self.linear_1(x))
+        return self.linear_2(x)  # [n_nodes, 1]
+
+
+@compile_mode("script")
 class AtomicEnergiesBlock(torch.nn.Module):
     atomic_energies: torch.Tensor
 

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -156,6 +156,27 @@ def weighted_mean_squared_error_dipole(
 
 
 # ------------------------------------------------------------------------------
+# Polarizability Loss Function
+# ------------------------------------------------------------------------------
+
+
+def weighted_mean_squared_error_polarizability(
+    ref: Batch,
+    pred: TensorDict,
+    ddp: Optional[
+        bool
+    ] = None,  # ,mean: Optional[torch.Tensor] = None , std: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    # polarizability: [n_graphs, ]
+    # ref_polar = ref["polarizability"].view(-1, 3, 3) * std.view(1, 3, 3) + mean.view(1, 3, 3) if mean is not None and std is not None else ref["polarizability"]
+    num_atoms = (ref.ptr[1:] - ref.ptr[:-1]).view(-1, 1, 1)  # [n_graphs,1]
+    raw_loss = torch.square(
+        (ref["polarizability"].view(-1, 3, 3) - pred["polarizability"]) / num_atoms
+    )
+    return reduce_loss(raw_loss, ddp)
+
+
+# ------------------------------------------------------------------------------
 # Conditional Losses for Forces
 # ------------------------------------------------------------------------------
 
@@ -503,6 +524,44 @@ class DipoleSingleLoss(torch.nn.Module):
 
     def __repr__(self):
         return f"{self.__class__.__name__}(dipole_weight={self.dipole_weight:.3f})"
+
+
+class DipolePolarLoss(torch.nn.Module):
+    def __init__(
+        self, dipole_weight=1.0, polarizability_weight=1.0
+    ) -> (
+        None
+    ):  # dipole_mean=None,dipole_std=None,polarizability_mean=None,polarizability_std=None
+        super().__init__()
+        self.register_buffer(
+            "dipole_weight",
+            torch.tensor(dipole_weight, dtype=torch.get_default_dtype()),
+        )
+        self.register_buffer(
+            "polarizability_weight",
+            torch.tensor(polarizability_weight, dtype=torch.get_default_dtype()),
+        )
+
+    def forward(
+        self, ref: Batch, pred: TensorDict, ddp: Optional[bool] = None
+    ) -> torch.Tensor:
+        loss_dipole = weighted_mean_squared_error_dipole(
+            ref, pred, ddp
+        )  # ,self.dipole_mean,self.dipole_std) #* 100.0  # scale adjustment
+
+        loss_polarizability = weighted_mean_squared_error_polarizability(
+            ref, pred, ddp
+        )  # ,self.polarizability_mean,self.polarizability_std) #* 100.0  # scale adjustment
+        return (
+            self.dipole_weight * loss_dipole
+            + self.polarizability_weight * loss_polarizability
+        )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"dipole_weight={self.dipole_weight:.3f}, polarizability_weight={self.polarizability_weight:.3f})"
+        )
 
 
 class WeightedEnergyForcesDipoleLoss(torch.nn.Module):

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -13,22 +13,27 @@ from e3nn.util.jit import compile_mode
 
 from mace.modules.embeddings import GenericJointEmbedding
 from mace.modules.radial import ZBLBasis
-from mace.tools.scatter import scatter_sum
+from mace.tools.scatter import scatter_mean, scatter_sum
+from mace.tools.torch_tools import get_change_of_basis, spherical_to_cartesian
 
 from .blocks import (
     AtomicEnergiesBlock,
     EquivariantProductBasisBlock,
     InteractionBlock,
+    LinearDipolePolarReadoutBlock,
     LinearDipoleReadoutBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
+    NonLinearDipolePolarReadoutBlock,
     NonLinearDipoleReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
     ScaleShiftBlock,
 )
 from .utils import (
+    compute_dielectric_gradients,
     compute_fixed_charge_dipole,
+    compute_fixed_charge_dipole_polar,
     get_atomic_virials_stresses,
     get_edge_vectors_and_lengths,
     get_outputs,
@@ -813,6 +818,334 @@ class AtomicDipolesMACE(torch.nn.Module):
         output = {
             "dipole": total_dipole,
             "atomic_dipoles": atomic_dipoles,
+        }
+        return output
+
+
+@compile_mode("script")
+class AtomicDielectricMACE(torch.nn.Module):
+    def __init__(
+        self,
+        r_max: float,
+        num_bessel: int,
+        num_polynomial_cutoff: int,
+        max_ell: int,
+        interaction_cls: Type[InteractionBlock],
+        interaction_cls_first: Type[InteractionBlock],
+        num_interactions: int,
+        num_elements: int,
+        hidden_irreps: o3.Irreps,
+        MLP_irreps: o3.Irreps,
+        avg_num_neighbors: float,
+        atomic_numbers: List[int],
+        correlation: int,
+        gate: Optional[Callable],
+        atomic_energies: Optional[
+            None
+        ],  # Just here to make it compatible with energy models, MUST be None
+        apply_cutoff: bool = True,  # pylint: disable=unused-argument
+        use_reduced_cg: bool = True,  # pylint: disable=unused-argument
+        use_so3: bool = False,  # pylint: disable=unused-argument
+        distance_transform: str = "None",  # pylint: disable=unused-argument
+        radial_type: Optional[str] = "bessel",
+        radial_MLP: Optional[List[int]] = None,
+        cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
+        edge_irreps: Optional[o3.Irreps] = None,  # pylint: disable=unused-argument
+        dipole_only: Optional[bool] = True,  # pylint: disable=unused-argument
+        use_polarizability: Optional[bool] = True,  # pylint: disable=unused-argument
+        means_stds: Optional[Dict[str, torch.Tensor]] = None,  # pylint: disable=W0613
+    ):
+        super().__init__()
+        self.register_buffer(
+            "atomic_numbers", torch.tensor(atomic_numbers, dtype=torch.int64)
+        )
+        self.register_buffer("r_max", torch.tensor(r_max, dtype=torch.float64))
+        self.register_buffer(
+            "num_interactions", torch.tensor(num_interactions, dtype=torch.int64)
+        )
+
+        # Predefine buffers to be TorchScript-safe
+        self.register_buffer("dipole_mean", torch.zeros(3))
+        self.register_buffer("dipole_std", torch.ones(3))
+        self.register_buffer(
+            "polarizability_mean", torch.zeros(3, 3)
+        )  # 3x3 matrix flattened
+        self.use_polarizability = use_polarizability
+        self.register_buffer("polarizability_std", torch.ones(3, 3))
+        self.register_buffer("change_of_basis", get_change_of_basis())
+        # self.register_buffer("mean_polarizability_sh", torch.zeros(6))
+        # self.register_buffer("std_polarizability_sh", torch.ones(6))
+        if means_stds is not None:
+            if "dipole_mean" in means_stds:
+                self.dipole_mean.data.copy_(means_stds["dipole_mean"])
+            if "dipole_std" in means_stds:
+                self.dipole_std.data.copy_(means_stds["dipole_std"])
+            if "polarizability_mean" in means_stds:
+                self.polarizability_mean.data.copy_(means_stds["polarizability_mean"])
+            if "polarizability_std" in means_stds:
+                self.polarizability_std.data.copy_(means_stds["polarizability_std"])
+            # if "mean_polarizability_sh" in means_stds:
+            #    self.mean_polarizability_sh.data.copy_(means_stds["mean_polarizability_sh"])
+            # if "std_polarizability_sh" in means_stds:
+            #    self.std_polarizability_sh.data.copy_(means_stds["std_polarizability_sh"])'''
+        assert atomic_energies is None
+        # self.use_polarizability = use_polarizability
+        # self.use_dipole = use_dipole
+
+        # Embedding
+        node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
+        node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
+        self.node_embedding = LinearNodeEmbeddingBlock(
+            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+        )
+        self.radial_embedding = RadialEmbeddingBlock(
+            r_max=r_max,
+            num_bessel=num_bessel,
+            num_polynomial_cutoff=num_polynomial_cutoff,
+            radial_type=radial_type,
+        )
+        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
+
+        sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
+        num_features = hidden_irreps.count(o3.Irrep(0, 1))
+        interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
+        self.spherical_harmonics = o3.SphericalHarmonics(
+            sh_irreps, normalize=True, normalization="component"
+        )
+        if radial_MLP is None:
+            radial_MLP = [64, 64, 64]
+
+        # Interactions and readouts
+        inter = interaction_cls_first(
+            node_attrs_irreps=node_attr_irreps,
+            node_feats_irreps=node_feats_irreps,
+            edge_attrs_irreps=sh_irreps,
+            edge_feats_irreps=edge_feats_irreps,
+            target_irreps=interaction_irreps,
+            hidden_irreps=hidden_irreps,
+            avg_num_neighbors=avg_num_neighbors,
+            radial_MLP=radial_MLP,
+        )
+        self.interactions = torch.nn.ModuleList([inter])
+
+        # Use the appropriate self connection at the first layer
+        use_sc_first = False
+        if "Residual" in str(interaction_cls_first):
+            use_sc_first = True
+
+        node_feats_irreps_out = inter.target_irreps
+        prod = EquivariantProductBasisBlock(
+            node_feats_irreps=node_feats_irreps_out,
+            target_irreps=hidden_irreps,
+            correlation=correlation,
+            num_elements=num_elements,
+            use_sc=use_sc_first,
+        )
+        self.products = torch.nn.ModuleList([prod])
+
+        self.readouts = torch.nn.ModuleList()
+        self.readouts.append(
+            LinearDipolePolarReadoutBlock(hidden_irreps, use_polarizability=True)
+        )
+
+        for i in range(num_interactions - 1):
+            if i == num_interactions - 2:
+                # does it always do polar and dipole together?
+                assert (
+                    len(hidden_irreps) > 1
+                ), "To predict dipoles use at least l=1 hidden_irreps"
+                # hidden_irreps_out = str(
+                #     hidden_irreps[1]
+                # )  # Select only l=1 vectors for last layer
+                hidden_irreps_out = (
+                    hidden_irreps  # this is different in the AtomicDipoleMACE
+                )
+            else:
+                hidden_irreps_out = hidden_irreps
+            inter = interaction_cls(
+                node_attrs_irreps=node_attr_irreps,
+                node_feats_irreps=hidden_irreps,
+                edge_attrs_irreps=sh_irreps,
+                edge_feats_irreps=edge_feats_irreps,
+                target_irreps=interaction_irreps,
+                hidden_irreps=hidden_irreps_out,
+                avg_num_neighbors=avg_num_neighbors,
+                radial_MLP=radial_MLP,
+            )
+            self.interactions.append(inter)
+            prod = EquivariantProductBasisBlock(
+                node_feats_irreps=interaction_irreps,
+                target_irreps=hidden_irreps_out,
+                correlation=correlation,
+                num_elements=num_elements,
+                use_sc=True,
+            )
+            self.products.append(prod)
+            if i == num_interactions - 2:
+                self.readouts.append(
+                    NonLinearDipolePolarReadoutBlock(
+                        hidden_irreps_out,
+                        MLP_irreps,
+                        gate,
+                        use_polarizability=True,
+                    )
+                )
+                # print("Nonlinear irrpes: ", hidden_irreps_out, MLP_irreps)
+                # exit()
+            else:
+                self.readouts.append(
+                    LinearDipolePolarReadoutBlock(
+                        hidden_irreps,
+                        # use_charge=True,
+                        use_polarizability=True,
+                    )
+                )
+
+    def forward(
+        self,
+        data: Dict[str, torch.Tensor],
+        training: bool = False,  # pylint: disable=W0613
+        compute_force: bool = False,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_dielectric_derivatives: bool = False,  # no training on derivatives
+        compute_edge_forces: bool = False,  # pylint: disable=W0613
+        compute_atomic_stresses: bool = False,  # pylint: disable=W0613
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        assert compute_force is False
+        assert compute_virials is False
+        assert compute_stress is False
+        assert compute_displacement is False
+        # Setup
+        data["node_attrs"].requires_grad_(True)
+        data["positions"].requires_grad_(True)
+        num_graphs = data["ptr"].numel() - 1
+        num_atoms = data["ptr"][1:] - data["ptr"][:-1]
+
+        # Embeddings
+        node_feats = self.node_embedding(data["node_attrs"])
+        vectors, lengths = get_edge_vectors_and_lengths(
+            positions=data["positions"],
+            edge_index=data["edge_index"],
+            shifts=data["shifts"],
+        )
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats, cutoff = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+
+        # Interactions
+        charges = []
+        dipoles = []
+        polarizabilities = []
+        for interaction, product, readout in zip(
+            self.interactions, self.products, self.readouts
+        ):
+            node_feats, sc = interaction(
+                node_attrs=data["node_attrs"],
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                cutoff=cutoff,
+            )
+
+            node_feats = product(
+                node_feats=node_feats,
+                sc=sc,
+                node_attrs=data["node_attrs"],
+            )
+
+            node_out = readout(node_feats).squeeze(-1)  # [n_nodes,3]
+            charges.append(node_out[:, 0])
+
+            if self.use_polarizability:
+                node_dipoles = node_out[:, 2:5]
+                node_polarizability = torch.cat(
+                    (node_out[:, 1].unsqueeze(-1), node_out[:, 5:]), dim=-1
+                )
+                polarizabilities.append(node_polarizability)
+                dipoles.append(node_dipoles)
+            else:
+                raise ValueError(
+                    "Polarizability is not used in this model, but it is required for the AtomicDielectricMACE."
+                )
+        contributions_dipoles = torch.stack(
+            dipoles, dim=-1
+        )  # [n_nodes,3,n_contributions]
+        atomic_dipoles = torch.sum(contributions_dipoles, dim=-1)  # [n_nodes,3]
+        atomic_charges = torch.stack(charges, dim=-1).sum(-1)  # [n_nodes,]
+        # The idea is to normalize the charges so that they sum to the net charge in the system before predicting the dipole.
+        total_charge_excess = scatter_mean(
+            src=atomic_charges, index=data["batch"], dim_size=num_graphs
+        ) - (data["total_charge"] / num_atoms)
+        atomic_charges = atomic_charges - total_charge_excess[data["batch"]]
+        total_dipole = scatter_sum(
+            src=atomic_dipoles,
+            index=data["batch"],
+            dim=0,
+            dim_size=num_graphs,
+        )  # [n_graphs,3]
+        baseline = compute_fixed_charge_dipole_polar(
+            charges=atomic_charges,  # or data["charges"], ?????
+            positions=data["positions"],
+            batch=data["batch"],
+            num_graphs=num_graphs,
+        )  # [n_graphs,3]
+        total_dipole = total_dipole + baseline
+
+        if self.use_polarizability:
+            # Compute the polarizabilities
+            contributions_polarizabilities = torch.stack(
+                polarizabilities, dim=-1
+            )  # [n_nodes,6,n_contributions]
+            atomic_polarizabilities = torch.sum(
+                contributions_polarizabilities, dim=-1
+            )  # [n_nodes,6]
+            total_polarizability_spherical = scatter_sum(
+                src=atomic_polarizabilities,
+                index=data["batch"],
+                dim=0,
+                dim_size=num_graphs,
+            )  # [n_graphs,6]
+            total_polarizability = spherical_to_cartesian(
+                total_polarizability_spherical, self.change_of_basis
+            )
+
+            if compute_dielectric_derivatives:
+                dmu_dr = compute_dielectric_gradients(
+                    dielectric=total_dipole,
+                    positions=data["positions"],
+                )
+                dalpha_dr = compute_dielectric_gradients(
+                    dielectric=total_polarizability.flatten(-2),
+                    positions=data["positions"],
+                )
+            else:
+                dmu_dr = None
+                dalpha_dr = None
+        else:
+            if compute_dielectric_derivatives:
+                dmu_dr = compute_dielectric_gradients(
+                    dielectric=total_dipole,
+                    positions=data["positions"],
+                )
+            else:
+                dmu_dr = None
+            total_polarizability = None
+            total_polarizability_spherical = None
+            dalpha_dr = None
+
+        output = {
+            "charges": atomic_charges,
+            "dipole": total_dipole,
+            "atomic_dipoles": atomic_dipoles,
+            "polarizability": total_polarizability,
+            "polarizability_sh": total_polarizability_spherical,
+            "dmu_dr": dmu_dr,
+            "dalpha_dr": dalpha_dr,
         }
         return output
 

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -490,6 +490,64 @@ def compute_fixed_charge_dipole(
     )  # [N_graphs,3]
 
 
+def compute_fixed_charge_dipole_polar(
+    charges: torch.Tensor,
+    positions: torch.Tensor,
+    batch: torch.Tensor,
+    num_graphs: int,
+) -> torch.Tensor:
+    mu = positions * charges.unsqueeze(
+        -1
+    )  # / (1e-11 / c / e)  # [N_atoms,3] = 0.20819...
+    return scatter_sum(src=mu, index=batch.unsqueeze(-1), dim=0, dim_size=num_graphs)
+
+
+@torch.jit.ignore
+def compute_dielectric_gradients(
+    dielectric: torch.Tensor,
+    positions: torch.Tensor,
+) -> Tuple[torch.tensor, torch.tensor]:
+    dielectric_flatten = dielectric.view(-1)
+
+    def get_vjp(v):
+        return torch.autograd.grad(
+            dielectric_flatten,
+            positions,
+            v,
+            retain_graph=True,
+            create_graph=True,
+            allow_unused=False,
+        )
+
+    try:
+        I_N = torch.eye(dielectric.shape[-1]).to(dielectric.device)
+        gradient = torch.vmap(get_vjp, in_dims=0, out_dims=0)(I_N)[0]
+    except RuntimeError:
+        gradient = compute_dielectric_gradients_loop(dielectric, positions).detach()
+    if gradient is None:
+        return torch.zeros((positions.shape[0], dielectric.shape[-1], 3))
+    return gradient
+
+
+def compute_dielectric_gradients_loop(
+    dielectric: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    gradients = []
+    for i in range(dielectric.shape[-1]):
+        grad_elem = dielectric[:, i]
+        hess_row = torch.autograd.grad(
+            grad_elem,
+            positions,
+            retain_graph=True,
+            create_graph=True,
+            allow_unused=False,
+        )[0]
+        gradients.append(hess_row)
+    gradients = torch.stack(gradients)
+    return gradients
+
+
 class InteractionKwargs(NamedTuple):
     lammps_class: Optional[torch.Tensor]
     lammps_natoms: Tuple[int, int] = (0, 0)

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -116,6 +116,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "TotalMAE",
             "DipoleRMSE",
             "DipoleMAE",
+            "DipolePolarRMSE",
             "EnergyDipoleRMSE",
         ],
         default="PerAtomRMSE",
@@ -132,6 +133,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "ScaleShiftMACE",
             "ScaleShiftBOTNet",
             "AtomicDipolesMACE",
+            "AtomicDielectricMACE",
             "EnergyDipolesMACE",
         ],
     )
@@ -303,6 +305,18 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         help="Select True to compute forces",
         type=str2bool,
         default=True,
+    )
+    parser.add_argument(
+        "--compute_polarizability",
+        help="Select True to compute polarizability",
+        action="store_true",
+        default=str2bool,
+    )
+    parser.add_argument(
+        "--compute_atomic_dipole",
+        help="Select True to compute dipoles",
+        action="store_true",
+        default=str2bool,
     )
 
     # Dataset
@@ -508,6 +522,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=DefaultKeys.DIPOLE.value,
     )
     parser.add_argument(
+        "--polarizability_key",
+        help="Key of polarizability in training xyz",
+        type=str,
+        default=DefaultKeys.POLARIZABILITY.value,
+    )
+    parser.add_argument(
         "--head_key",
         help="Key of head in training xyz",
         type=str,
@@ -579,6 +599,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "virials",
             "stress",
             "dipole",
+            "dipole_polar",
             "huber",
             "universal",
             "energy_forces_dipole",
@@ -639,6 +660,20 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=float,
         default=1.0,
         dest="swa_dipole_weight",
+    )
+    parser.add_argument(
+        "--swa_polarizability_weight",
+        "--stage_two_polarizability_weight",
+        help="weight of polarizability after starting Stage Two (previously called swa)",
+        type=float,
+        default=1.0,
+        dest="swa_polarizability_weight",
+    )
+    parser.add_argument(
+        "--polarizability_weight",
+        help="weight of polarizability loss",
+        type=float,
+        default=1.0,
     )
     parser.add_argument(
         "--config_type_weights",
@@ -966,6 +1001,12 @@ def build_preprocess_arg_parser() -> argparse.ArgumentParser:
         help="Key of reference dipoles in training xyz",
         type=str,
         default=DefaultKeys.DIPOLE.value,
+    )
+    parser.add_argument(
+        "--polarizability_key",
+        help="Key of polarizability in training xyz",
+        type=str,
+        default=DefaultKeys.POLARIZABILITY.value,
     )
     parser.add_argument(
         "--charges_key",

--- a/mace/tools/default_keys.py
+++ b/mace/tools/default_keys.py
@@ -9,6 +9,7 @@ class DefaultKeys(Enum):
     STRESS = "REF_stress"
     VIRIALS = "REF_virials"
     DIPOLE = "dipole"
+    POLARIZABILITY = "polarizability"
     HEAD = "head"
     CHARGES = "REF_charges"
     TOTAL_CHARGE = "total_charge"

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -309,6 +309,10 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
         "atomic_inter_shift": shift.cpu().numpy(),
         "heads": heads,
     }
+    if model.__class__.__name__ == "AtomicDielectricMACE":
+        config["use_polarizability"] = model.use_polarizability
+        config["only_dipole"] = False  # model.only_dipole
+        config["gate"] = torch.nn.functional.silu
     return config
 
 
@@ -619,6 +623,11 @@ def get_loss_fn(
         loss_fn = modules.DipoleSingleLoss(
             dipole_weight=args.dipole_weight,
         )
+    elif args.loss == "dipole_polar":
+        loss_fn = modules.DipolePolarLoss(
+            dipole_weight=args.dipole_weight,
+            polarizability_weight=args.polarizability_weight,
+        )
     elif args.loss == "energy_forces_dipole":
         assert dipole_only is False and compute_dipole is True
         loss_fn = modules.WeightedEnergyForcesDipoleLoss(
@@ -667,6 +676,14 @@ def get_swa(
         )
         logging.info(
             f"Stage Two (after {args.start_swa} epochs) with loss function: {loss_fn_energy}, energy weight : {args.swa_energy_weight}, forces weight : {args.swa_forces_weight}, stress weight : {args.swa_stress_weight} and learning rate : {args.swa_lr}"
+        )
+    elif args.loss == "dipole_polar":
+        loss_fn_energy = modules.DipolePolarLoss(
+            dipole_weight=args.swa_dipole_weight,
+            polarizability_weight=args.swa_polarizability_weight,
+        )
+        logging.info(
+            f"Stage Two (after {args.start_swa} epochs) with loss function: {loss_fn_energy}, dipole weight : {args.swa_dipole_weight}, polarizability weight : {args.swa_polarizability_weight}, and learning rate : {args.swa_lr}"
         )
     elif args.loss == "energy_forces_dipole":
         loss_fn_energy = modules.WeightedEnergyForcesDipoleLoss(

--- a/mace/tools/tables_utils.py
+++ b/mace/tools/tables_utils.py
@@ -91,6 +91,13 @@ def create_error_table(
             "MAE MU / mDebye / atom",
             "relative MU MAE %",
         ]
+    elif table_type == "DipolePolarRMSE":
+        table.field_names = [
+            "config_type",
+            "RMSE MU / me A / atom",
+            "relative MU RMSE %",
+            "RMSE ALPHA e A^2 / V / atom",
+        ]
     elif table_type == "EnergyDipoleRMSE":
         table.field_names = [
             "config_type",
@@ -230,6 +237,15 @@ def create_error_table(
                     name,
                     f"{metrics['mae_mu_per_atom'] * 1000:8.2f}",
                     f"{metrics['rel_mae_mu']:8.1f}",
+                ]
+            )
+        elif table_type == "DipolePolarRMSE":
+            table.add_row(
+                [
+                    name,
+                    f"{metrics['rmse_mu_per_atom'] * 1000:.2f}",
+                    f"{metrics['rel_rmse_mu']:.1f}",
+                    f"{metrics['rmse_polarizability_per_atom'] * 1000:.2f}",
                 ]
             )
         elif table_type == "EnergyDipoleRMSE":

--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -79,13 +79,15 @@ def set_default_dtype(dtype: str) -> None:
     torch.set_default_dtype(dtype_dict[dtype])
 
 
-def spherical_to_cartesian(t: torch.Tensor):
-    """
-    Convert spherical notation to cartesian notation
-    """
-    stress_cart_tensor = CartesianTensor("ij=ji")
-    stress_rtp = stress_cart_tensor.reduced_tensor_products()
-    return stress_cart_tensor.to_cartesian(t, rtp=stress_rtp)
+def get_change_of_basis() -> torch.Tensor:
+    return CartesianTensor("ij=ji").reduced_tensor_products().change_of_basis
+
+
+def spherical_to_cartesian(t: torch.Tensor, change_of_basis: torch.Tensor):
+    # Optionally handle device mismatch
+    if change_of_basis.device != t.device:
+        change_of_basis = change_of_basis.to(t.device)
+    return torch.einsum("ijk,...i->...jk", change_of_basis, t)
 
 
 def cartesian_to_spherical(t: torch.Tensor):

--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -129,6 +129,12 @@ def valid_err_log(
         logging.info(
             f"{inintial_phrase}: head: {valid_loader_name}, loss={valid_loss:8.8f}, RMSE_MU_per_atom={error_mu:8.2f} mDebye",
         )
+    elif log_errors == "DipolePolarRMSE":
+        error_mu = eval_metrics["rmse_mu_per_atom"] * 1e3
+        error_polarizability = eval_metrics["rmse_polarizability_per_atom"] * 1e3
+        logging.info(
+            f"{inintial_phrase}: head: {valid_loader_name}, loss={valid_loss:.4f}, RMSE_MU_per_atom={error_mu:.2f} me A, RMSE_polarizability_per_atom={error_polarizability:.2f} me A^2 / V",
+        )
     elif log_errors == "EnergyDipoleRMSE":
         error_e = eval_metrics["rmse_e_per_atom"] * 1e3
         error_f = eval_metrics["rmse_f"] * 1e3
@@ -583,6 +589,13 @@ class MACELoss(Metric):
         self.add_state("mus", default=[], dist_reduce_fx="cat")
         self.add_state("delta_mus", default=[], dist_reduce_fx="cat")
         self.add_state("delta_mus_per_atom", default=[], dist_reduce_fx="cat")
+        self.add_state(
+            "polarizability_computed", default=torch.tensor(0.0), dist_reduce_fx="sum"
+        )
+        self.add_state("delta_polarizability", default=[], dist_reduce_fx="cat")
+        self.add_state(
+            "delta_polarizability_per_atom", default=[], dist_reduce_fx="cat"
+        )
 
     def update(self, batch, output):  # pylint: disable=arguments-differ
         loss = self.loss_fn(pred=output, ref=batch)
@@ -616,6 +629,18 @@ class MACELoss(Metric):
             self.delta_mus_per_atom.append(
                 (batch.dipole - output["dipole"])
                 / (batch.ptr[1:] - batch.ptr[:-1]).unsqueeze(-1)
+            )
+        if (
+            output.get("polarizability") is not None
+            and batch.polarizability is not None
+        ):
+            self.polarizability_computed += 1.0
+            self.delta_polarizability.append(
+                batch.polarizability - output["polarizability"]
+            )
+            self.delta_polarizability_per_atom.append(
+                (batch.polarizability - output["polarizability"])
+                / (batch.ptr[1:] - batch.ptr[:-1]).unsqueeze(-1).unsqueeze(-1)
             )
 
     def convert(self, delta: Union[torch.Tensor, List[torch.Tensor]]) -> np.ndarray:
@@ -665,5 +690,19 @@ class MACELoss(Metric):
             aux["rmse_mu_per_atom"] = compute_rmse(delta_mus_per_atom)
             aux["rel_rmse_mu"] = compute_rel_rmse(delta_mus, mus)
             aux["q95_mu"] = compute_q95(delta_mus)
+        if self.polarizability_computed:
+            delta_polarizability = self.convert(self.delta_polarizability)
+            delta_polarizability_per_atom = self.convert(
+                self.delta_polarizability_per_atom
+            )
+            aux["mae_polarizability"] = compute_mae(delta_polarizability)
+            aux["mae_polarizability_per_atom"] = compute_mae(
+                delta_polarizability_per_atom
+            )
+            aux["rmse_polarizability"] = compute_rmse(delta_polarizability)
+            aux["rmse_polarizability_per_atom"] = compute_rmse(
+                delta_polarizability_per_atom
+            )
+            aux["q95_polarizability"] = compute_q95(delta_polarizability)
 
         return aux["loss"], aux

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -315,7 +315,64 @@ def trained_dipole_fixture(tmp_path_factory, fitting_configs):
     return MACECalculator(
         model_paths=tmp_path / "MACE.model", device="cpu", model_type="DipoleMACE"
     )
-
+@pytest.fixture(scope="module", name="trained_dipole_polarizability_model")
+def trained_dipole_polar_fixture(tmp_path_factory, fitting_configs):
+    _mace_params = {
+        "name": "MACE",
+        "valid_fraction": 0.05,
+        "energy_weight": 1.0,
+        "forces_weight": 10.0,
+        "stress_weight": 1.0,
+        "model": "AtomicDielectricMACE",
+        "num_channels": 8,
+        "max_L": 2,
+        "r_max": 3.5,
+        "batch_size": 5,
+        "max_num_epochs": 10,
+        "MLP_irreps": "16x0e+16x1o+16x2e",
+        "ema": None,
+        "ema_decay": 0.99,
+        "amsgrad": None,
+        "restart_latest": None,
+        "device": "cpu",
+        "seed": 5,
+        "loss": "dipole_polar",
+        "energy_key": "",
+        "forces_key": "",
+        "stress_key": "",
+        "dipole_key": "REF_dipole",
+        "polarizability_key": "REF_polarizability",
+        "error_table": "DipolePolarRMSE",
+        "eval_interval": 2,
+    }
+    tmp_path = tmp_path_factory.mktemp("run_")
+    ase.io.write(tmp_path / "fit.xyz", fitting_configs)
+    mace_params = _mace_params.copy()
+    mace_params["checkpoints_dir"] = str(tmp_path)
+    mace_params["model_dir"] = str(tmp_path)
+    mace_params["train_file"] = tmp_path / "fit.xyz"
+    # make sure run_train.py is using the mace that is currently being tested
+    run_env = os.environ.copy()
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    run_env["PYTHONPATH"] = ":".join(sys.path)
+    print("DEBUG subprocess PYTHONPATH", run_env["PYTHONPATH"])
+    cmd = (
+        sys.executable
+        + " "
+        + str(run_train)
+        + " "
+        + " ".join(
+            [
+                (f"--{k}={v}" if v is not None else f"--{k}")
+                for k, v in mace_params.items()
+            ]
+        )
+    )
+    p = subprocess.run(cmd.split(), env=run_env, check=True)
+    assert p.returncode == 0
+    return MACECalculator(
+        tmp_path / "MACE.model", device="cpu", model_type="DipolePolarizabilityMACE"
+    )
 
 @pytest.fixture(scope="module", name="trained_energy_dipole_model")
 def trained_energy_dipole_fixture(tmp_path_factory, fitting_configs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -163,6 +163,63 @@ def test_dipole_mace():
     )
 
 
+def test_dipole_polar_mace():
+    # create dipole MACE model
+    model_config = dict(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o + 16x2e"),
+        MLP_irreps=o3.Irreps("16x0e + 16x1o + 16x2e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=None,
+        avg_num_neighbors=3,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="gaussian",
+    )
+    model = modules.AtomicDielectricMACE(**model_config)
+
+    atomic_data = data.AtomicData.from_config(config, z_table=table, cutoff=3.0)
+    atomic_data2 = data.AtomicData.from_config(
+        config_rotated, z_table=table, cutoff=3.0
+    )
+    data_loader = torch_geometric.dataloader.DataLoader(
+        dataset=[atomic_data, atomic_data2],
+        batch_size=2,
+        shuffle=False,
+        drop_last=False,
+    )
+    batch = next(iter(data_loader))
+    output = model(
+        batch,
+        training=True,
+    )
+    # sanity check of dipoles being the right shape
+    assert output["dipole"][0].unsqueeze(0).shape == atomic_data.dipole.shape
+    # test equivariance of output dipoles
+    assert np.allclose(
+        np.array(rot @ output["dipole"][0].detach().numpy()),
+        output["dipole"][1].detach().numpy(),
+    )
+    # sanity check of polarizability being the right shape
+    assert output["polarizability"][0].unsqueeze(0).shape == atomic_data.polarizability.shape
+    # test equivariance of output polarizability
+    assert np.allclose(
+        np.array(rot @ output["polarizability"][0].detach().numpy()@ rot.T),
+        output["polarizability"][1].detach().numpy(),
+    )
+
+
 def test_energy_dipole_mace():
     # create dipole MACE model
     model_config = dict(


### PR DESCRIPTION
I updated the old `MACE/mu_alpha` branch to the current main branch. It passes all tests of the current main branch.
In addition to the `AtomicDipolesMACE` and `DipoleMACE` models, it now also includes the `AtomicDielectricMACE` and `DipolePolarizabilityMACE` models. This allows users to train and calculate polarizabilities and dipoles. I am aware that there is some redundancy in having both sets of models in the code, but for backward compatibility, it might be useful to keep the old models available. Also one can then still have a L=1 model for the dipoles and doesn't need to train a L=2 model.

I tested the model with different SPICE subsets, and the training and prediction works fine.
I can also add a brief script on how to obtain the polarizabilities using ASE via `.get_properties["polarizability"]`, as well as some documentation on how to properly train these models.

It is still missing some new features, like the output plots, which one might want to add in later stages.