### PR TITLE
Hotfix: Solving weight shape error for polarizability_weights

### DIFF
--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -239,9 +239,17 @@ class AtomicData(torch_geometric.data.Data):
             )
             if config.property_weights.get("polarizability") is not None
             else torch.tensor(
-                1.0, dtype=torch.get_default_dtype()
-            )  ### Might need to be updated
+                [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+                dtype=torch.get_default_dtype(),
+            )
         )
+        if len(polarizability_weight.shape) == 0:
+            polarizability_weight = polarizability_weight * torch.tensor(
+                [[[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]],
+                dtype=torch.get_default_dtype(),
+            )
+        elif len(polarizability_weight.shape) == 2:
+            polarizability_weight = polarizability_weight.unsqueeze(0)
         forces = (
             torch.tensor(
                 config.properties.get("forces"), dtype=torch.get_default_dtype()

--- a/mace/tools/utils.py
+++ b/mace/tools/utils.py
@@ -197,8 +197,8 @@ def filter_nonzero_weight(
         weight = weight.view(*view).repeat(*repeats)
         if spread_quantity_vector:
             quantity_weight = quantity_weight.view(*view).repeat(*repeats)
-
     filtered_q = quantity[weight * quantity_weight > 0]
+
     if len(filtered_q) == 0:
         quantity_l.pop()
         return 0.0


### PR DESCRIPTION
There was a small bug in the training of the polarizability, where the dimensions of the polarizability_weight had not been properly added with regard to some other updates made in the version update. Unfortunately, this bug prevented the model from training at all.

@ilyes319 I would highly recommend merging this directly into the main branch; otherwise, the training on polarizabilities won't be supported at all