### PR TITLE
add use_edge_irreps_first arg

### DIFF
--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -651,6 +651,7 @@ class AtomicDipolesMACE(torch.nn.Module):
         cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         edge_irreps: Optional[o3.Irreps] = None,  # pylint: disable=unused-argument
+        use_edge_irreps_first: bool = False,  # pylint: disable=unused-argument
     ):
         super().__init__()
         self.register_buffer(
@@ -865,6 +866,7 @@ class AtomicDielectricMACE(torch.nn.Module):
         cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         edge_irreps: Optional[o3.Irreps] = None,  # pylint: disable=unused-argument
+        use_edge_irreps_first: bool = False,  # pylint: disable=unused-argument
         dipole_only: Optional[bool] = True,  # pylint: disable=unused-argument
         use_polarizability: Optional[bool] = True,  # pylint: disable=unused-argument
         means_stds: Optional[Dict[str, torch.Tensor]] = None,  # pylint: disable=W0613
@@ -1192,6 +1194,7 @@ class EnergyDipolesMACE(torch.nn.Module):
         cueq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         oeq_config: Optional[Dict[str, Any]] = None,  # pylint: disable=unused-argument
         edge_irreps: Optional[o3.Irreps] = None,  # pylint: disable=unused-argument
+        use_edge_irreps_first: bool = False,  # pylint: disable=unused-argument
     ):
         super().__init__()
         self.register_buffer(

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -276,6 +276,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
     )
+    parser.add_argument(
+        "--use_edge_irreps_first",
+        help="use edge irreps in the first interaction block",
+        type=str2bool,
+        default=False,
+    )
     # add option to specify irreps by channel number and max L
     parser.add_argument(
         "--num_channels",

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -191,6 +191,7 @@ def configure_model(
             atomic_numbers=z_table.zs,
             use_reduced_cg=args.use_reduced_cg,
             use_so3=args.use_so3,
+            use_edge_irreps_first=args.use_edge_irreps_first,
             cueq_config=cueq_config,
         )
         model_config_foundation = None


### PR DESCRIPTION
Hello,

In https://github.com/ACEsuit/mace/pull/1267, `use_edge_irreps_first` was added to allow control over the edge irreps in the first interaction block. There currently isn't a way to set this using the training interface.

This PR adds an arg to the training CLI so that this can be set by the user.