### PR TITLE
Fix: Old AtomicDielectricMACE models trained only on Dipoles were not properly supported.

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -430,8 +430,13 @@ class MACECalculator(Calculator):
                 ret_tensors["dipole"][i] = out["dipole"].detach()
             if self.model_type == "DipolePolarizabilityMACE":
                 ret_tensors["charges"][i] = out["charges"].detach()
-                ret_tensors["polarizability"][i] = out["polarizability"].detach()
-                ret_tensors["polarizability_sh"][i] = out["polarizability_sh"].detach()
+                if out["polarizability"] is not None:
+                    ret_tensors["polarizability"][i] = out["polarizability"].detach()
+                    ret_tensors["polarizability_sh"][i] = out["polarizability_sh"].detach()
+                else:
+                    print("This model is not trained to predict polarizability, it will be only zeros")
+                    ret_tensors["polarizability"][i] = torch.zeros(3, 3, device=self.device)
+                    ret_tensors["polarizability_sh"][i] = torch.zeros(1, 6, device=self.device)
             if self.model_type in ["MACE"]:
                 if out["atomic_stresses"] is not None:
                     ret_tensors.setdefault("atomic_stresses", []).append(

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -1070,9 +1070,11 @@ class AtomicDielectricMACE(torch.nn.Module):
                 polarizabilities.append(node_polarizability)
                 dipoles.append(node_dipoles)
             else:
-                raise ValueError(
-                    "Polarizability is not used in this model, but it is required for the AtomicDielectricMACE."
-                )
+                node_dipoles = node_out[:, 1:4]
+                dipoles.append(node_dipoles)
+                #raise ValueError(
+                #    "Polarizability is not used in this model, but it is required for the AtomicDielectricMACE."
+                #)
         contributions_dipoles = torch.stack(
             dipoles, dim=-1
         )  # [n_nodes,3,n_contributions]


### PR DESCRIPTION
Now, `AtomicDielectricMACE` models from legacy versions of the code are also supported. For example, models from [https://github.com/venkatkapil24/MACE-OFF-mu-models](https://github.com/venkatkapil24/MACE-OFF-mu-models). 

Credits to @cecicxy, who reported the problem in this [issue](https://github.com/venkatkapil24/MACE-OFF-mu-models/issues/2) .