### PR TITLE
Reimplementation of MACELES

### DIFF
--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -54,7 +54,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--compute_bec",
-        help="compute BEC",,
+        help="compute BEC",
         action="store_true",
         default=False,
     )
@@ -121,10 +121,8 @@ def run(args: argparse.Namespace) -> None:
 
     # Load model
     model = torch.load(f=args.model, map_location=args.device)
-    if model.__class__.__name__ != 'MACELES' and args.compute_bec:
-        raise ValueError(
-            "BEC can only be computed with MACELES model. "
-        )
+    if model.__class__.__name__ != "MACELES" and args.compute_bec:
+        raise ValueError("BEC can only be computed with MACELES model. ")
     if args.enable_cueq:
         print("Converting models to CuEq for acceleration")
         model = run_e3nn_to_cueq(model, device=device)
@@ -173,7 +171,11 @@ def run(args: argparse.Namespace) -> None:
 
     for batch in data_loader:
         batch = batch.to(device)
-        output = model(batch.to_dict(), compute_stress=args.compute_stress, compute_bec=args.compute_bec)
+        output = model(
+            batch.to_dict(),
+            compute_stress=args.compute_stress,
+            compute_bec=args.compute_bec,
+        )
         energies_list.append(torch_tools.to_numpy(output["energy"]))
         if args.compute_stress:
             stresses_list.append(torch_tools.to_numpy(output["stress"]))
@@ -257,12 +259,8 @@ def run(args: argparse.Namespace) -> None:
         assert len(atoms_list) == stresses.shape[0]
 
     if args.compute_bec:
