### PR TITLE
fix parser default values

### DIFF
--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -329,14 +329,14 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--compute_polarizability",
         help="Select True to compute polarizability",
-        action="store_true",
-        default=str2bool,
+        type=str2bool,
+        default=False,
     )
     parser.add_argument(
         "--compute_atomic_dipole",
         help="Select True to compute dipoles",
-        action="store_true",
-        default=str2bool,
+        type=str2bool,
+        default=False,
     )
 
     # Dataset


### PR DESCRIPTION
Fixes default argparser values for `--compute-polarizability` and `--compute_atomic_dipole`. Previous values raised ValueErrors when trying to train while using weights and biases.