### PR TITLE
Fix return types of foundation checkpoint loaders for `return_raw_model=False`

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -1,7 +1,7 @@
 import os
 import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, ParamSpec, TypeVar, Union, overload
+from typing import Any, Literal, Optional, Union, overload
 
 import torch
 from ase import units


### PR DESCRIPTION
using `typing.overload` to change return type from `MaceCalculator` to `torch.nn.Module` of foundation model load functions when `return_raw_model=True`

this is causing 50+ type errors in one my codebases which can only be silenced by lots of ugly `typing.cast`s. would be much nicer to fix it here for everyone