### PR TITLE
use the one available head if that's all there is, regardless of name

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -237,6 +237,8 @@ class MACECalculator(Calculator):
         kwarg_head = kwargs.get("head", None)
         if kwarg_head is not None:
             self.head = kwarg_head
+        elif len(self.available_heads) == 1:
+            self.head = self.available_heads[0]
         else:
             self.head = [
                 head for head in self.available_heads if head.lower() == "default"


### PR DESCRIPTION
automatically use the head if one is all that's all that's available, even if it's not named "default"