### PR TITLE
Fix behavior of auto-downloaded MP data when using pseudolabels

### DIFF
--- a/mace/calculators/__init__.py
+++ b/mace/calculators/__init__.py
@@ -1,4 +1,4 @@
-from .foundations_models import mace_anicc, mace_mp, mace_off
+from .foundations_models import mace_anicc, mace_mp, mace_off, mace_omol
 from .lammps_mace import LAMMPS_MACE
 from .mace import MACECalculator
 

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -109,7 +109,7 @@ class MACECalculator(Calculator):
 
         self.results = {}
         if info_keys is None:
-            info_keys = {}
+            info_keys = {"total_spin": "spin", "total_charge": "charge"}
         if arrays_keys is None:
             arrays_keys = {}
         self.info_keys = info_keys

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -34,6 +34,13 @@ except (ImportError, ModuleNotFoundError):
     CUEQQ_AVAILABLE = False
     run_e3nn_to_cueq = None
 
+try:
+    import intel_extension_for_pytorch as ipex
+
+    has_ipex = True
+except ImportError:
+    has_ipex = False
+
 
 def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
     """Get the dtype of the model"""
@@ -50,7 +57,7 @@ class MACECalculator(Calculator):
     args:
         model_paths: str, path to model or models if a committee is produced
                 to make a committee use a wild card notation like mace_*.model
-        device: str, device to run on (cuda or cpu)
+        device: str, device to run on (cuda or cpu or xpu)
         energy_units_to_eV: float, conversion factor from model energy units to eV
         length_units_to_A: float, conversion factor from model length units to Angstroms
         default_dtype: str, default dtype of model
@@ -204,6 +211,10 @@ class MACECalculator(Calculator):
         # Ensure all models are on the same device
         for model in self.models:
             model.to(device)
+
+        if has_ipex and device == "xpu":
+            for model in self.models:
+                model = ipex.optimize(model)
 
         r_maxs = [model.r_max.cpu() for model in self.models]
         r_maxs = np.array(r_maxs)

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -19,29 +19,23 @@ except (ImportError, ModuleNotFoundError):
     CUEQQ_AVAILABLE = False
     cue = None
 
+SizeLike = Union[torch.Size, List[int]]
 
