### PR TITLE
don't apply user's --atomic_numbers to pt_head with doing multihead

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -226,6 +226,10 @@ def run(args) -> None:
     for head, head_args in args.heads.items():
         logging.info(f"=============    Processing head {head}     ===========")
         head_config = dict_head_to_dataclass(head_args, head, args)
+        # don't apply user's --atomic_numbers to pt_head, that info needs to come
+        # from the actual pt data
+        if args.multiheads_finetuning and head_config.head_name == "pt_head":
+            head_config.atomic_numbers = None
 
         # Handle train_file and valid_file - normalize to lists
         if hasattr(head_config, "train_file") and head_config.train_file is not None:


### PR DESCRIPTION
Currenly `run_train.py` applies the user's `--atomic_numbers` to select the atomic numbers that will be supposed in all heads.  This wipes that setting for the "pt_head" if multihead replay is active, so that the replay head gets its atomic numbers from the set included in its fitting data, which could include other elements, e.g. if random padding is used to add more configurations beyond the element-specific filtering to reach the request number `--num_samples_pt`. 

closes #1097