### PR TITLE
Update e3nn version pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     torch>=1.12
-    e3nn==0.4.4
+    e3nn>=0.5.0
     numpy
     opt_einsum
     ase


### PR DESCRIPTION
e3nn has been moving forward with new functionality for a while. All of the other dependencies I want to use pymace with have moved forward to the new version. This PR is to see if newer e3nn passes automated testing. The version number is being set as a minimum pin to allow for more flexible solutions.

Fixes #555