-        bec_list = [
-            becs for sublist in bec_list for becs in sublist
-        ]
-        qs_list = [
-            qs for sublist in qs_list for qs in sublist
-        ]
+        bec_list = [becs for sublist in bec_list for becs in sublist]
+        qs_list = [qs for sublist in qs_list for qs in sublist]
 
     if args.return_contributions:
         contributions = np.concatenate(contributions_list, axis=0)

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1,0 +1,285 @@
+from mace.modules.models import ScaleShiftMACE
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+import numpy as np
+import torch
+from e3nn import o3
+from e3nn.util.jit import compile_mode
+
+from mace.modules.embeddings import GenericJointEmbedding
+from mace.modules.radial import ZBLBasis
+from mace.tools.scatter import scatter_sum
+
+from mace.modules.blocks import (
+    AtomicEnergiesBlock,
+    EquivariantProductBasisBlock,
+    InteractionBlock,
+    LinearDipoleReadoutBlock,
+    LinearNodeEmbeddingBlock,
+    LinearReadoutBlock,
+    NonLinearDipoleReadoutBlock,
+    NonLinearReadoutBlock,
+    RadialEmbeddingBlock,
+    ScaleShiftBlock,
+)
+from mace.modules.utils import (
+    compute_fixed_charge_dipole,
+    get_atomic_virials_stresses,
+    get_edge_vectors_and_lengths,
+    get_outputs,
+    get_symmetric_displacement,
+    prepare_graph,
+)
+from mace.modules.wrapper_ops import CuEquivarianceConfig
+
+
+def _copy_mace_readout(
+    mace_readout: torch.nn.Module, cueq_config: Optional[CuEquivarianceConfig] = None
+) -> torch.nn.Module:
+    """
+    Helper function to copy a MACE readout block.
+    """
+    if isinstance(mace_readout, LinearReadoutBlock):
+        return LinearReadoutBlock(
+            irreps_in=mace_readout.linear.irreps_in, # type:ignore
+            irrep_out=mace_readout.linear.irreps_out, # type:ignore
+            cueq_config=cueq_config,
+        )
+    elif isinstance(mace_readout, NonLinearReadoutBlock):  # type:ignore
+        return NonLinearReadoutBlock(
+            irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+            MLP_irreps=mace_readout.hidden_irreps,
+            gate=mace_readout.non_linearity._modules["acts"][0].f,  # type:ignore
+            irrep_out=mace_readout.linear_2.irreps_out,  # type:ignore
+            num_heads=mace_readout.num_heads,
+            cueq_config=cueq_config,
+        )
+    else:
+        raise TypeError("Unsupported readout type.")
+
+
+def _get_readout_input_dim(block: torch.nn.Module) -> int:
+    if isinstance(block, LinearReadoutBlock):
+        return block.linear.irreps_in.dim  # type:ignore
+    elif isinstance(block, NonLinearReadoutBlock):  # type:ignore
+        return block.linear_1.irreps_in.dim  # type:ignore
+    else:
+        raise TypeError("Unsupported readout type for input dimension retrieval.")
+
+@compile_mode("script")
+class MACELES(ScaleShiftMACE):
+    def __init__(self, les_arguments: Optional[Dict] = None, **kwargs):
+        super().__init__(**kwargs)
+        try:
+            from les import Les
+        except:
+            raise ImportError(
+                "Cannot import 'les'. Please install the 'les' library from https://github.com/ChengUCB/les."
+            )
+        if les_arguments is None:
+            les_arguments = {"use_atomwise": False}
+        self.compute_bec = les_arguments.get("compute_bec", False)
+        self.bec_output_index = les_arguments.get("bec_output_index", None)
+        self.les = Les(les_arguments=les_arguments)
+        self.les_readouts = torch.nn.ModuleList()
+        self.readout_input_dims = [
+            _get_readout_input_dim(readout) for readout in self.readouts  # type:ignore
+        ]
+        cueq_config = kwargs.get("cueq_config", None)
+        for readout in self.readouts:  # type:ignore
+            self.les_readouts.append(
+                _copy_mace_readout(readout, cueq_config=cueq_config)
+            )
+
+    def forward(
+        self, data: Dict[str, torch.Tensor],
+        training: bool = False,
+        compute_force: bool = True,
+        compute_virials: bool = False,
+        compute_stress: bool = False,
+        compute_displacement: bool = False,
+        compute_hessian: bool = False,
+        compute_edge_forces: bool = False,
+        compute_atomic_stresses: bool = False,
+        compute_bec: bool = False,
+        lammps_mliap: bool = False,
+        **kwargs,
+    ) -> Dict[str, Optional[torch.Tensor]]:
+        # Setup
+        ctx = prepare_graph(
+            data,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_displacement=compute_displacement,
+            lammps_mliap=lammps_mliap,
+        )
+        is_lammps = ctx.is_lammps
+        num_atoms_arange = ctx.num_atoms_arange
+        num_graphs = ctx.num_graphs
+        displacement = ctx.displacement
+        positions = ctx.positions
+        vectors = ctx.vectors
+        lengths = ctx.lengths
+        cell = ctx.cell
+        node_heads = ctx.node_heads
+        interaction_kwargs = ctx.interaction_kwargs
+        lammps_natoms = interaction_kwargs.lammps_natoms
+        lammps_class = interaction_kwargs.lammps_class
+
+        # Atomic energies
+        node_e0 = self.atomic_energies_fn(data["node_attrs"])[
+            num_atoms_arange, node_heads
+        ]
+        e0 = scatter_sum(
+            src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
+        ).to(
+            vectors.dtype
+        )  # [n_graphs, n_heads]
+        # Embeddings
+        node_feats = self.node_embedding(data["node_attrs"])
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats, cutoff = self.radial_embedding(
+            lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+        )
+        if hasattr(self, "pair_repulsion"):
+            pair_node_energy = self.pair_repulsion_fn(
+                lengths, data["node_attrs"], data["edge_index"], self.atomic_numbers
+            )
+            if is_lammps:
+                pair_node_energy = pair_node_energy[: lammps_natoms[0]]
+            pair_energy = scatter_sum(
+                src=pair_node_energy, index=data["batch"], dim=-1, dim_size=num_graphs
+            )  # [n_graphs,]
+        else:
+            pair_node_energy = torch.zeros_like(node_e0)
+            pair_energy = torch.zeros_like(e0)
+
+        if hasattr(self, "joint_embedding"):
+            embedding_features: Dict[str, torch.Tensor] = {}
+            for name, _ in self.embedding_specs.items():
+                embedding_features[name] = data[name]
+            node_feats += self.joint_embedding(
+                data["batch"],
+                embedding_features,
+            )
+            if hasattr(self, "embedding_readout"):
+                embedding_node_energy = self.embedding_readout(
+                    node_feats, node_heads
+                ).squeeze(-1)
+                embedding_energy = scatter_sum(
+                    src=embedding_node_energy,
+                    index=data["batch"],
+                    dim=0,
+                    dim_size=num_graphs,
+                )
+                e0 += embedding_energy
+
+        # Interactions
+        energies = [e0, pair_energy]
+        node_energies_list = [node_e0, pair_node_energy]
+        node_qs_list = []
+        node_feats_concat: List[torch.Tensor] = []
+
+        for i, (interaction, product) in enumerate(
+            zip(self.interactions, self.products)
+        ):
+            node_attrs_slice = data["node_attrs"]
+            if is_lammps and i > 0:
+                node_attrs_slice = node_attrs_slice[: lammps_natoms[0]]
+            node_feats, sc = interaction(
+                node_attrs=node_attrs_slice,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=data["edge_index"],
+                cutoff=cutoff,
+                first_layer=(i == 0),
+                lammps_class=lammps_class,
+                lammps_natoms=lammps_natoms,
+            )
+            if is_lammps and i == 0:
+                node_attrs_slice = node_attrs_slice[: lammps_natoms[0]]
+            node_feats = product(
+                node_feats=node_feats, sc=sc, node_attrs=node_attrs_slice
+            )
+            node_feats_concat.append(node_feats)
+
+        for i, (readout, les_readout) in enumerate(
+            zip(self.readouts, self.les_readouts)
+        ):
+            feat_idx = -1 if len(self.readouts) == 1 else i
+            node_es = readout(node_feats_concat[feat_idx], node_heads)[
+                num_atoms_arange, node_heads
+            ]
+            node_qs = les_readout(node_feats_concat[feat_idx], node_heads)[
+                num_atoms_arange, node_heads
+            ]  # type:ignore
+            node_qs_list.append(node_qs)
+            energy = scatter_sum(node_es, data["batch"], dim=0, dim_size=num_graphs)
+            energies.append(energy)
+            node_energies_list.append(node_es)
+
+        contributions = torch.stack(energies, dim=-1)
+        total_energy = torch.sum(contributions, dim=-1)
+        node_energy = torch.sum(torch.stack(node_energies_list, dim=-1), dim=-1)
+        node_feats_out = torch.cat(node_feats_concat, dim=-1)
+
+        les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1)
+        les_result = self.les(
+            latent_charges=les_q,
+            positions=data['positions'],
+            cell=data['cell'].view(-1, 3, 3),
+            batch=data["batch"],
+            compute_energy=True,
+            compute_bec=(compute_bec or self.compute_bec),
+            bec_output_index=self.bec_output_index,
+            )
+        les_energy_opt = les_result['E_lr']   
+        if les_energy_opt is None:
+            les_energy = torch.zeros_like(total_energy)
+        else:
+            les_energy = les_energy_opt
+        total_energy += les_energy
+
+        forces, virials, stress, hessian, edge_forces = get_outputs(
+            energy=total_energy,
+            positions=positions,
+            displacement=displacement,
+            vectors=vectors,
+            cell=cell,
+            training=training,
+            compute_force=compute_force,
+            compute_virials=compute_virials,
+            compute_stress=compute_stress,
+            compute_hessian=compute_hessian,
+            compute_edge_forces=compute_edge_forces,
+        )
+
+        atomic_virials: Optional[torch.Tensor] = None
+        atomic_stresses: Optional[torch.Tensor] = None
+        if compute_atomic_stresses and edge_forces is not None:
+            atomic_virials, atomic_stresses = get_atomic_virials_stresses(
+                edge_forces=edge_forces,
+                edge_index=data["edge_index"],
+                vectors=vectors,
+                num_atoms=positions.shape[0],
+                batch=data["batch"],
+                cell=cell,
+            )
+        return {
+            "energy": total_energy,
+            "node_energy": node_energy,
+            "contributions": contributions,
+            "forces": forces,
+            "edge_forces": edge_forces,
+            "virials": virials,
+            "stress": stress,
+            "atomic_virials": atomic_virials,
+            "atomic_stresses": atomic_stresses,
+            "displacement": displacement,
+            "hessian": hessian,
+            "node_feats": node_feats_out,
+            "les_energy": les_energy,
+            "latent_charges": les_q,
+            "BEC": les_result['BEC'],
+        }

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -82,7 +82,6 @@ class MACELES(ScaleShiftMACE):
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
         compute_bec: bool = False,
