### PR TITLE
support for newer versions of pandas in visualize_train

### DIFF
--- a/mace/cli/visualise_train.py
+++ b/mace/cli/visualise_train.py
@@ -226,8 +226,14 @@ def plot_epoch_dependence(
         .reset_index()
     )
     valid_data = valid_data[valid_data["head"] == head]
+
+    agg_columns = data[data["mode"] == "opt"].columns[
+        data[data["mode"] == "opt"].notna().any()
+    ]
     train_data = (
-        data[data["mode"] == "opt"]
+        data[data["mode"] == "opt"][
+            agg_columns
+        ]  # For Pandas > v1.5 compatibility, do not evaluate NaN-columns
         .groupby(["mode", "epoch"])
         .agg(["mean", "std"])
         .reset_index()


### PR DESCRIPTION
With newer versions of pandas (>v1.5~), the plotting fails with:
--
Plotting failed: dtype 'str' does not support operation 'mean'
--

This is because newer versions of pandas no longer ignores columns with only NaN values, which is the case for mae and other evaluation metrics in the train data.

This change forces the aggregation in the train dataset to only be done on the metrics that are used in the plotting.
