### PR TITLE
Bugfix compile test

### DIFF
--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -148,7 +148,7 @@ def test_eager_benchmark(
 def test_compile_benchmark(benchmark, compile_mode, enable_amp, enable_cueq):
     with tools.torch_tools.default_dtype(torch.float32):
         batch = create_batch("cuda")
-        batch["positions"].requires_grad_(True)
+        batch["positions"].requires_grad_(True) # since compile_mode is not None
         torch.compiler.reset()
         model = mace_compile.prepare(create_mace)("cuda", enable_cueq=enable_cueq)
         model = torch.compile(model, mode=compile_mode)


### PR DESCRIPTION
Before this change, when running `test_compile` I get many errors like for `test_compile_benchmark`:
```
E           torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <function grad at 0x14b0722193a0>(*(), **{'outputs': [FakeTensor(..., device='cuda:0', size=(1,), grad_fn=<Error>)], 'inputs': [FakeTensor(..., device='cuda:0', size=(64, 3))], 'grad_outputs': [FakeTensor(..., device='cuda:0', size=(1,))], 'retain_graph': True, 'create_graph': True, 'allow_unused': True}): got RuntimeError('One of the differentiated Tensors does not require grad')
E           
E           from user code:
E              File "/raven/u/twarford/dev/mace/mace/modules/utils.py", line 195, in get_outputs
E               compute_forces(
E             File "/raven/u/twarford/dev/mace/mace/modules/utils.py", line 26, in compute_forces
E               gradient = torch.autograd.grad(
E           
E           Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

Notice: `RuntimeError('One of the differentiated Tensors does not require grad')`.

This is fixed with the change made.