-        **kwargs,
     ) -> Dict[str, Optional[torch.Tensor]]:
         ctx = prepare_graph(
             data,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -270,7 +270,7 @@ class MACE(torch.nn.Module):
         compute_edge_forces: bool = False,
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         ctx = prepare_graph(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -270,7 +270,6 @@ class MACE(torch.nn.Module):
         compute_edge_forces: bool = False,
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
-        **kwargs,  # pylint: disable=unused-argument
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         ctx = prepare_graph(
@@ -450,7 +449,6 @@ class ScaleShiftMACE(MACE):
         compute_edge_forces: bool = False,
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
-        **kwargs,
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         ctx = prepare_graph(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -270,6 +270,7 @@ class MACE(torch.nn.Module):
         compute_edge_forces: bool = False,
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
+        **kwargs,
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         ctx = prepare_graph(
@@ -449,6 +450,7 @@ class ScaleShiftMACE(MACE):
         compute_edge_forces: bool = False,
         compute_atomic_stresses: bool = False,
         lammps_mliap: bool = False,
+        **kwargs,
     ) -> Dict[str, Optional[torch.Tensor]]:
         # Setup
         ctx = prepare_graph(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -6,7 +6,7 @@
 
 import argparse
 import os
-from typing import Optional
+from typing import Optional, Dict
 
 from .default_keys import DefaultKeys
 
@@ -130,6 +130,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
             "BOTNet",
             "MACE",
             "ScaleShiftMACE",
+            "MACELES",
             "ScaleShiftBOTNet",
             "AtomicDipolesMACE",
             "EnergyDipolesMACE",
@@ -394,6 +395,13 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--statistics_file",
         help="json file containing statistics of training set",
         type=str,
+        default=None,
+        required=False,
+    )
+    parser.add_argument(
+        "--les_arguments",
+        help="Path to the LES arguments file",
+        type=read_yaml,
         default=None,
         required=False,
     )
@@ -1072,3 +1080,18 @@ def str2bool(value):
     if value.lower() in ("no", "false", "f", "n", "0"):
         return False
     raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def read_yaml(value: str) -> Dict:
+    from pathlib import Path
+    import yaml
+
+    if not Path(value).is_file():
+        raise argparse.ArgumentTypeError(f"File {value} does not exist.")
+    with open(value, "r") as file:
+        try:
+            return yaml.safe_load(file)
+        except yaml.YAMLError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Error parsing YAML file {value}: {exc}"
+            ) from exc

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -6,7 +6,7 @@
 
 import argparse
 import os
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from .default_keys import DefaultKeys
 
@@ -1084,11 +1084,12 @@ def str2bool(value):
 
 def read_yaml(value: str) -> Dict:
     from pathlib import Path
+
     import yaml
 
     if not Path(value).is_file():
         raise argparse.ArgumentTypeError(f"File {value} does not exist.")
-    with open(value, "r") as file:
+    with open(value, "r", encoding="utf-8") as file:
         try:
             return yaml.safe_load(file)
         except yaml.YAMLError as exc:

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -108,7 +108,7 @@ def configure_model(
             model_config_foundation["atomic_inter_shift"] = [0.0] * len(heads)
         model_config_foundation["atomic_inter_scale"] = [1.0] * len(heads)
         args.avg_num_neighbors = model_config_foundation["avg_num_neighbors"]
-        args.model = "FoundationMACE"
+        args.model = "FoundationMACELES" if args.model == "MACELES" else "FoundationMACE"
         model_config_foundation["heads"] = heads
         model_config = model_config_foundation
 
@@ -259,6 +259,12 @@ def _build_model(
         )
     if args.model == "FoundationMACE":
         return modules.ScaleShiftMACE(**model_config_foundation)
+    if args.model == "FoundationMACELES":
+        from mace.modules.extensions import MACELES
+        return MACELES(
+            les_arguments=args.les_arguments,
+            **model_config_foundation,
+        )
     if args.model == "ScaleShiftBOTNet":
         # say it is deprecated
         raise RuntimeError("ScaleShiftBOTNet is deprecated, use MACE instead")

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -74,7 +74,11 @@ def configure_model(
         logging.info("Using embedding specifications from command line arguments")
         logging.info(f"Embedding specifications: {args.embedding_specs}")
     # Build model
-    if model_foundation is not None and args.model in ["MACE", "ScaleShiftMACE"]:
+    if model_foundation is not None and args.model in [
+        "MACE",
+        "ScaleShiftMACE",
+        "MACELES",
+    ]:
         logging.info("Loading FOUNDATION model")
         model_config_foundation = extract_config_mace_model(model_foundation)
         model_config_foundation["atomic_energies"] = atomic_energies
@@ -96,12 +100,12 @@ def configure_model(
 
         args.max_L = model_config_foundation["hidden_irreps"].lmax
 
-        if args.model == "MACE" and model_foundation.__class__.__name__ == "MACE":
-            model_config_foundation["atomic_inter_shift"] = [0.0] * len(heads)
-        else:
+        if args.model == "ScaleShiftMACE" or model_foundation.__class__.__name__ == "ScaleShiftMACE":
             model_config_foundation["atomic_inter_shift"] = (
                 _determine_atomic_inter_shift(args.mean, heads)
             )
+        else:
+            model_config_foundation["atomic_inter_shift"] = [0.0] * len(heads)
         model_config_foundation["atomic_inter_scale"] = [1.0] * len(heads)
         args.avg_num_neighbors = model_config_foundation["avg_num_neighbors"]
         args.model = "FoundationMACE"
@@ -289,5 +293,27 @@ def _build_model(
                 "RealAgnosticInteractionBlock"
             ],
             MLP_irreps=o3.Irreps(args.MLP_irreps),
+        )
+    if args.model == "MACELES":
+        from mace.modules.extensions import MACELES
+
+        return MACELES(
+            les_arguments=args.les_arguments,
+            **model_config,
+            pair_repulsion=args.pair_repulsion,
+            distance_transform=args.distance_transform,
+            correlation=args.correlation,
+            gate=modules.gate_dict[args.gate],
+            interaction_cls_first=modules.interaction_classes[args.interaction_first],
+            MLP_irreps=o3.Irreps(args.MLP_irreps),
+            atomic_inter_scale=args.std,
+            atomic_inter_shift=[0.0] * len(heads),
+            radial_MLP=ast.literal_eval(args.radial_MLP),
+            radial_type=args.radial_type,
+            heads=heads,
+            embedding_specs=args.embedding_specs,
+            use_embedding_readout=args.use_embedding_readout,
+            use_last_readout_only=args.use_last_readout_only,
+            use_agnostic_product=args.use_agnostic_product,
         )
     raise RuntimeError(f"Unknown model: '{args.model}'")

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -100,7 +100,10 @@ def configure_model(
 
         args.max_L = model_config_foundation["hidden_irreps"].lmax
 
-        if args.model == "ScaleShiftMACE" or model_foundation.__class__.__name__ == "ScaleShiftMACE":
+        if (
+            args.model == "ScaleShiftMACE"
+            or model_foundation.__class__.__name__ == "ScaleShiftMACE"
+        ):
             model_config_foundation["atomic_inter_shift"] = (
                 _determine_atomic_inter_shift(args.mean, heads)
             )
@@ -108,7 +111,9 @@ def configure_model(
             model_config_foundation["atomic_inter_shift"] = [0.0] * len(heads)
         model_config_foundation["atomic_inter_scale"] = [1.0] * len(heads)
         args.avg_num_neighbors = model_config_foundation["avg_num_neighbors"]
-        args.model = "FoundationMACELES" if args.model == "MACELES" else "FoundationMACE"
+        args.model = (
+            "FoundationMACELES" if args.model == "MACELES" else "FoundationMACE"
+        )
         model_config_foundation["heads"] = heads
         model_config = model_config_foundation
 
@@ -261,6 +266,7 @@ def _build_model(
         return modules.ScaleShiftMACE(**model_config_foundation)
     if args.model == "FoundationMACELES":
         from mace.modules.extensions import MACELES
+
         return MACELES(
             les_arguments=args.les_arguments,
             **model_config_foundation,

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -768,6 +768,14 @@ def get_params_options(
                 "weight_decay": 0.0,
             }
         )
+    if hasattr(model, "les_readouts") and model.les_readouts is not None:
+        param_options["params"].append(
+            {
+                "name": "les_readouts",
+                "params": model.les_readouts.parameters(),
+                "weight_decay": 0.0,
+            }
+        )
     return param_options
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ dev =
     pytest-benchmark
     pylint
 schedulefree = schedulefree
+les = les @ git+https://github.com/ChengUCB/les
 cueq = cuequivariance-torch>=0.2.0
 cueq-cuda-11 = cuequivariance-ops-torch-cu11>=0.2.0
 cueq-cuda-12 = cuequivariance-ops-torch-cu12>=0.2.0

--- a/tests/test_maceles.py
+++ b/tests/test_maceles.py
@@ -1,26 +1,18 @@
-import json
-import os
-import subprocess
-import sys
-from pathlib import Path
 
 import ase.io
 import numpy as np
 import pytest
-import torch
 from ase.atoms import Atoms
 from mace.tools.arg_parser import build_default_arg_parser
 from mace.cli.run_train import run as mace_run
-from mace.calculators import MACECalculator, mace_mp
+from mace.calculators import MACECalculator
 
 try:
-    import cuequivariance as cue  # pylint: disable=unused-import
-
-    CUET_AVAILABLE = True
+    from les import Les
+    LES_AVAILABLE = True
 except ImportError:
-    CUET_AVAILABLE = False
+    LES_AVAILABLE = False
 
-run_train = Path(__file__).parent.parent / "mace" / "cli" / "run_train.py"
 
 
 @pytest.fixture(name="fitting_configs")
@@ -80,7 +72,7 @@ _mace_params = {
     "use_reduced_cg": False,
 }
 
-
+@pytest.mark.skipif(not LES_AVAILABLE, reason="LES library is not available")
 def test_run_train(tmp_path, fitting_configs):
     ase.io.write(tmp_path / "fit.xyz", fitting_configs)
 
@@ -129,7 +121,7 @@ def test_run_train(tmp_path, fitting_configs):
 
     assert np.allclose(Es, ref_Es)
 
-
+@pytest.mark.skipif(not LES_AVAILABLE, reason="LES library is not available")
 def test_run_train_with_mp(tmp_path, fitting_configs):
     ase.io.write(tmp_path / "fit.xyz", fitting_configs)
 

--- a/tests/test_maceles.py
+++ b/tests/test_maceles.py
@@ -1,0 +1,159 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import ase.io
+import numpy as np
+import pytest
+import torch
+from ase.atoms import Atoms
+from mace.tools.arg_parser import build_default_arg_parser
+from mace.cli.run_train import run as mace_run
+from mace.calculators import MACECalculator, mace_mp
+
+try:
+    import cuequivariance as cue  # pylint: disable=unused-import
+
+    CUET_AVAILABLE = True
+except ImportError:
+    CUET_AVAILABLE = False
+
+run_train = Path(__file__).parent.parent / "mace" / "cli" / "run_train.py"
+
+
+@pytest.fixture(name="fitting_configs")
+def fixture_fitting_configs():
+    water = Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0, -2.0, 0], [1, 0, 0], [0, 1, 0]],
+        cell=[4] * 3,
+        pbc=[True] * 3,
+    )
+    fit_configs = [
+        Atoms(numbers=[8], positions=[[0, 0, 0]], cell=[6] * 3),
+        Atoms(numbers=[1], positions=[[0, 0, 0]], cell=[6] * 3),
+    ]
+    fit_configs[0].info["REF_energy"] = 0.0
+    fit_configs[0].info["config_type"] = "IsolatedAtom"
+    fit_configs[1].info["REF_energy"] = 0.0
+    fit_configs[1].info["config_type"] = "IsolatedAtom"
+
+    np.random.seed(5)
+    for _ in range(20):
+        c = water.copy()
+        c.positions += np.random.normal(0.1, size=c.positions.shape)
+        c.info["REF_energy"] = np.random.normal(0.1)
+        print(c.info["REF_energy"])
+        c.new_array("REF_forces", np.random.normal(0.1, size=c.positions.shape))
+        c.info["REF_stress"] = np.random.normal(0.1, size=6)
+        fit_configs.append(c)
+
+    return fit_configs
+
+
+@pytest.fixture(name="pretraining_configs")
+def fixture_pretraining_configs():
+    configs = []
+    for _ in range(10):
+        atoms = Atoms(
+            numbers=[8, 1, 1],
+            positions=np.random.rand(3, 3) * 3,
+            cell=[5, 5, 5],
+            pbc=[True] * 3,
+        )
+        atoms.info["REF_energy"] = np.random.normal(0, 1)
+        atoms.arrays["REF_forces"] = np.random.normal(0, 1, size=(3, 3))
+        atoms.info["REF_stress"] = np.random.normal(0, 1, size=6)
+        configs.append(atoms)
+    configs.append(
+        Atoms(numbers=[8], positions=[[0, 0, 0]], cell=[6] * 3, pbc=[True] * 3),
+    )
+    configs.append(
+        Atoms(numbers=[1], positions=[[0, 0, 0]], cell=[6] * 3, pbc=[True] * 3)
+    )
+    configs[-2].info["REF_energy"] = -2.0
+    configs[-2].info["config_type"] = "IsolatedAtom"
+    configs[-1].info["REF_energy"] = -4.0
+    configs[-1].info["config_type"] = "IsolatedAtom"
+    return configs
+
+
+_mace_params = {
+    "name": "MACE",
+    "valid_fraction": 0.05,
+    "energy_weight": 1.0,
+    "forces_weight": 10.0,
+    "stress_weight": 1.0,
+    "model": "MACELES",
+    "hidden_irreps": "128x0e",
+    "r_max": 3.5,
+    "batch_size": 5,
+    "max_num_epochs": 10,
+    "swa": None,
+    "start_swa": 5,
+    "ema": None,
+    "ema_decay": 0.99,
+    "amsgrad": None,
+    "restart_latest": None,
+    "device": "cpu",
+    "seed": 5,
+    "loss": "stress",
+    "energy_key": "REF_energy",
+    "forces_key": "REF_forces",
+    "stress_key": "REF_stress",
+    "eval_interval": 2,
+    "use_reduced_cg": False,
+}
+
+
+def test_run_train(tmp_path, fitting_configs):
+    ase.io.write(tmp_path / "fit.xyz", fitting_configs)
+
+    mace_params = _mace_params.copy()
+    mace_params["checkpoints_dir"] = str(tmp_path)
+    mace_params["model_dir"] = str(tmp_path)
+    mace_params["train_file"] = tmp_path / "fit.xyz"
+
+    args = build_default_arg_parser().parse_args(
+        [f"--{k}={v}" if v is not None else f"--{k}" for k, v in mace_params.items()]
+    )
+
+    mace_run(args)
+
+    calc = MACECalculator(model_paths=tmp_path / "MACE.model", device="cpu")
+
+    Es = []
+    for at in fitting_configs:
+        at.calc = calc
+        Es.append(at.get_potential_energy())
+
+    print("Es", Es)
+    # from a run on 04/06/2024 on stress_bugfix 967f0bfb6490086599da247874b24595d149caa7
+    ref_Es = [
+        0.0,
+        0.0,
+        -0.039181344585828524,
+        -0.0915223395136733,
+        -0.14953484236456582,
+        -0.06662480820063998,
+        -0.09983737353050133,
+        0.12477442296789745,
+        -0.06486086271762856,
+        -0.1460607988519944,
+        0.12886334908465508,
+        -0.14000990081920373,
+        -0.05319886578958313,
+        0.07780520158391,
+        -0.08895480281886901,
+        -0.15474719614734422,
+        0.007756765146527644,
+        -0.044879267197498685,
+        -0.036065736712447574,
+        -0.24413743841886623,
+        -0.0838104612106429,
+        -0.14751978636626545,
+    ]
+
+    assert np.allclose(Es, ref_Es)


### PR DESCRIPTION
This PR re-implements the MACELES model , updating it for compatibility with the current develop branch. Original PR #934 by @BingqingCheng.

## Verification and Changes
The new implementation has been checked against the old one. It initializes identically, and forward passes on the same data with freshly initialized models produce the same results.

A key correction is the inclusion of the `les_readouts` parameters in the optimizer. These parameters were previously not part of the parameter groups and were therefore not being trained. This PR corrects that. The new implementation also supports initializing a MACELES model from a foundation model checkpoint.

## Questions
- Given that `les_readouts` were not trained, was it the original intention for the latent charges to be derived from a fixed random projection of the node features? With this change, the projection will now be trained. @BingqingCheng
- You can see that in the test I've added, the model predicts a non-zero energy for isolated atoms even though `remove_self_interactions` is set to True in the Ewald block of LES (which is the default). Is this the expected behaviour? @BingqingCheng
- I'm not sure if want to keep the ability to finetune the foundation models, I would guess the optimal parameters will be quite different for a model with long-range effects and for a model without. @ilyes319, I am happy to remove the changes that enable this behaviour.
