### PR TITLE
Fix test of real to pretrain data ratio for repeating configs

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -352,16 +352,16 @@ def run(args) -> None:
         assert head_config_pt is not None, "Pretraining head not found"
         if all_ase_readable:
             ratio_pt_ft = (size_collections_train - len(head_config_pt.collections.train)) / len(head_config_pt.collections.train)
-            if ratio_pt_ft < 0.1:
+            if ratio_pt_ft < args.real_pt_data_ratio_threshold:
                 logging.warning(
                     f"Ratio of the number of configurations in the training set and the in the pt_train_file is {ratio_pt_ft}, "
-                    f"increasing the number of configurations in the fine-tuning heads by {int(0.1 / ratio_pt_ft)}"
+                    f"increasing the number of configurations in the fine-tuning heads by {int(args.real_pt_data_ratio_threshold / ratio_pt_ft)}"
                 )
                 for head_config in head_configs:
                     if head_config.head_name == "pt_head":
                         continue
                     head_config.collections.train += (
-                        head_config.collections.train * int(0.1 / ratio_pt_ft)
+                        head_config.collections.train * int(args.real_pt_data_ratio_threshold / ratio_pt_ft)
                     )
             logging.info(
                 f"Total number of configurations in pretraining: train={len(head_config_pt.collections.train)}, valid={len(head_config_pt.collections.valid)}"

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -351,7 +351,7 @@ def run(args) -> None:
         head_config_pt = next(head_config_pt, None)
         assert head_config_pt is not None, "Pretraining head not found"
         if all_ase_readable:
-            ratio_pt_ft = size_collections_train / len(head_config_pt.collections.train)
+            ratio_pt_ft = (size_collections_train - len(head_config_pt.collections.train)) / len(head_config_pt.collections.train)
             if ratio_pt_ft < 0.1:
                 logging.warning(
                     f"Ratio of the number of configurations in the training set and the in the pt_train_file is {ratio_pt_ft}, "

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -234,9 +234,9 @@ def load_from_xyz(
         key_specification.info_keys["energy"] = "REF_energy"
         for atoms in atoms_list:
             try:
-                print("OK")
+                # print("OK")
                 atoms.info["REF_energy"] = atoms.get_potential_energy()
-                print("atoms.info['REF_energy']:", atoms.info["REF_energy"])
+                # print("atoms.info['REF_energy']:", atoms.info["REF_energy"])
             except Exception as e:  # pylint: disable=W0703
                 logging.error(f"Failed to extract energy: {e}")
                 atoms.info["REF_energy"] = None

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -461,6 +461,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=1.0,
     )
     parser.add_argument(
+        "--real_pt_data_ratio_threshold",
+        help="threshold of real data to replay data below which real data (sum over all real heads) is duplicated",
+        type=float,
+        default=0.1,
+    )
+    parser.add_argument(
         "--num_samples_pt",
         help="Number of samples in the pretrained head",
         type=int,


### PR DESCRIPTION
Correct numerator in ratio of real to pretrain configs when checking ratio to see if duplicating real configs is needed.

Also (incidentally) remove unneeded debugging prints.

closes #1108 