### PR TITLE
permit first block to be non-linear in 'MACE'-type models

### DIFF
--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -244,6 +244,7 @@ def _build_model(
         if args.interaction_first not in [
             "RealAgnosticInteractionBlock",
             "RealAgnosticDensityInteractionBlock",
+            "RealAgnosticResidualNonLinearInteractionBlock",
         ]:
             args.interaction_first = "RealAgnosticInteractionBlock"
         return modules.ScaleShiftMACE(


### PR DESCRIPTION
Hello,

This PR adds the non-linear interaction block to the list of permitted blocks for the first layer of a `"MACE"` type model.