### PR TITLE
Fix: Create model directory before saving model files

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -974,6 +974,7 @@ def run(args) -> None:
                     convert_to_json_format(extract_config_mace_model(model))
                 ),
             }
+            os.makedirs(args.model_dir, exist_ok=True)
             if swa_eval:
                 torch.save(
                     model_to_save, Path(args.model_dir) / (args.name + "_stagetwo.model")


### PR DESCRIPTION
**Problem:**
The current code attempts to save model files to `args.model_dir` without ensuring the directory exists, which causes errors when the model directory differs from the working directory (by default, `if args.model_dir is None: args.model_dir = args.work_dir` in `mace/tools/arg_parser_tools.py`).
This issue wasn't discovered earlier because `args.model_dir` defaults to the working directory, which typically already exists.

**Solution:**
Added `os.makedirs(args.model_dir, exist_ok=True)` in `mace/cli/run_train.py` to ensure the model directory is created before attempting to save files.

**Testing:**
- Verified the fix works correctly with a custom model directory
- Confirmed the original error occurs without this fix when using a non-existent model directory
- No impact on existing functionality when the model directory already exists
- No impact on the other functions since this is a minor fix