-def get_transfer_keys(num_layers: int) -> List[str]:
-    """Get list of keys that need to be transferred"""
-    return [
-        "node_embedding.linear.weight",
-        "radial_embedding.bessel_fn.bessel_weights",
-        "atomic_energies_fn.atomic_energies",
-        "readouts.0.linear.weight",
-        *[f"readouts.{j}.linear.weight" for j in range(num_layers - 1)],
-        "scale_shift.scale",
-        "scale_shift.shift",
-        *[f"readouts.{num_layers-1}.linear_{i}.weight" for i in range(1, 3)],
-    ] + [
-        s
-        for j in range(num_layers)
-        for s in [
-            f"interactions.{j}.linear_up.weight",
-            *[f"interactions.{j}.conv_tp_weights.layer{i}.weight" for i in range(4)],
-            f"interactions.{j}.linear.weight",
-            f"interactions.{j}.skip_tp.weight",
-            f"products.{j}.linear.weight",
-        ]
-    ]
+
+def shapes_match_up_to_unsqueeze(a: SizeLike, b: SizeLike) -> bool:
+    if isinstance(a, torch.Tensor):
+        a = a.shape
+    if isinstance(b, torch.Tensor):
+        b = b.shape
+    drop = lambda s: tuple(d for d in s if d != 1)
+    return drop(a) == drop(b)
+
+
+def reshape_like(src: torch.Tensor, ref_shape: torch.Size) -> torch.Tensor:
+    try:
+        return src.reshape(ref_shape)
+    except RuntimeError:
+        return src.clone().reshape(ref_shape)
 
 
 def get_kmax_pairs(
@@ -140,14 +134,6 @@ def transfer_weights(
     source_dict = source_model.state_dict()
     target_dict = target_model.state_dict()
 
-    # Transfer main weights
-    transfer_keys = get_transfer_keys(num_layers)
-    for key in transfer_keys:
-        if key in source_dict:  # Check if key exists
-            target_dict[key] = source_dict[key]
-        else:
-            logging.warning(f"Key {key} not found in source model")
-
     # Transfer symmetric contractions
     products = target_model.products
     transfer_symmetric_contractions(
@@ -160,13 +146,8 @@ def transfer_weights(
         use_reduced_cg,
     )
 
-    # Unsqueeze linear and skip_tp layers
-    for key in source_dict.keys():
-        if any(x in key for x in ["linear", "skip_tp"]) and "weight" in key:
-            target_dict[key] = target_dict[key].squeeze(0)
-
     # Transfer remaining matching keys
-    transferred_keys = set(transfer_keys)
+    transferred_keys = set()
     remaining_keys = (
         set(source_dict.keys()) & set(target_dict.keys()) - transferred_keys
     )
@@ -174,9 +155,17 @@ def transfer_weights(
 
     if remaining_keys:
         for key in remaining_keys:
+            src = source_dict[key]
+            tgt = target_dict[key]
             if source_dict[key].shape == target_dict[key].shape:
                 logging.debug(f"Transferring additional key: {key}")
                 target_dict[key] = source_dict[key]
+            elif shapes_match_up_to_unsqueeze(src.shape, tgt.shape):
+                logging.debug(
+                    f"Transferring key {key} after adapting shape "
+                    f"{tuple(src.shape)} → {tuple(tgt.shape)}"
+                )
+                target_dict[key] = reshape_like(src, tgt.shape)
             else:
                 logging.warning(
                     f"Shape mismatch for key {key}: "
@@ -184,7 +173,7 @@ def transfer_weights(
                 )
 
     # Transfer avg_num_neighbors
-    for i in range(2):
+    for i in range(num_layers):
         target_model.interactions[i].avg_num_neighbors = source_model.interactions[
             i
         ].avg_num_neighbors

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -27,7 +27,10 @@ def shapes_match_up_to_unsqueeze(a: SizeLike, b: SizeLike) -> bool:
         a = a.shape
     if isinstance(b, torch.Tensor):
         b = b.shape
-    drop = lambda s: tuple(d for d in s if d != 1)
+
+    def drop(s):
+        return tuple(d for d in s if d != 1)
+
     return drop(a) == drop(b)
 
 

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import torch
 from e3nn import o3
@@ -19,29 +19,23 @@ except (ImportError, ModuleNotFoundError):
     CUEQQ_AVAILABLE = False
     cue = None
 
+SizeLike = Union[torch.Size, List[int]]
 
-def get_transfer_keys(num_layers: int) -> List[str]:
-    """Get list of keys that need to be transferred"""
-    return [
-        "node_embedding.linear.weight",
-        "radial_embedding.bessel_fn.bessel_weights",
-        "atomic_energies_fn.atomic_energies",
-        "readouts.0.linear.weight",
-        *[f"readouts.{j}.linear.weight" for j in range(num_layers - 1)],
-        "scale_shift.scale",
-        "scale_shift.shift",
-        *[f"readouts.{num_layers-1}.linear_{i}.weight" for i in range(1, 3)],
-    ] + [
-        s
-        for j in range(num_layers)
-        for s in [
-            f"interactions.{j}.linear_up.weight",
-            *[f"interactions.{j}.conv_tp_weights.layer{i}.weight" for i in range(4)],
-            f"interactions.{j}.linear.weight",
-            f"interactions.{j}.skip_tp.weight",
-            f"products.{j}.linear.weight",
-        ]
-    ]
+
+def shapes_match_up_to_unsqueeze(a: SizeLike, b: SizeLike) -> bool:
+    if isinstance(a, torch.Tensor):
+        a = a.shape
+    if isinstance(b, torch.Tensor):
+        b = b.shape
+    drop = lambda s: tuple(d for d in s if d != 1)
+    return drop(a) == drop(b)
+
+
+def reshape_like(src: torch.Tensor, ref_shape: torch.Size) -> torch.Tensor:
+    try:
+        return src.reshape(ref_shape)
+    except RuntimeError:
+        return src.clone().reshape(ref_shape)
 
 
 def get_kmax_pairs(
@@ -126,14 +120,6 @@ def transfer_weights(
     source_dict = source_model.state_dict()
     target_dict = target_model.state_dict()
 
-    # Transfer main weights
-    transfer_keys = get_transfer_keys(num_layers)
-    for key in transfer_keys:
-        if key in source_dict:  # Check if key exists
-            target_dict[key] = source_dict[key]
-        else:
-            logging.warning(f"Key {key} not found in source model")
-
     products = source_model.products
     # Transfer symmetric contractions
     transfer_symmetric_contractions(
@@ -146,28 +132,31 @@ def transfer_weights(
         use_reduced_cg,
     )
 
-    # Unsqueeze linear and skip_tp layers
-    for key in source_dict.keys():
-        if any(x in key for x in ["linear", "skip_tp"]) and "weight" in key:
-            target_dict[key] = target_dict[key].unsqueeze(0)
-
-    transferred_keys = set(transfer_keys)
+    transferred_keys = set()
     remaining_keys = (
         set(source_dict.keys()) & set(target_dict.keys()) - transferred_keys
     )
     remaining_keys = {k for k in remaining_keys if "symmetric_contraction" not in k}
     if remaining_keys:
         for key in remaining_keys:
+            src = source_dict[key]
+            tgt = target_dict[key]
             if source_dict[key].shape == target_dict[key].shape:
                 logging.debug(f"Transferring additional key: {key}")
                 target_dict[key] = source_dict[key]
+            elif shapes_match_up_to_unsqueeze(src.shape, tgt.shape):
+                logging.debug(
+                    f"Transferring key {key} after adapting shape "
+                    f"{tuple(src.shape)} → {tuple(tgt.shape)} -> {reshape_like(src, tgt.shape).shape}"
+                )
+                target_dict[key] = reshape_like(src, tgt.shape)
             else:
-                logging.warning(
+                logging.debug(
                     f"Shape mismatch for key {key}: "
                     f"source {source_dict[key].shape} vs target {target_dict[key].shape}"
                 )
     # Transfer avg_num_neighbors
-    for i in range(2):
+    for i in range(num_layers):
         target_model.interactions[i].avg_num_neighbors = source_model.interactions[
             i
         ].avg_num_neighbors
@@ -200,6 +189,7 @@ def run(
     num_product_irreps = len(config["hidden_irreps"].slices()) - 1
     correlation = config["correlation"]
     use_reduced_cg = config.get("use_reduced_cg", True)
+
     # Add cuequivariance config
     config["cueq_config"] = CuEquivarianceConfig(
         enabled=True,

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -27,7 +27,10 @@ def shapes_match_up_to_unsqueeze(a: SizeLike, b: SizeLike) -> bool:
         a = a.shape
     if isinstance(b, torch.Tensor):
         b = b.shape
-    drop = lambda s: tuple(d for d in s if d != 1)
+
+    def drop(s):
+        return tuple(d for d in s if d != 1)
+
     return drop(a) == drop(b)
 
 

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -53,6 +53,7 @@ class SelectionSettings:
     filtering_type: FilteringType = FilteringType.COMBINATIONS
     weight_ft: float = 1.0
     weight_pt: float = 1.0
+    allow_random_padding: bool = False
     seed: int = 42
 
 
@@ -147,6 +148,12 @@ def parse_args() -> argparse.Namespace:
         help="list of atomic numbers to filter the configurations",
         type=str_to_list,
         default=None,
+    )
+    parser.add_argument(
+        "--allow_random_padding",
+        help="allow random padding of the configurations to match the number of samples",
+        action="store_false",
+        default=True,
     )
     parser.add_argument("--seed", help="random seed", type=int, default=42)
     return parser.parse_args()
@@ -398,6 +405,7 @@ def _subsample_data(
     num_samples: int | None,
     subselect: SubselectType,
     descriptors_path: str | None,
+    allow_random_padding: bool,
     calc: MACECalculator | None,
 ) -> List[ase.Atoms]:
     if num_samples is None or num_samples == len(filtered_atoms):
@@ -405,7 +413,7 @@ def _subsample_data(
             f"No subsampling, keeping all {len(filtered_atoms)} filtered configurations"
         )
         return filtered_atoms
-    if num_samples > len(filtered_atoms):
+    if num_samples > len(filtered_atoms) and allow_random_padding:
         num_sample_randomly = num_samples - len(filtered_atoms)
         logging.info(
             f"Number of configurations after filtering {len(filtered_atoms)} "
@@ -470,6 +478,7 @@ def select_samples(
         settings.num_samples,
         settings.subselect,
         settings.descriptors,
+        settings.allow_random_padding,
         calc,
     )
     if ase.io.formats.filetype(settings.output, read=False) != "extxyz":

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -53,7 +53,7 @@ class SelectionSettings:
     filtering_type: FilteringType = FilteringType.COMBINATIONS
     weight_ft: float = 1.0
     weight_pt: float = 1.0
-    allow_random_padding: bool = False
+    allow_random_padding: bool = True
     seed: int = 42
 
 
@@ -150,10 +150,10 @@ def parse_args() -> argparse.Namespace:
         default=None,
     )
     parser.add_argument(
-        "--allow_random_padding",
-        help="allow random padding of the configurations to match the number of samples",
+        "--disallow_random_padding",
+        help="do not allow random padding of the configurations to match the number of samples",
         action="store_false",
-        default=True,
+        dest="allow_random_padding",
     )
     parser.add_argument("--seed", help="random seed", type=int, default=42)
     return parser.parse_args()

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import logging
 from dataclasses import dataclass
 from enum import Enum
@@ -53,6 +54,11 @@ class SelectionSettings:
     weight_ft: float = 1.0
     weight_pt: float = 1.0
     seed: int = 42
+
+
+def str_to_list(s: str) -> List[int]:
+    assert isinstance(s, str), "Input must be a string"
+    return ast.literal_eval(s)
 
 
 def parse_args() -> argparse.Namespace:
@@ -135,6 +141,12 @@ def parse_args() -> argparse.Namespace:
         help="weight for the pretraining set",
         type=float,
         default=1.0,
+    )
+    parser.add_argument(
+        "--atomic_numbers",
+        help="list of atomic numbers to filter the configurations",
+        type=str_to_list,
+        default=None,
     )
     parser.add_argument("--seed", help="random seed", type=int, default=42)
     return parser.parse_args()

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -22,7 +22,7 @@ from torch_ema import ExponentialMovingAverage
 
 import mace
 from mace import data, tools
-from mace.calculators.foundations_models import mace_mp, mace_off
+from mace.calculators.foundations_models import mace_mp, mace_off, mace_mp_names
 from mace.cli.convert_cueq_e3nn import run as run_cueq_to_e3nn
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.cli.visualise_train import TrainingPlotter
@@ -117,8 +117,10 @@ def run(args) -> None:
     commit = print_git_commit()
     model_foundation: Optional[torch.nn.Module] = None
     foundation_model_avg_num_neighbors = 0
+    # Filter out None from mace_mp_names to get valid model names
+    valid_mace_mp_models = [name for name in mace_mp_names if name is not None]
     if args.foundation_model is not None:
-        if args.foundation_model in ["small", "medium", "large"]:
+        if args.foundation_model in valid_mace_mp_models:
             logging.info(
                 f"Using foundation model mace-mp-0 {args.foundation_model} as initial checkpoint."
             )
@@ -151,7 +153,7 @@ def run(args) -> None:
             0
         ].avg_num_neighbors
         if (
-            args.foundation_model not in ["small", "medium", "large"]
+            args.foundation_model not in ["smal", "medium", "large"]
             and args.pt_train_file is None
         ):
             logging.warning(

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -22,7 +22,7 @@ from torch_ema import ExponentialMovingAverage
 
 import mace
 from mace import data, tools
-from mace.calculators.foundations_models import mace_mp, mace_off, mace_mp_names
+from mace.calculators.foundations_models import mace_mp, mace_mp_names, mace_off
 from mace.cli.convert_cueq_e3nn import run as run_cueq_to_e3nn
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.cli.visualise_train import TrainingPlotter

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -784,6 +784,14 @@ def run(args) -> None:
         logging.info("DRY RUN mode enabled. Stopping now.")
         return
 
+    if args.device == "xpu":
+        try:
+            model, optimizer = ipex.optimize(model, optimizer=optimizer)
+        except ImportError as e:
+            logging.error(
+                "Intel Extension for PyTorch not found, but XPU device was specified. "
+                "Please install it to use XPU device."
+            )
 
     tools.train(
         model=model,

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -153,7 +153,7 @@ def run(args) -> None:
             0
         ].avg_num_neighbors
         if (
-            args.foundation_model not in ["smal", "medium", "large"]
+            args.foundation_model not in ["small", "medium", "large"]
             and args.pt_train_file is None
         ):
             logging.warning(

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -296,6 +296,7 @@ def run(args) -> None:
                 key_specification=head_config.key_specification,
                 head_name=head_config.head_name,
                 keep_isolated_atoms=head_config.keep_isolated_atoms,
+                no_data_ok=(args.pseudolabel_replay and args.multiheads_finetuning and head_config.head_name == "pt_head"),
             )
             head_config.collections = SubsetCollection(
                 train=collections.train,

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -88,7 +88,7 @@ def run(args) -> None:
     if args.device == "xpu":
         try:
             import intel_extension_for_pytorch as ipex
-            import oneccl_bindings_for_pytorch as oneccl
+            import oneccl_bindings_for_pytorch as oneccl  # pylint: disable=unused-import
         except ImportError as e:
             raise ImportError(
                 "Error: Intel extension for PyTorch not found, but XPU device was specified"

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -293,7 +293,7 @@ class AtomicData(torch_geometric.data.Data):
                 config.properties.get("total_spin"), dtype=torch.get_default_dtype()
             )
             if config.properties.get("total_spin") is not None
-            else torch.tensor(0.0, dtype=torch.get_default_dtype())
+            else torch.tensor(1.0, dtype=torch.get_default_dtype())
         )
 
         return cls(

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -263,10 +263,12 @@ def load_from_xyz(
 
     final_energy_key = key_specification.info_keys["energy"]
     final_forces_key = key_specification.arrays_keys["forces"]
+    final_dipole_key = key_specification.info_keys.get("dipole", "REF_dipole")
     has_energy = any(final_energy_key in atoms.info for atoms in atoms_list)
     has_forces = any(final_forces_key in atoms.arrays for atoms in atoms_list)
+    has_dipole = any(final_dipole_key in atoms.info for atoms in atoms_list)
 
-    if not has_energy and not has_forces:
+    if not has_energy and not has_forces and not has_dipole:
         raise ValueError(
             f"Neither '{final_energy_key}' nor '{final_forces_key}' found in '{file_path}'. Please change the key names in the command line arguments or ensure that the file contains the required data."
         )

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -223,6 +223,9 @@ def load_from_xyz(
     forces_key = key_specification.arrays_keys["forces"]
     stress_key = key_specification.info_keys["stress"]
     head_key = key_specification.info_keys["head"]
+    original_energy_key = energy_key
+    original_forces_key = forces_key
+    original_stress_key = stress_key
     if energy_key == "energy":
         logging.warning(
             "Since ASE version 3.23.0b1, using energy_key 'energy' is no longer safe when communicating between MACE and ASE. We recommend using a different key, rewriting 'energy' to 'REF_energy'. You need to use --energy_key='REF_energy' to specify the chosen key name."
@@ -230,7 +233,9 @@ def load_from_xyz(
         key_specification.info_keys["energy"] = "REF_energy"
         for atoms in atoms_list:
             try:
+                print("OK")
                 atoms.info["REF_energy"] = atoms.get_potential_energy()
+                print("atoms.info['REF_energy']:", atoms.info["REF_energy"])
             except Exception as e:  # pylint: disable=W0703
                 logging.error(f"Failed to extract energy: {e}")
                 atoms.info["REF_energy"] = None
@@ -267,11 +272,11 @@ def load_from_xyz(
         )
     if not has_energy:
         logging.warning(
-            f"No energies found with key '{final_energy_key}' in '{file_path}'. Please change the key name in the command line arguments or ensure that the file contains the required data."
+            f"No energies found with key '{final_energy_key}' in '{file_path}'. If this is unexpected, please change the key name in the command line arguments or ensure that the file contains the required data."
         )
     if not has_forces:
         logging.warning(
-            f"No forces found with key '{final_forces_key}' in '{file_path}'."
+            f"No forces found with key '{final_forces_key}' in '{file_path}'. If this is unexpected, Please change the key name in the command line arguments or ensure that the file contains the required data."
         )
 
     if not isinstance(atoms_list, list):
@@ -313,6 +318,9 @@ def load_from_xyz(
         key_specification=key_specification,
         head_name=head_name,
     )
+    key_specification.info_keys["energy"] = original_energy_key
+    key_specification.arrays_keys["forces"] = original_forces_key
+    key_specification.info_keys["stress"] = original_stress_key
     return atomic_energies_dict, configs
 
 

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -255,6 +255,25 @@ def load_from_xyz(
                 atoms.info["REF_stress"] = atoms.get_stress()
             except Exception as e:  # pylint: disable=W0703
                 atoms.info["REF_stress"] = None
+
+    final_energy_key = key_specification.info_keys["energy"]
+    final_forces_key = key_specification.arrays_keys["forces"]
+    has_energy = any(final_energy_key in atoms.info for atoms in atoms_list)
+    has_forces = any(final_forces_key in atoms.arrays for atoms in atoms_list)
+
+    if not has_energy and not has_forces:
+        raise ValueError(
+            f"Neither '{final_energy_key}' nor '{final_forces_key}' found in '{file_path}'. Please change the key names in the command line arguments or ensure that the file contains the required data."
+        )
+    if not has_energy:
+        logging.warning(
+            f"No energies found with key '{final_energy_key}' in '{file_path}'. Please change the key name in the command line arguments or ensure that the file contains the required data."
+        )
+    if not has_forces:
+        logging.warning(
+            f"No forces found with key '{final_forces_key}' in '{file_path}'."
+        )
+
     if not isinstance(atoms_list, list):
         atoms_list = [atoms_list]
 

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -217,6 +217,7 @@ def load_from_xyz(
     config_type_weights: Optional[Dict] = None,
     extract_atomic_energies: bool = False,
     keep_isolated_atoms: bool = False,
+    no_data_ok: bool = False,
 ) -> Tuple[Dict[int, float], Configurations]:
     atoms_list = ase.io.read(file_path, index=":")
     energy_key = key_specification.info_keys["energy"]
@@ -269,9 +270,11 @@ def load_from_xyz(
     has_dipole = any(final_dipole_key in atoms.info for atoms in atoms_list)
 
     if not has_energy and not has_forces and not has_dipole:
-        raise ValueError(
-            f"Neither '{final_energy_key}' nor '{final_forces_key}' found in '{file_path}'. Please change the key names in the command line arguments or ensure that the file contains the required data."
-        )
+        msg = f"Neither '{final_energy_key}' nor '{final_forces_key}' found in '{file_path}'. Continuing because no_data_ok=True was passed in."
+        if no_data_ok:
+            logging.warning(msg)
+        else:
+            raise ValueError(msg)
     if not has_energy:
         logging.warning(
             f"No energies found with key '{final_energy_key}' in '{file_path}'. If this is unexpected, please change the key name in the command line arguments or ensure that the file contains the required data."

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -9,6 +9,7 @@ from .blocks import (
     LinearDipoleReadoutBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
+    NonLinearBiasReadoutBlock,
     NonLinearDipoleReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
@@ -50,6 +51,14 @@ interaction_classes: Dict[str, Type[InteractionBlock]] = {
     "RealAgnosticDensityInteractionBlock": RealAgnosticDensityInteractionBlock,
     "RealAgnosticDensityResidualInteractionBlock": RealAgnosticDensityResidualInteractionBlock,
     "RealAgnosticResidualNonLinearInteractionBlock": RealAgnosticResidualNonLinearInteractionBlock,
+}
+
+readout_classes: Dict[str, Type[LinearReadoutBlock]] = {
+    "LinearReadoutBlock": LinearReadoutBlock,
+    "LinearDipoleReadoutBlock": LinearDipoleReadoutBlock,
+    "NonLinearDipoleReadoutBlock": NonLinearDipoleReadoutBlock,
+    "NonLinearReadoutBlock": NonLinearReadoutBlock,
+    "NonLinearBiasReadoutBlock": NonLinearBiasReadoutBlock,
 }
 
 scaling_classes: Dict[str, Callable] = {

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1133,8 +1133,8 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
 
         if self.cueq_config is not None:
             if self.cueq_config.layout_str == "ir_mul":
-                import cuequivariance_torch as cuet
                 import cuequivariance as cue
+                import cuequivariance_torch as cuet
 
                 self.transpose_mul_ir = cuet.TransposeIrrepsLayout(
                     irreps=cue.Irreps(self.cueq_config.group, self.irreps_nonlin),

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1176,7 +1176,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         )
 
         if hasattr(self, "conv_fusion"):
-            mji = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
+            message = self.conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
         else:
             mji = self.conv_tp(
                 node_feats[edge_index[0]], edge_attrs, tp_weights

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -281,15 +281,12 @@ class RadialEmbeddingBlock(torch.nn.Module):
     ):
         cutoff = self.cutoff_fn(edge_lengths)  # [n_edges, 1]
         if hasattr(self, "distance_transform"):
-            print("apply distance transform", self.distance_transform)
             edge_lengths = self.distance_transform(
                 edge_lengths, node_attrs, edge_index, atomic_numbers
             )
-        print("appy cutoff", self.apply_cutoff)
         radial = self.bessel_fn(edge_lengths)  # [n_edges, n_basis]
         if hasattr(self, "apply_cutoff"):
             if not self.apply_cutoff:
-                print("not applying cutoff")
                 return radial, cutoff
         return radial * cutoff, None  # [n_edges, n_basis], [n_edges, 1]
 

--- a/mace/modules/embeddings.py
+++ b/mace/modules/embeddings.py
@@ -42,15 +42,14 @@ class GenericJointEmbedding(nn.Module):
                 raise ValueError(f"Unknown type {spec['type']} for feature {name}")
 
         # build the single concat→SiLU→Linear head
-        total_dim = base_dim + sum(spec["emb_dim"] for spec in self.specs.values())
+        total_dim = sum(spec["emb_dim"] for spec in self.specs.values())
         self.project = nn.Sequential(
-            nn.SiLU(),
             nn.Linear(total_dim, self.out_dim, bias=False),
+            nn.SiLU(),
         )
 
     def forward(
         self,
-        species_emb: torch.Tensor,  # [N_nodes, base_dim]
         batch: torch.Tensor,  # [N_nodes,] graph indices
         features: Dict[str, torch.Tensor],
     ) -> torch.Tensor:
@@ -59,7 +58,7 @@ class GenericJointEmbedding(nn.Module):
         and we upsample any per‐graph ones via feat[batch].
         Returns: [N_nodes, out_dim]
         """
-        embs = [species_emb]
+        embs = []
         for name, spec in self.specs.items():
             feat = features[name]
             if spec["per"] == "graph":

--- a/mace/modules/embeddings.py
+++ b/mace/modules/embeddings.py
@@ -1,6 +1,4 @@
-# joint_embedding.py
-
-from typing import Dict, Optional, Sequence
+from typing import Any, Dict, Optional
 
 import torch
 from torch import nn
@@ -17,7 +15,7 @@ class GenericJointEmbedding(nn.Module):
         self,
         *,
         base_dim: int,
-        embedding_specs: Sequence[tuple[str, Dict]],
+        embedding_specs: Optional[Dict[str, Any]],
         out_dim: Optional[int] = None,
     ):
         super().__init__()

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -331,7 +331,7 @@ class MACE(torch.nn.Module):
             if hasattr(self, "embedding_readout"):
                 embedding_node_energy = self.embedding_readout(
                     node_feats, node_heads
-                ).squeeze()
+                ).squeeze(-1)
                 embedding_energy = scatter_sum(
                     src=embedding_node_energy,
                     index=data["batch"],
@@ -510,7 +510,7 @@ class ScaleShiftMACE(MACE):
             if hasattr(self, "embedding_readout"):
                 embedding_node_energy = self.embedding_readout(
                     node_feats, node_heads
-                ).squeeze()
+                ).squeeze(-1)
                 embedding_energy = scatter_sum(
                     src=embedding_node_energy,
                     index=data["batch"],

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -4,7 +4,6 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
-import os
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import numpy as np

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -63,6 +63,8 @@ class MACE(torch.nn.Module):
         use_reduced_cg: bool = True,
         use_so3: bool = False,
         use_agnostic_product: bool = False,
+        use_last_readout_only: bool = False,
+        use_embedding_readout: bool = False,
         distance_transform: str = "None",
         edge_irreps: Optional[o3.Irreps] = None,
         radial_MLP: Optional[List[int]] = None,
@@ -72,6 +74,7 @@ class MACE(torch.nn.Module):
         embedding_specs: Optional[Dict[str, Any]] = None,
         oeq_config: Optional[Dict[str, Any]] = None,
         lammps_mliap: Optional[bool] = False,
+        readout_cls: Optional[Type[NonLinearReadoutBlock]] = NonLinearReadoutBlock,
     ):
         super().__init__()
         self.register_buffer(
@@ -93,6 +96,9 @@ class MACE(torch.nn.Module):
         self.edge_irreps = edge_irreps
         self.use_reduced_cg = use_reduced_cg
         self.use_agnostic_product = use_agnostic_product
+        self.use_so3 = use_so3
+        self.use_last_readout_only = use_last_readout_only
+
         # Embedding
         node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
         node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
@@ -109,12 +115,21 @@ class MACE(torch.nn.Module):
                 embedding_specs=embedding_specs,
                 out_dim=embedding_size,
             )
+            if use_embedding_readout:
+                self.embedding_readout = LinearReadoutBlock(
+                    node_feats_irreps,
+                    o3.Irreps(f"{len(heads)}x0e"),
+                    cueq_config,
+                    oeq_config,
+                )
+
         self.radial_embedding = RadialEmbeddingBlock(
             r_max=r_max,
             num_bessel=num_bessel,
             num_polynomial_cutoff=num_polynomial_cutoff,
             radial_type=radial_type,
             distance_transform=distance_transform,
+            apply_cutoff=apply_cutoff,
         )
         edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
         if pair_repulsion:
@@ -180,11 +195,15 @@ class MACE(torch.nn.Module):
         self.products = torch.nn.ModuleList([prod])
 
         self.readouts = torch.nn.ModuleList()
-        self.readouts.append(
-            LinearReadoutBlock(
-                hidden_irreps, o3.Irreps(f"{len(heads)}x0e"), cueq_config, oeq_config
+        if not use_last_readout_only:
+            self.readouts.append(
+                LinearReadoutBlock(
+                    hidden_irreps,
+                    o3.Irreps(f"{len(heads)}x0e"),
+                    cueq_config,
+                    oeq_config,
+                )
             )
-        )
 
         for i in range(num_interactions - 1):
             if i == num_interactions - 2:
@@ -221,7 +240,7 @@ class MACE(torch.nn.Module):
             self.products.append(prod)
             if i == num_interactions - 2:
                 self.readouts.append(
-                    NonLinearReadoutBlock(
+                    readout_cls(
                         hidden_irreps_out,
                         (len(heads) * MLP_irreps).simplify(),
                         gate,
@@ -231,7 +250,7 @@ class MACE(torch.nn.Module):
                         oeq_config,
                     )
                 )
-            else:
+            elif not use_last_readout_only:
                 self.readouts.append(
                     LinearReadoutBlock(
                         hidden_irreps,
@@ -306,18 +325,28 @@ class MACE(torch.nn.Module):
             for name, _ in self.embedding_specs.items():
                 embedding_features[name] = data[name]
             node_feats += self.joint_embedding(
-                node_feats,
                 data["batch"],
                 embedding_features,
             )
+            if hasattr(self, "embedding_readout"):
+                embedding_node_energy = self.embedding_readout(
+                    node_feats, node_heads
+                ).squeeze()
+                embedding_energy = scatter_sum(
+                    src=embedding_node_energy,
+                    index=data["batch"],
+                    dim=0,
+                    dim_size=num_graphs,
+                )
+                e0 += embedding_energy
 
         # Interactions
         energies = [e0, pair_energy]
         node_energies_list = [node_e0, pair_node_energy]
         node_feats_concat: List[torch.Tensor] = []
 
-        for i, (interaction, product, readout) in enumerate(
-            zip(self.interactions, self.products, self.readouts)
+        for i, (interaction, product) in enumerate(
+            zip(self.interactions, self.products)
         ):
             node_attrs_slice = data["node_attrs"]
             if is_lammps and i > 0:
@@ -339,7 +368,12 @@ class MACE(torch.nn.Module):
                 node_feats=node_feats, sc=sc, node_attrs=node_attrs_slice
             )
             node_feats_concat.append(node_feats)
-            node_es = readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+
+        for i, readout in enumerate(self.readouts):
+            feat_idx = -1 if len(self.readouts) == 1 else i
+            node_es = readout(node_feats_concat[feat_idx], node_heads)[
+                num_atoms_arange, node_heads
+            ]
             energy = scatter_sum(node_es, data["batch"], dim=0, dim_size=num_graphs)
             energies.append(energy)
             node_energies_list.append(node_es)
@@ -463,21 +497,33 @@ class ScaleShiftMACE(MACE):
         else:
             pair_node_energy = torch.zeros_like(node_e0)
 
+        # Embeddings of additional features
         if hasattr(self, "joint_embedding"):
             embedding_features: Dict[str, torch.Tensor] = {}
             for name, _ in self.embedding_specs.items():
                 embedding_features[name] = data[name]
             node_feats += self.joint_embedding(
-                node_feats,
                 data["batch"],
                 embedding_features,
             )
+            if hasattr(self, "embedding_readout"):
+                embedding_node_energy = self.embedding_readout(
+                    node_feats, node_heads
+                ).squeeze()
+                embedding_energy = scatter_sum(
+                    src=embedding_node_energy,
+                    index=data["batch"],
+                    dim=0,
+                    dim_size=num_graphs,
+                )
+                e0 += embedding_energy
+
         # Interactions
         node_es_list = [pair_node_energy]
         node_feats_list: List[torch.Tensor] = []
 
-        for i, (interaction, product, readout) in enumerate(
-            zip(self.interactions, self.products, self.readouts)
+        for i, (interaction, product) in enumerate(
+            zip(self.interactions, self.products)
         ):
             node_attrs_slice = data["node_attrs"]
             if is_lammps and i > 0:
@@ -499,8 +545,13 @@ class ScaleShiftMACE(MACE):
                 node_feats=node_feats, sc=sc, node_attrs=node_attrs_slice
             )
             node_feats_list.append(node_feats)
+
+        for i, readout in enumerate(self.readouts):
+            feat_idx = -1 if len(self.readouts) == 1 else i
             node_es_list.append(
-                readout(node_feats, node_heads)[num_atoms_arange, node_heads]
+                readout(node_feats_list[feat_idx], node_heads)[
+                    num_atoms_arange, node_heads
+                ]
             )
 
         node_feats_out = torch.cat(node_feats_list, dim=-1)

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -37,9 +37,6 @@ from .utils import (
     prepare_graph,
 )
 
-# pylint: disable=C0302
-USE_FLOAT64_E0 = os.environ.get("MACE_USE_FLOAT64_E0", "false").lower() == "true"
-
 
 @compile_mode("script")
 class MACE(torch.nn.Module):
@@ -300,8 +297,6 @@ class MACE(torch.nn.Module):
         node_e0 = self.atomic_energies_fn(data["node_attrs"])[
             num_atoms_arange, node_heads
         ]
-        if USE_FLOAT64_E0:
-            node_e0 = node_e0.double()  # Ensure e0 is in float64
         e0 = scatter_sum(
             src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
         ).to(
@@ -482,8 +477,6 @@ class ScaleShiftMACE(MACE):
         node_e0 = self.atomic_energies_fn(data["node_attrs"])[
             num_atoms_arange, node_heads
         ]
-        if USE_FLOAT64_E0:
-            node_e0 = node_e0.double()
         e0 = scatter_sum(
             src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
         ).to(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -388,7 +388,6 @@ class MACE(torch.nn.Module):
         total_energy = torch.sum(contributions, dim=-1)
         node_energy = torch.sum(torch.stack(node_energies_list, dim=-1), dim=-1)
         node_feats_out = torch.cat(node_feats_concat, dim=-1)
-        node_energy = node_e0.double() + pair_node_energy.double()
 
         forces, virials, stress, hessian, edge_forces = get_outputs(
             energy=total_energy,

--- a/mace/modules/radial.py
+++ b/mace/modules/radial.py
@@ -378,6 +378,7 @@ class RadialMLP(torch.nn.Module):
                 modules.append(torch.nn.SiLU())
 
         self.net = torch.nn.Sequential(*modules)
+        self.hs = channels_list
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         return self.net(inputs)

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -278,7 +278,6 @@ class SymmetricContractionWrapper:
         use_reduced_cg: bool = True,
     ):
         use_reduced_cg = use_reduced_cg and CUET_AVAILABLE
-        print("Using reduced CG:", use_reduced_cg)
         if (
             CUET_AVAILABLE
             and cueq_config is not None
@@ -304,3 +303,24 @@ class SymmetricContractionWrapper:
             num_elements=num_elements,
             use_reduced_cg=use_reduced_cg,
         )
+
+
+class TransposeIrrepsLayoutWrapper:
+    """Wrapper around cuet.TransposeIrrepsLayout"""
+
+    def __new__(
+        cls,
+        irreps: o3.Irreps,
+        source: str,
+        target: str,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+    ):
+        if CUET_AVAILABLE and cueq_config is not None and cueq_config.enabled:
+            return cuet.TransposeIrrepsLayout(
+                cue.Irreps(cueq_config.group, irreps),
+                source=getattr(cue, source),
+                target=getattr(cue, target),
+                use_fallback=True,
+            )
+
+        return None

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -127,6 +127,9 @@ def with_scatter_sum(conv_tp: torch.nn.Module) -> torch.nn.Module:
 def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
     """Wraps a cuet.ConvTensorProduct to use conv fusion"""
     conv_tp.original_forward = conv_tp.forward
+    num_segment = conv_tp.m.buffer_num_segments[0]
+    num_operands = conv_tp.m.operand_extent
+    conv_tp.weight_numel = num_segment * num_operands
 
     def forward(
         self,

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -145,7 +145,7 @@ def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
             {1: sender},
             {0: node_feats},
             {0: receiver},
-        )
+        )[0]
 
     conv_tp.forward = types.MethodType(forward, conv_tp)
     return conv_tp

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -176,6 +176,18 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=True,
     )
     parser.add_argument(
+        "--use_last_readout_only",
+        help="use only the last readout for the final output",
+        type=str2bool,
+        default=False,
+    )
+    parser.add_argument(
+        "--use_embedding_readout",
+        help="use embedding readout for the final output",
+        type=str2bool,
+        default=False,
+    )
+    parser.add_argument(
         "--interaction",
         help="name of interaction block",
         type=str,

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -470,6 +470,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default="none",
     )
     parser.add_argument(
+        "--disallow_random_padding_pt",
+        help="do not allow random padding of the configurations to match the number of samples",
+        action="store_false",
+        dest="allow_random_padding",
+    )
+    parser.add_argument(
         "--pt_train_file",
         help="Training set file for the pretrained head",
         type=str,

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -172,8 +172,8 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--apply_cutoff",
         help="apply cutoff to the radial basis functions before MLP",
-        action="store_true",
-        default=False,
+        type=str2bool,
+        default=True,
     )
     parser.add_argument(
         "--interaction",

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -224,7 +224,7 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         "--use_reduced_cg",
         help="use reduced generalized Clebsch-Gordan coefficients",
         type=str2bool,
-        default=True,
+        default=False,
     )
     parser.add_argument(
         "--use_so3",

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -230,6 +230,9 @@ def _build_model(
             radial_type=args.radial_type,
             heads=heads,
             embedding_specs=args.embedding_specs,
+            use_embedding_readout=args.use_embedding_readout,
+            use_last_readout_only=args.use_last_readout_only,
+            use_agnostic_product=args.use_agnostic_product,
         )
     if args.model == "ScaleShiftMACE":
         return modules.ScaleShiftMACE(
@@ -246,6 +249,9 @@ def _build_model(
             radial_type=args.radial_type,
             heads=heads,
             embedding_specs=args.embedding_specs,
+            use_embedding_readout=args.use_embedding_readout,
+            use_last_readout_only=args.use_last_readout_only,
+            use_agnostic_product=args.use_agnostic_product,
         )
     if args.model == "FoundationMACE":
         return modules.ScaleShiftMACE(**model_config_foundation)

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -305,7 +305,7 @@ def generate_pseudolabels_for_configs(
 
                 updated_configs.append(config_copy)
 
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             logging.error(
                 f"Error generating pseudolabels for batch {i//batch_size + 1}: {str(e)}"
             )
@@ -411,6 +411,6 @@ def apply_pseudolabels_to_pt_head_configs(
 
         return True
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
         logging.error(f"Error applying pseudolabels: {str(e)}")
         return False

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -182,6 +182,7 @@ def assemble_mp_data(
             filtering_type=FilteringType(args.filter_type_pt),
             subselect=SubselectType(args.subselect_pt),
             default_dtype=args.default_dtype,
+            allow_random_padding=args.allow_random_padding,
         )
         select_samples(settings)
         head_config_pt.train_file = [output]
@@ -196,6 +197,7 @@ def assemble_mp_data(
             key_specification=head_config_pt.key_specification,
             head_name="pt_head",
             keep_isolated_atoms=args.keep_isolated_atoms,
+            no_data_ok=(args.pseudolabel_replay and args.multiheads_finetuning and head_config_pt.head_name == "pt_head"),
         )
         return collections_mp
     except Exception as exc:

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -292,9 +292,7 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
             if hasattr(model, "use_last_readout_only")
             else False
         ),
-        "use_embedding_readout": (
-            True if hasattr(model, "embedding_readout") else False
-        ),
+        "use_embedding_readout": (hasattr(model, "embedding_readout")),
         "readout_cls": model.readouts[-1].__class__,
         "cueq_config": model.cueq_config if hasattr(model, "cueq_config") else None,
         "atomic_energies": model.atomic_energies_fn.atomic_energies.cpu().numpy(),

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -287,6 +287,15 @@ def extract_config_mace_model(model: torch.nn.Module) -> Dict[str, Any]:
             if hasattr(model, "use_agnostic_product")
             else False
         ),
+        "use_last_readout_only": (
+            model.use_last_readout_only
+            if hasattr(model, "use_last_readout_only")
+            else False
+        ),
+        "use_embedding_readout": (
+            True if hasattr(model, "embedding_readout") else False
+        ),
+        "readout_cls": model.readouts[-1].__class__,
         "cueq_config": model.cueq_config if hasattr(model, "cueq_config") else None,
         "atomic_energies": model.atomic_energies_fn.atomic_energies.cpu().numpy(),
         "avg_num_neighbors": model.interactions[0].avg_num_neighbors,
@@ -745,6 +754,22 @@ def get_params_options(
         amsgrad=args.amsgrad,
         betas=(args.beta, 0.999),
     )
+    if hasattr(model, "joint_embedding") and model.joint_embedding is not None:
+        param_options["params"].append(
+            {
+                "name": "joint_embedding",
+                "params": model.joint_embedding.parameters(),
+                "weight_decay": 0.0,
+            }
+        )
+    if hasattr(model, "embedding_readout") and model.embedding_readout is not None:
+        param_options["params"].append(
+            {
+                "name": "embedding_readout",
+                "params": model.embedding_readout.parameters(),
+                "weight_decay": 0.0,
+            }
+        )
     return param_options
 
 

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -53,6 +53,7 @@ def get_dataset_from_xyz(
     seed: int = 1234,
     keep_isolated_atoms: bool = False,
     head_name: str = "Default",
+    no_data_ok: bool = False,
 ) -> Tuple[SubsetCollection, Optional[Dict[int, float]]]:
     """
     Load training, validation, and test datasets from xyz files.
@@ -68,6 +69,7 @@ def get_dataset_from_xyz(
         seed: Random seed for train/validation split
         keep_isolated_atoms: Whether to keep isolated atoms in the dataset
         head_name: Name of the head for multi-head models
+        no_data_ok: accept files that have no energy/force/stress data
 
     Returns:
         Tuple containing:
@@ -106,6 +108,7 @@ def get_dataset_from_xyz(
             extract_atomic_energies=True,  # Extract from all files to average
             keep_isolated_atoms=keep_isolated_atoms,
             head_name=head_name,
+            no_data_ok=no_data_ok,
         )
         all_train_configs.extend(train_configs)
 

--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -66,6 +66,11 @@ def init_device(device_str: str) -> torch.device:
         return torch.device("mps")
     if device_str == "xpu":
         torch.xpu.is_available()
+        devices = torch.xpu.device_count()
+        is_available = devices > 0
+        assert is_available, logging.info("No XPU backend is available")
+        torch.xpu.memory_stats()
+        logging.info("Using XPU GPU acceleration")
         return torch.device("xpu")
 
     logging.info("Using CPU")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ ignore-paths = [
 ]
 
 [tool.pylint.FORMAT]
-max-module-lines = 1500
+max-module-lines = 2000

--- a/tests/test_cueq_oeq.py
+++ b/tests/test_cueq_oeq.py
@@ -152,24 +152,12 @@ class BackendTestBase:
 
         # Check outputs match for both conversions
 
-        torch.testing.assert_close(
-            out_e3nn["energy"], out_backend["energy"], atol=tol, rtol=tol
-        )
-        torch.testing.assert_close(
-            out_backend["energy"], out_e3nn_back["energy"], atol=tol, rtol=tol
-        )
-        torch.testing.assert_close(
-            out_e3nn["forces"], out_backend["forces"], atol=tol, rtol=tol
-        )
-        torch.testing.assert_close(
-            out_backend["forces"], out_e3nn_back["forces"], atol=tol, rtol=tol
-        )
-        torch.testing.assert_close(
-            out_e3nn["stress"], out_backend["stress"], atol=tol, rtol=tol
-        )
-        torch.testing.assert_close(
-            out_backend["stress"], out_e3nn_back["stress"], atol=tol, rtol=tol
-        )
+        torch.testing.assert_close(out_e3nn["energy"], out_backend["energy"])
+        torch.testing.assert_close(out_backend["energy"], out_e3nn_back["energy"])
+        torch.testing.assert_close(out_e3nn["forces"], out_backend["forces"])
+        torch.testing.assert_close(out_backend["forces"], out_e3nn_back["forces"])
+        torch.testing.assert_close(out_e3nn["stress"], out_backend["stress"])
+        torch.testing.assert_close(out_backend["stress"], out_e3nn_back["stress"])
 
         # Test backward pass equivalence
         loss_e3nn = out_e3nn["energy"].sum()

--- a/tests/test_cueq_oeq.py
+++ b/tests/test_cueq_oeq.py
@@ -152,7 +152,6 @@ class BackendTestBase:
 
         # Check outputs match for both conversions
 
-        tol = 1e-4 if default_dtype == torch.float32 else 1e-8
         torch.testing.assert_close(
             out_e3nn["energy"], out_backend["energy"], atol=tol, rtol=tol
         )
@@ -180,6 +179,8 @@ class BackendTestBase:
         loss_e3nn.backward()
         loss_backend.backward()
         loss_e3nn_back.backward()
+
+        tol = 1e-4 if default_dtype == torch.float32 else 1e-8
 
         def print_gradient_diff(name1, p1, name2, p2, conv_type):
             if p1.grad is not None and p1.grad.shape == p2.grad.shape:

--- a/tests/test_run_train_allkeys.py
+++ b/tests/test_run_train_allkeys.py
@@ -46,6 +46,7 @@ _mace_params = {
     "num_radial_basis": 10,
     "r_max": 6.0,
     "default_dtype": "float64",
+    "use_reduced_cg": False,
 }
 
 


### PR DESCRIPTION
Make it possible for parsing of data files to ignore entirely missing energy/force/stress data, e.g. when pseudolabels will be used so only geometry is important.

Use this functionality when parsing the pt head MP data in mace_run_train.

Make allowing random padding default if more configs are requested than number selected by combinations/inclusive/exclusive. Also change misleadingly named --allow_random_padding in `fine_tuning_select.py` to `--disallow_random_padding`, and add the same flag to `run_train.py` (should perhaps use the same code to add parser flags to both, but would need some refactoring).

closes #1089
closes #1090