### PR TITLE
Fix non-periodic cell construction in `get_neighborhood`

### DIFF
--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -24,16 +24,15 @@ def get_neighborhood(
     pbc_y = pbc[1]
     pbc_z = pbc[2]
     identity = np.identity(3, dtype=float)
-    max_positions = np.max(np.absolute(positions)) + 1
-    # Extend cell in non-periodic directions
-    # For models with more than 5 layers, the multiplicative constant needs to be increased.
-    # temp_cell = np.copy(cell)
+    max_positions = np.max(positions, axis=0) - np.min(positions, axis=0)
+    padding = 1  # 1 angstrom padding
+
     if not pbc_x:
-        cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
+        cell[0, :] = (max_positions[0] + cutoff + padding) * identity[0, :]
     if not pbc_y:
-        cell[1, :] = max_positions * 5 * cutoff * identity[1, :]
+        cell[1, :] = (max_positions[1] + cutoff + padding) * identity[1, :]
     if not pbc_z:
-        cell[2, :] = max_positions * 5 * cutoff * identity[2, :]
+        cell[2, :] = (max_positions[2] + cutoff + padding) * identity[2, :]
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",


### PR DESCRIPTION

  When `pbc=False`, the artificial cell for the neighbor list was computed as:                                                                                                      
   
  ```python
  max_positions * 5 * cutoff * identity[i, :]                                                                                                                                     
 ```

  - This is multiplicative in system size and cutoff, producing unnecessarily large cells for large molecules/clusters (e.g., a 100 Å system with 6 Å cutoff gives ~3000 Å cells).  This can cause box **skew errors** and excessive memory usage (**cuda out of memory**) in the electrostatic models. 
  - The hard coded factor of 5 (tied to MACE max model layers) is irrelevant as the neighbor list operates on a single cutoff, not the model's receptive field. Instead we use a padding of cutoff + 1A. 


  **Fix: Use an additive, per-dimension formula:**
```python 
  max_positions = np.max(positions, axis=0) - np.min(positions, axis=0)
  cell[i, :] = (max_positions[i] + cutoff + padding) * identity[i, :]
```



  ### Minimal failure example 
```python
at1 = Atoms('H3O', positions=[[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], cell=None, pbc=False)
at = at1.copy()
at.set_positions(at1.get_positions() + [5000,0,0])
out = neighborhood.get_neighborhood(
    positions= at.get_positions(),
    cell= at.get_cell(),
    pbc= at.get_pbc(),
    cutoff= 5.0,
)
print(out[-1])

```