### PR TITLE
Fix bug in stage-two evaluation with multi-gpu

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -944,6 +944,10 @@ def run(args) -> None:
         )
         model.to(device)
         if args.distributed:
+            # re-enable gradients for distributed model for evaluation of stage-two model
+            # after param.requires_grad = False was called before evaluating stage-one model
+            for param in model.parameters():
+                param.requires_grad = True
             distributed_model = DDP(model, device_ids=[local_rank])
         model_to_evaluate = model if not args.distributed else distributed_model
         if swa_eval:


### PR DESCRIPTION
At the end of the training script `mace/cli/run_train.py` an error occurs when evaluating metrics on stage-two model in the distributed (multi-GPU) environment, preventing also to save the best stage-two model.


Basically, in the for loop
`for swa_eval in swas:`
first the stage-one model is evaluated, and before calling `create_error_table`, all model parameters are set to not require gradients:
```
        for param in model.parameters():
            param.requires_grad = False
```
Then, in the second iteration of the for loop to test the stage-two model, torch DDP raises 
`RuntimeError: DistributedDataParallel is not needed when a module doesn't have any parameter that requires a gradient` (see traceback below):

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/leonardo/pub/userexternal/epedrett/.venv/mace/bin/mace_run_train", line 7, in <module>
[rank0]:     sys.exit(main())
[rank0]:              ^^^^^^
[rank0]:   File "/leonardo/pub/userexternal/epedrett/.venv/mace/lib/python3.11/site-packages/mace/cli/run_train.py", line 77, in main
[rank0]:     run(args)
[rank0]:   File "/leonardo/pub/userexternal/epedrett/.venv/mace/lib/python3.11/site-packages/mace/cli/run_train.py", line 947, in run
[rank0]:     distributed_model = DDP(model, device_ids=[local_rank])
[rank0]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/leonardo/pub/userexternal/epedrett/.venv/mace/lib/python3.11/site-packages/torch/nn/parallel/distributed.py", line 708, in __init__
[rank0]:     self._log_and_throw(
[rank0]:   File "/leonardo/pub/userexternal/epedrett/.venv/mace/lib/python3.11/site-packages/torch/nn/parallel/distributed.py", line 1130, in _log_and_throw
[rank0]:     raise err_type(err_msg)
[rank0]: RuntimeError: DistributedDataParallel is not needed when a module doesn't have any parameter that requires a gradient.
```
Here I just re-set `param.requires_grad` to true before creating `distributed_model = DDP(model, device_ids=[local_rank])`


Edit:
after a bit of tinkering, I found that this error did not arise previously in another environment thay I had with mace 0.3.13 (I'm not 100% sure if it's due to mace version or some changes in other dependencies, but I have the exact same versions of torch (2.5.1) and torchmetrics and cuequivariance, so it's very likely from mace itself). 
In that case, somewhere during the execution of `create_error_table` all the `requires_grad` values were re-set to true, and so when loading DDP for the second time there was no issue.
Anyway, I believe that it would be better not to rely on an external function to change the status of the model params, and this fix should be more robust.