### PR TITLE
torch.compile with reduce-overhead + GatedNonLinearity Reimplementation

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -161,3 +161,25 @@ jobs:
           pytest -v tests/test_calculator.py::test_mace_polar_constructor
           pytest -v tests/test_models.py::test_dipole_polar_mace
           pytest -v tests/test_foundations.py -k polar
+
+  pytest-torchsim:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install requirements alongside torchsim
+        run: |
+          pip install -U pip
+          pip install ".[dev,torchsim]"
+
+      - name: Log installed environment alongside torchsim
+        run: |
+          python3 -m pip freeze
+
+      - name: Run torchsim tests
+        run: |
+          pytest -v tests/test_torchsim.py

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -11,7 +11,6 @@ from mace.tools.utils import get_cache_dir
 
 from .mace import MACECalculator
 
-
 _DOWNLOAD_TIMEOUT = 120  # seconds – socket-level read timeout for model downloads
 
 
@@ -41,6 +40,7 @@ def _urlretrieve_with_timeout(url, filename, timeout=_DOWNLOAD_TIMEOUT):
     if total > 0:
         print()  # newline after progress
     return filename, info
+
 
 module_dir = os.path.dirname(__file__)
 local_model_path = os.path.join(
@@ -123,9 +123,7 @@ def download_mace_mp_checkpoint(model: Optional[Union[str, Path]] = None) -> str
     if not os.path.isfile(cached_model_path):
         os.makedirs(cache_dir, exist_ok=True)
         print(f"Downloading MACE model from {checkpoint_url!r}")
-        _, http_msg = _urlretrieve_with_timeout(
-            checkpoint_url, cached_model_path
-        )
+        _, http_msg = _urlretrieve_with_timeout(checkpoint_url, cached_model_path)
         if "Content-Type: text/html" in str(http_msg):
             raise RuntimeError(
                 f"Model download failed, please check the URL {checkpoint_url}"
@@ -167,9 +165,7 @@ def download_mace_polar_checkpoint(model: Union[str, Path]) -> str:
     if not os.path.isfile(cached_model_path):
         os.makedirs(cache_dir, exist_ok=True)
         print(f"Downloading MACE-Polar model from {checkpoint_url!r}")
-        _, http_msg = _urlretrieve_with_timeout(
-            checkpoint_url, cached_model_path
-        )
+        _, http_msg = _urlretrieve_with_timeout(checkpoint_url, cached_model_path)
         if "Content-Type: text/html" in str(http_msg):
             raise RuntimeError(
                 f"Model download failed, please check the URL {checkpoint_url}"

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -5,12 +5,13 @@
 ###########################################################################################
 
 import logging
+import time
 
 # pylint: disable=wrong-import-position
 import os
 from glob import glob
 from pathlib import Path
-from typing import List, Union
+from typing import Dict, List, Optional, Union
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
 
@@ -23,8 +24,13 @@ from e3nn import o3
 from mace import data as mace_data
 from mace.modules.utils import extract_invariant
 from mace.tools import torch_geometric, torch_tools, utils
-from mace.tools.compile import prepare
+from mace.tools.compile import prepare, disable_e3nn_codegen, simplify
 from mace.tools.scripts_utils import extract_model
+
+try:
+    import torch._dynamo as dynamo
+except ImportError:
+    dynamo = None
 
 try:
     from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
@@ -43,11 +49,26 @@ except (ImportError, ModuleNotFoundError):
     run_e3nn_to_oeq = None
 
 try:
+    from mace.cli.convert_e3nn_hybrid import run as run_e3nn_to_hybrid
+
+    HYBRID_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    HYBRID_AVAILABLE = False
+    run_e3nn_to_hybrid = None
+
+try:
     import intel_extension_for_pytorch as ipex
 
     has_ipex = True
 except ImportError:
     has_ipex = False
+
+_EDGE_PAD_MULTIPLE = 64
+_EDGE_PAD_HEADROOM = 1.25
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
 
 
 def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
@@ -62,18 +83,22 @@ def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
 
 class MACECalculator(Calculator):
     """MACE ASE Calculator
-    args:
-        model_paths: str, path to model or models if a committee is produced
-                to make a committee use a wild card notation like mace_*.model
-        device: str, device to run on (cuda or cpu or xpu)
-        energy_units_to_eV: float, conversion factor from model energy units to eV
-        length_units_to_A: float, conversion factor from model length units to Angstroms
-        default_dtype: str, default dtype of model
-        charges_key: str, Array field of atoms object where atomic charges are stored
-        model_type: str, type of model to load
-                    Options: [MACE, DipoleMACE, EnergyDipoleMACE]
 
-    Dipoles are returned in units of Debye
+    Supports accelerated backends (cueq, openequivariance, hybrid) and
+    torch.compile with automatic graph padding to avoid recompilation
+    during geometry relaxation / MD.
+
+    Args:
+        model_paths: path(s) to model file(s); supports wildcards for committees
+        models: pre-loaded model(s) as an alternative to model_paths
+        device: 'cuda', 'cpu', or 'xpu'
+        compile_mode: torch.compile mode ('default', 'reduce-overhead', etc.)
+                      or None to disable compilation
+        enable_cueq: use cuequivariance for symmetric contractions / linear
+        enable_oeq: use openequivariance for channelwise tensor product
+        pad_num_atoms: fixed atom count for padding (0 = auto-estimate on first call)
+        pad_num_edges: fixed edge count for padding (0 = auto-estimate on first call)
+        warmup: if True, run one dummy forward pass after init to trigger compilation
     """
 
     def __init__(
@@ -92,28 +117,33 @@ class MACECalculator(Calculator):
         fullgraph=True,
         enable_cueq=False,
         enable_oeq=False,
+        pad_num_atoms: int = 0,
+        pad_num_edges: int = 0,
+        warmup: bool = False,
         **kwargs,
     ):
         Calculator.__init__(self, **kwargs)
-        if enable_cueq or enable_oeq:
+
+        self._enable_cueq = enable_cueq
+        self._enable_oeq = enable_oeq
+        self._uses_accelerated_backend = enable_cueq or enable_oeq
+
+        if self._uses_accelerated_backend:
             assert model_type in [
                 "MACE",
                 "PolarMACE",
-            ], "CuEq only supports MACE and PolarMACE models"
-            if compile_mode is not None:
-                logging.warning(
-                    "CuEq or Oeq does not support torch.compile, setting compile_mode to None"
-                )
-                compile_mode = None
+            ], "CuEq/OEq only supports MACE and PolarMACE models"
         if enable_cueq and enable_oeq:
-            raise ValueError(
-                "CuEq and OEq cannot be used together, please choose one of them"
-            )
-        if enable_cueq and not CUEQQ_AVAILABLE:
+            if not HYBRID_AVAILABLE:
+                raise ImportError(
+                    "Hybrid cueq+oeq mode requires both cuequivariance and "
+                    "openequivariance to be installed"
+                )
+        elif enable_cueq and not CUEQQ_AVAILABLE:
             raise ImportError(
                 "cuequivariance is not installed so CuEq acceleration cannot be used"
             )
-        if enable_oeq and not OEQ_AVAILABLE:
+        elif enable_oeq and not OEQ_AVAILABLE:
             raise ImportError(
                 "openequivariance is not installed so OEq acceleration cannot be used"
             )
@@ -160,7 +190,6 @@ class MACECalculator(Calculator):
                 f"Give a valid model_type: [MACE, PolarMACE, DipoleMACE, DipolePolarizabilityMACE, EnergyDipoleMACE], {model_type} not supported"
             )
 
-        # superclass constructor initializes self.implemented_properties to an empty list
         if model_type in ["MACE", "EnergyDipoleMACE", "PolarMACE"]:
             self.implemented_properties.extend(
                 [
@@ -186,14 +215,12 @@ class MACECalculator(Calculator):
                 ]
             )
 
+        # ── Load models ──────────────────────────────────────────────────
         if model_paths is not None:
             if isinstance(model_paths, str):
-                # Find all models that satisfy the wildcard (e.g. mace_model_*.pt)
                 model_paths_glob = glob(model_paths)
-
                 if len(model_paths_glob) == 0:
                     raise ValueError(f"Couldn't find MACE model files: {model_paths}")
-
                 model_paths = model_paths_glob
             elif isinstance(model_paths, Path):
                 model_paths = [model_paths]
@@ -201,20 +228,15 @@ class MACECalculator(Calculator):
             if len(model_paths) == 0:
                 raise ValueError("No mace file names supplied")
             self.num_models = len(model_paths)
-
-            # Load models from files.
             self.models = [
                 torch.load(f=model_path, map_location=device)
                 for model_path in model_paths
             ]
-
         elif models is not None:
             if not isinstance(models, list):
                 models = [models]
-
             if len(models) == 0:
                 raise ValueError("No models supplied")
-
             self.models = models
             self.num_models = len(models)
 
@@ -232,21 +254,7 @@ class MACECalculator(Calculator):
             ]:
                 self.implemented_properties.extend(["dipole_var"])
 
-        if compile_mode is not None:
-            logging.info(f"Torch compile is enabled with mode: {compile_mode}")
-            self.models = [
-                torch.compile(
-                    prepare(extract_model)(model=model, map_location=device),
-                    mode=compile_mode,
-                    fullgraph=fullgraph,
-                )
-                for model in self.models
-            ]
-            self.use_compile = True
-        else:
-            self.use_compile = False
-
-        # Ensure all models are on the same device
+        # ── Ensure dtype consistency ─────────────────────────────────────
         for model in self.models:
             model.to(device)
 
@@ -317,21 +325,81 @@ class MACECalculator(Calculator):
             elif default_dtype == "float32":
                 self.models = [model.float() for model in self.models]
         torch_tools.set_default_dtype(default_dtype)
-        if enable_cueq:
+
+        # ── Backend conversion (cueq / oeq / hybrid) ────────────────────
+        if enable_cueq and enable_oeq:
+            logging.info(
+                "Converting models to hybrid cueq+oeq: "
+                "cueq for symmetric contractions/linear, oeq for conv TP"
+            )
+            self.models = [
+                run_e3nn_to_hybrid(model, device=device).to(device)
+                for model in self.models
+            ]
+        elif enable_cueq:
             logging.info("Converting models to CuEq for acceleration")
             self.models = [
                 run_e3nn_to_cueq(model, device=device).to(device)
                 for model in self.models
             ]
-        if enable_oeq:
+        elif enable_oeq:
             logging.info("Converting models to OEq for acceleration")
             self.models = [
                 run_e3nn_to_oeq(model, device=device).to(device)
                 for model in self.models
             ]
+
+        # ── torch.compile ────────────────────────────────────────────────
+        self.use_compile = False
+        if compile_mode is not None:
+            logging.info(f"Torch compile is enabled with mode: {compile_mode}")
+            if self._enable_oeq:
+                # oeq custom ops break when autograd.grad is inlined in the
+                # compiled graph.  Ensure it is a graph break instead.
+                if dynamo is not None:
+                    try:
+                        dynamo.disallow_in_graph(torch.autograd.grad)
+                    except Exception:
+                        pass
+            else:
+                if dynamo is not None:
+                    dynamo.allow_in_graph(torch.autograd.grad)
+            if self._uses_accelerated_backend:
+                with disable_e3nn_codegen():
+                    self.models = [simplify(m) for m in self.models]
+                self.models = [
+                    torch.compile(m, mode=compile_mode, fullgraph=False)
+                    for m in self.models
+                ]
+            else:
+                self.models = [
+                    torch.compile(
+                        prepare(extract_model)(model=model, map_location=device),
+                        mode=compile_mode,
+                        fullgraph=fullgraph,
+                    )
+                    for model in self.models
+                ]
+            self.use_compile = True
+
         for model in self.models:
             for param in model.parameters():
                 param.requires_grad = False
+
+        # ── Padding ──────────────────────────────────────────────────────
+        if pad_num_atoms <= 0:
+            pad_num_atoms = int(os.environ.get("MACE_ASE_PAD_NUM_ATOMS", "0"))
+        if pad_num_edges <= 0:
+            pad_num_edges = int(os.environ.get("MACE_ASE_PAD_NUM_EDGES", "0"))
+        self.pad_num_atoms = max(int(pad_num_atoms), 0)
+        self.pad_num_edges = max(int(pad_num_edges), 0)
+        self._padding_initialized = self.pad_num_atoms > 0 and self.pad_num_edges > 0
+
+        # ── Warmup ───────────────────────────────────────────────────────
+        if warmup and self.use_compile:
+            logging.info(
+                "Warmup requested -- will trigger on first calculate() call"
+            )
 
     def check_state(self, atoms, tol: float = 1e-15) -> list:
         """
@@ -361,11 +429,36 @@ class MACECalculator(Calculator):
             state.append("info")
         return state
 
+    @staticmethod
+    def _slice_real_outputs(
+        out: Dict[str, Union[torch.Tensor, None]], num_real_atoms: int
+    ) -> Dict[str, Union[torch.Tensor, None]]:
+        """Strip padding from model outputs, keeping only real-atom results."""
+        graph_level_keys = {
+            "energy", "stress", "virials", "dipole",
+            "polarizability", "polarizability_sh",
+            "displacement", "contributions",
+        }
+        atom_level_keys = {
+            "node_energy", "forces", "charges",
+            "atomic_stresses", "atomic_virials",
+            "atomic_dipoles", "node_feats",
+        }
+        sliced: Dict[str, Union[torch.Tensor, None]] = {}
+        for key, value in out.items():
+            if value is None or not torch.is_tensor(value):
+                sliced[key] = value
+            elif key in graph_level_keys and value.ndim > 0:
+                sliced[key] = value[0]
+            elif key in atom_level_keys:
+                sliced[key] = value[:num_real_atoms]
+            else:
+                sliced[key] = value
+        return sliced
+
     def _create_result_tensors(
         self, num_models: int, num_atoms: int, batch, out: dict
     ) -> dict:
-        # unfortunately, code is expecting shape that isn't always same as underlying model
-        # output tensor shape, e.g. stress is returned as 1x3x3 and we want 3x3
         tensor_shapes = {
             "energy": [],
             "node_energy": [num_atoms],
@@ -398,17 +491,33 @@ class MACECalculator(Calculator):
 
         node_e0 = None
         if "node_energy" in out:
-            node_heads = batch["head"][batch["batch"]]
-            num_atoms_arange = torch.arange(batch["positions"].shape[0])
+            node_heads = batch["head"][batch["batch"]][:num_atoms]
+            num_atoms_arange = torch.arange(num_atoms)
             node_e0 = (
                 self.models[0]
-                .atomic_energies_fn(batch["node_attrs"])[num_atoms_arange, node_heads]
+                .atomic_energies_fn(batch["node_attrs"][:num_atoms])[
+                    num_atoms_arange, node_heads
+                ]
                 .detach()
                 .cpu()
                 .numpy()
             )
 
         return dict_of_tensors, node_e0
+
+    def _auto_estimate_padding(self, real_num_atoms: int, real_num_edges: int):
+        """Set padding targets on first call based on actual graph size."""
+        if self._padding_initialized:
+            return
+        self.pad_num_atoms = real_num_atoms
+        self.pad_num_edges = _round_up(
+            int(real_num_edges * _EDGE_PAD_HEADROOM), _EDGE_PAD_MULTIPLE
+        )
+        self._padding_initialized = True
+        logging.info(
+            "Auto-estimated padding: %d atoms, %d edges (real: %d atoms, %d edges)",
+            self.pad_num_atoms, self.pad_num_edges, real_num_atoms, real_num_edges,
+        )
 
     def _atoms_to_batch(self, atoms):
         self.arrays_keys.update({self.charges_key: "charges"})
@@ -418,20 +527,51 @@ class MACECalculator(Calculator):
         config = mace_data.config_from_atoms(
             atoms, key_specification=keyspec, head_name=self.head
         )
-        data_loader = torch_geometric.dataloader.DataLoader(
-            dataset=[
-                mace_data.AtomicData.from_config(
-                    config,
-                    z_table=self.z_table,
-                    cutoff=self.r_max,
-                    heads=self.available_heads,
-                )
-            ],
-            batch_size=1,
-            shuffle=False,
-            drop_last=False,
+        real_graph = mace_data.AtomicData.from_config(
+            config,
+            z_table=self.z_table,
+            cutoff=self.r_max,
+            heads=self.available_heads,
         )
-        batch = next(iter(data_loader)).to(self.device)
+
+        real_num_atoms = int(real_graph["node_attrs"].shape[0])
+        real_num_edges = int(real_graph["edge_index"].shape[1])
+
+        if self.use_compile and not self._padding_initialized:
+            self._auto_estimate_padding(real_num_atoms, real_num_edges)
+
+        if real_num_edges > self.pad_num_edges and self._padding_initialized:
+            old = self.pad_num_edges
+            self.pad_num_edges = _round_up(
+                int(real_num_edges * _EDGE_PAD_HEADROOM), _EDGE_PAD_MULTIPLE
+            )
+            logging.warning(
+                "Edge count %d exceeded pad budget %d -- bumping to %d "
+                "(will trigger one recompile)",
+                real_num_edges, old, self.pad_num_edges,
+            )
+
+        target_num_atoms = max(real_num_atoms, self.pad_num_atoms)
+        target_num_edges = max(real_num_edges, self.pad_num_edges)
+        pad_atoms = target_num_atoms - real_num_atoms
+        pad_edges = target_num_edges - real_num_edges
+
+        data_list = [real_graph]
+        if pad_atoms > 0 or pad_edges > 0:
+            from mace.data.padding_tools import build_fake_padding_graph
+
+            if pad_edges > 0 and pad_atoms <= 0:
+                pad_atoms = 1
+            data_list.append(
+                build_fake_padding_graph(
+                    real_graph,
+                    num_atoms=pad_atoms,
+                    num_edges=pad_edges,
+                    r_max=self.r_max,
+                )
+            )
+
+        batch = torch_geometric.Batch.from_data_list(data_list).to(self.device)
         return batch
 
     def _clone_batch(self, batch):
@@ -450,19 +590,20 @@ class MACECalculator(Calculator):
         :param system_changes: [str], system changes since last calculation, used by ASE internally
         :return:
         """
-        # call to base-class to set atoms attribute
         Calculator.calculate(self, atoms)
 
         batch_base = self._atoms_to_batch(atoms)
+        num_real_atoms = len(atoms)
+        is_padded = self.pad_num_atoms > 0 or self.pad_num_edges > 0
 
-        if self.model_type in ["MACE", "EnergyDipoleMACE", "PolarMACE"]:
-            compute_stress = not self.use_compile
-        else:
-            compute_stress = False
+        compute_stress = self.model_type in ["MACE", "EnergyDipoleMACE", "PolarMACE"]
+        # For oeq/hybrid + compile: create displacement outside the compiled
+        # graph so autograd.grad (which runs as a graph break) can
+        # differentiate energy w.r.t. displacement for stress.
+        oeq_compile = self.use_compile and self._enable_oeq
 
         ret_tensors = None
         node_e0 = None
-        # copy from output of model() call to ret_tensors
         for i, model in enumerate(self.models):
             batch = self._clone_batch(batch_base)
             model_dtype = next(model.parameters()).dtype
@@ -470,16 +611,31 @@ class MACECalculator(Calculator):
                 value = batch[key]
                 if torch.is_tensor(value) and torch.is_floating_point(value):
                     batch[key] = value.to(dtype=model_dtype)
+            batch_dict = batch.to_dict()
+
+            if oeq_compile and compute_stress:
+                positions = batch_dict["positions"]
+                num_graphs = int(batch_dict["ptr"].numel() - 1)
+                displacement = torch.zeros(
+                    (num_graphs, 3, 3),
+                    dtype=positions.dtype,
+                    device=positions.device,
+                )
+                displacement = displacement + positions.sum() * 0.0
+                batch_dict["displacement"] = displacement
+
             out = model(
-                batch.to_dict(),
+                batch_dict,
                 compute_stress=compute_stress,
-                training=self.use_compile,
+                training=self.use_compile and not oeq_compile,
                 compute_edge_forces=self.compute_atomic_stresses,
                 compute_atomic_stresses=self.compute_atomic_stresses,
             )
+            if is_padded:
+                out = self._slice_real_outputs(out, num_real_atoms)
             if i == 0:
                 ret_tensors, node_e0 = self._create_result_tensors(
-                    self.num_models, len(atoms), batch, out
+                    self.num_models, num_real_atoms, batch, out
                 )
             for key, val in ret_tensors.items():
                 if out.get(key) is not None:

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -5,13 +5,12 @@
 ###########################################################################################
 
 import logging
-import time
 
 # pylint: disable=wrong-import-position
 import os
 from glob import glob
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
 
@@ -24,13 +23,8 @@ from e3nn import o3
 from mace import data as mace_data
 from mace.modules.utils import extract_invariant
 from mace.tools import torch_geometric, torch_tools, utils
-from mace.tools.compile import prepare, disable_e3nn_codegen, simplify
+from mace.tools.compile import disable_e3nn_codegen, prepare, simplify
 from mace.tools.scripts_utils import extract_model
-
-try:
-    import torch._dynamo as dynamo
-except ImportError:
-    dynamo = None
 
 try:
     from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
@@ -83,22 +77,18 @@ def get_model_dtype(model: torch.nn.Module) -> torch.dtype:
 
 class MACECalculator(Calculator):
     """MACE ASE Calculator
+    args:
+        model_paths: str, path to model or models if a committee is produced
+                to make a committee use a wild card notation like mace_*.model
+        device: str, device to run on (cuda or cpu or xpu)
+        energy_units_to_eV: float, conversion factor from model energy units to eV
+        length_units_to_A: float, conversion factor from model length units to Angstroms
+        default_dtype: str, default dtype of model
+        charges_key: str, Array field of atoms object where atomic charges are stored
+        model_type: str, type of model to load
+                    Options: [MACE, DipoleMACE, EnergyDipoleMACE]
 
-    Supports accelerated backends (cueq, openequivariance, hybrid) and
-    torch.compile with automatic graph padding to avoid recompilation
-    during geometry relaxation / MD.
-
-    Args:
-        model_paths: path(s) to model file(s); supports wildcards for committees
-        models: pre-loaded model(s) as an alternative to model_paths
-        device: 'cuda', 'cpu', or 'xpu'
-        compile_mode: torch.compile mode ('default', 'reduce-overhead', etc.)
-                      or None to disable compilation
-        enable_cueq: use cuequivariance for symmetric contractions / linear
-        enable_oeq: use openequivariance for channelwise tensor product
-        pad_num_atoms: fixed atom count for padding (0 = auto-estimate on first call)
-        pad_num_edges: fixed edge count for padding (0 = auto-estimate on first call)
-        warmup: if True, run one dummy forward pass after init to trigger compilation
+    Dipoles are returned in units of Debye
     """
 
     def __init__(
@@ -215,7 +205,6 @@ class MACECalculator(Calculator):
                 ]
             )
 
-        # ── Load models ──────────────────────────────────────────────────
         if model_paths is not None:
             if isinstance(model_paths, str):
                 model_paths_glob = glob(model_paths)
@@ -254,7 +243,6 @@ class MACECalculator(Calculator):
             ]:
                 self.implemented_properties.extend(["dipole_var"])
 
-        # ── Ensure dtype consistency ─────────────────────────────────────
         for model in self.models:
             model.to(device)
 
@@ -326,7 +314,6 @@ class MACECalculator(Calculator):
                 self.models = [model.float() for model in self.models]
         torch_tools.set_default_dtype(default_dtype)
 
-        # ── Backend conversion (cueq / oeq / hybrid) ────────────────────
         if enable_cueq and enable_oeq:
             logging.info(
                 "Converting models to hybrid cueq+oeq: "
@@ -349,17 +336,18 @@ class MACECalculator(Calculator):
                 for model in self.models
             ]
 
-        # ── torch.compile ────────────────────────────────────────────────
         self.use_compile = False
         if compile_mode is not None:
             logging.info(f"Torch compile is enabled with mode: {compile_mode}")
+            try:
+                dynamo = torch._dynamo
+            except AttributeError:
+                dynamo = None
             if self._enable_oeq:
-                # oeq custom ops break when autograd.grad is inlined in the
-                # compiled graph.  Ensure it is a graph break instead.
                 if dynamo is not None:
                     try:
                         dynamo.disallow_in_graph(torch.autograd.grad)
-                    except Exception:
+                    except (TypeError, AttributeError):
                         pass
             else:
                 if dynamo is not None:
@@ -386,7 +374,6 @@ class MACECalculator(Calculator):
             for param in model.parameters():
                 param.requires_grad = False
 
-        # ── Padding ──────────────────────────────────────────────────────
         if pad_num_atoms <= 0:
             pad_num_atoms = int(os.environ.get("MACE_ASE_PAD_NUM_ATOMS", "0"))
         if pad_num_edges <= 0:
@@ -395,11 +382,8 @@ class MACECalculator(Calculator):
         self.pad_num_edges = max(int(pad_num_edges), 0)
         self._padding_initialized = self.pad_num_atoms > 0 and self.pad_num_edges > 0
 
-        # ── Warmup ───────────────────────────────────────────────────────
         if warmup and self.use_compile:
-            logging.info(
-                "Warmup requested -- will trigger on first calculate() call"
-            )
+            logging.info("Warmup requested -- will trigger on first calculate() call")
 
     def check_state(self, atoms, tol: float = 1e-15) -> list:
         """
@@ -435,14 +419,23 @@ class MACECalculator(Calculator):
     ) -> Dict[str, Union[torch.Tensor, None]]:
         """Strip padding from model outputs, keeping only real-atom results."""
         graph_level_keys = {
-            "energy", "stress", "virials", "dipole",
-            "polarizability", "polarizability_sh",
-            "displacement", "contributions",
+            "energy",
+            "stress",
+            "virials",
+            "dipole",
+            "polarizability",
+            "polarizability_sh",
+            "displacement",
+            "contributions",
         }
         atom_level_keys = {
-            "node_energy", "forces", "charges",
-            "atomic_stresses", "atomic_virials",
-            "atomic_dipoles", "node_feats",
+            "node_energy",
+            "forces",
+            "charges",
+            "atomic_stresses",
+            "atomic_virials",
+            "atomic_dipoles",
+            "node_feats",
         }
         sliced: Dict[str, Union[torch.Tensor, None]] = {}
         for key, value in out.items():
@@ -516,7 +509,10 @@ class MACECalculator(Calculator):
         self._padding_initialized = True
         logging.info(
             "Auto-estimated padding: %d atoms, %d edges (real: %d atoms, %d edges)",
-            self.pad_num_atoms, self.pad_num_edges, real_num_atoms, real_num_edges,
+            self.pad_num_atoms,
+            self.pad_num_edges,
+            real_num_atoms,
+            real_num_edges,
         )
 
     def _atoms_to_batch(self, atoms):
@@ -548,7 +544,9 @@ class MACECalculator(Calculator):
             logging.warning(
                 "Edge count %d exceeded pad budget %d -- bumping to %d "
                 "(will trigger one recompile)",
-                real_num_edges, old, self.pad_num_edges,
+                real_num_edges,
+                old,
+                self.pad_num_edges,
             )
 
         target_num_atoms = max(real_num_atoms, self.pad_num_atoms)
@@ -560,7 +558,7 @@ class MACECalculator(Calculator):
         if pad_atoms > 0 or pad_edges > 0:
             from mace.data.padding_tools import build_fake_padding_graph
 
-            if pad_edges > 0 and pad_atoms <= 0:
+            if pad_edges > 0 >= pad_atoms:
                 pad_atoms = 1
             data_list.append(
                 build_fake_padding_graph(

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -1,0 +1,471 @@
+"""TorchSim-compatible MACE model wrapper with cueq/oeq acceleration and torch.compile."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Union
+
+import torch
+
+log = logging.getLogger(__name__)
+
+_PAD_MULTIPLE = 64
+_PAD_HEADROOM = 1.25
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+try:
+    import torch_sim as ts
+    from torch_sim.models.interface import ModelInterface
+    from torch_sim.neighbors import torchsim_nl
+
+    _TORCHSIM_IMPORT_ERROR: Optional[ImportError] = None
+except ImportError as exc:
+    ts = None  # type: ignore[assignment]
+    torchsim_nl = None  # type: ignore[assignment]
+    _TORCHSIM_IMPORT_ERROR = exc
+
+    class ModelInterface(torch.nn.Module):  # type: ignore[no-redef]
+        """Fallback base class when torch-sim is not installed."""
+
+from mace.tools import atomic_numbers_to_indices, utils
+
+
+def to_one_hot(
+    indices: torch.Tensor, num_classes: int, dtype: torch.dtype
+) -> torch.Tensor:
+    """Generate one-hot vectors from class indices."""
+    shape = indices.shape[:-1] + (num_classes,)
+    out = torch.zeros(shape, device=indices.device, dtype=dtype).view(shape)
+    out.scatter_(dim=-1, index=indices, value=1)
+    return out.view(*shape)
+
+
+class MaceTorchSimModel(ModelInterface):
+    """TorchSim wrapper around a MACE model."""
+
+    def __init__(
+        self,
+        model: Union[str, Path, torch.nn.Module],
+        device: Optional[torch.device] = None,
+        dtype: torch.dtype = torch.float64,
+        neighbor_list_fn: Optional[Callable] = None,
+        compute_forces: bool = True,
+        compute_stress: bool = True,
+        enable_cueq: bool = False,
+        enable_oeq: bool = False,
+        compile_mode: Optional[str] = None,
+        atomic_numbers: Optional[torch.Tensor] = None,
+        system_idx: Optional[torch.Tensor] = None,
+    ) -> None:
+        if _TORCHSIM_IMPORT_ERROR is not None:
+            raise ImportError(
+                "MaceTorchSimModel requires torch-sim-atomistic. "
+                "Install with `pip install torch-sim-atomistic` "
+                "or `pip install -e '.[torchsim]'`."
+            ) from _TORCHSIM_IMPORT_ERROR
+
+        super().__init__()
+        self._device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self._dtype = dtype
+        self._compute_forces = compute_forces
+        self._compute_stress = compute_stress
+        self._enable_cueq = enable_cueq
+        self._enable_oeq = enable_oeq
+        self._uses_accelerated = enable_cueq or enable_oeq
+        self._use_compile = compile_mode is not None
+        self._memory_scales_with = "n_atoms_x_density"
+        self.neighbor_list_fn = neighbor_list_fn or torchsim_nl
+
+        self._atom_budget = 0
+        self._edge_budget = 0
+        self._system_budget = 0
+        self._budgets_ready = False
+
+        if isinstance(model, (str, Path)):
+            self.model = torch.load(
+                str(model), map_location=self._device, weights_only=False
+            )
+        elif isinstance(model, torch.nn.Module):
+            self.model = model.to(self._device)
+        else:
+            raise TypeError("model must be a path or torch.nn.Module")
+
+        self.model = self.model.eval().to(device=self._device)
+        if self._dtype is not None:
+            self.model = self.model.to(dtype=self._dtype)
+
+        if enable_cueq and enable_oeq:
+            from mace.cli.convert_e3nn_hybrid import run as run_hybrid
+            self.model = run_hybrid(self.model, device=self._device.type)
+        elif enable_cueq:
+            from mace.cli.convert_e3nn_cueq import run as run_cueq
+            self.model = run_cueq(self.model, device=self._device.type)
+        elif enable_oeq:
+            from mace.cli.convert_e3nn_oeq import run as run_oeq
+            self.model = run_oeq(self.model, device=self._device.type)
+
+        self.model = self.model.to(device=self._device).eval()
+
+        if compile_mode is not None:
+            self._setup_compile(compile_mode)
+
+        for p in self.model.parameters():
+            p.requires_grad = False
+
+        self.r_max = float(self.model.r_max)
+        self.z_table = utils.AtomicNumberTable(
+            [int(z) for z in self.model.atomic_numbers]
+        )
+        self.model.atomic_numbers = (
+            self.model.atomic_numbers.detach().clone().to(device=self._device)
+        )
+        self._n_elements = len(self.z_table)
+
+        self.atomic_numbers_in_init = atomic_numbers is not None
+        if atomic_numbers is not None:
+            if system_idx is None:
+                system_idx = torch.zeros(
+                    len(atomic_numbers), dtype=torch.long, device=self._device
+                )
+            self.setup_from_system_idx(atomic_numbers, system_idx)
+
+    def _setup_compile(self, compile_mode: str) -> None:
+        import torch._dynamo as dynamo
+        from mace.tools.compile import simplify
+
+        if self._enable_oeq:
+            # oeq ops are opaque to AOTAutograd; autograd.grad must run in eager
+            try:
+                dynamo.allow_in_graph(torch.autograd.grad)
+                dynamo.disallow_in_graph(torch.autograd.grad)
+            except Exception:
+                pass
+        else:
+            dynamo.allow_in_graph(torch.autograd.grad)
+
+        self.model = simplify(self.model)
+        self.model = torch.compile(
+            self.model,
+            mode=compile_mode,
+            fullgraph=False,
+        )
+
+    def setup_from_system_idx(
+        self, atomic_numbers: torch.Tensor, system_idx: torch.Tensor
+    ) -> None:
+        if atomic_numbers.shape[0] != system_idx.shape[0]:
+            raise ValueError("atomic_numbers and system_idx must have same shape[0]")
+
+        self.atomic_numbers = atomic_numbers.to(device=self._device, dtype=torch.long)
+        self.system_idx = system_idx.to(device=self._device, dtype=torch.long)
+
+        if self.system_idx.numel() == 0:
+            raise ValueError("at least one atom is required")
+
+        self.n_systems = int(self.system_idx.max().item()) + 1
+        self.n_atoms_per_system = []
+        ptr = [0]
+        for idx in range(self.n_systems):
+            n_atoms = int((self.system_idx == idx).sum().item())
+            self.n_atoms_per_system.append(n_atoms)
+            ptr.append(ptr[-1] + n_atoms)
+
+        self.ptr = torch.tensor(ptr, dtype=torch.long, device=self._device)
+        self.total_atoms = int(self.atomic_numbers.shape[0])
+
+        atomic_indices = torch.tensor(
+            atomic_numbers_to_indices(
+                self.atomic_numbers.detach().cpu().numpy(), z_table=self.z_table
+            ),
+            dtype=torch.long,
+            device=self._device,
+        ).unsqueeze(-1)
+
+        self.node_attrs = to_one_hot(
+            atomic_indices,
+            num_classes=self._n_elements,
+            dtype=self._dtype,
+        )
+
+    def _ensure_budgets(
+        self, n_atoms: int, n_edges: int, n_systems: int
+    ) -> None:
+        changed = False
+        if n_atoms > self._atom_budget:
+            old = self._atom_budget
+            self._atom_budget = _round_up(int(n_atoms * _PAD_HEADROOM), _PAD_MULTIPLE)
+            if old:
+                log.warning("Atom budget %d -> %d (recompile)", old, self._atom_budget)
+            changed = True
+        if n_edges > self._edge_budget:
+            old = self._edge_budget
+            self._edge_budget = _round_up(int(n_edges * _PAD_HEADROOM), _PAD_MULTIPLE)
+            if old:
+                log.warning("Edge budget %d -> %d (recompile)", old, self._edge_budget)
+            changed = True
+        if n_systems > self._system_budget:
+            old = self._system_budget
+            self._system_budget = _round_up(int(n_systems * _PAD_HEADROOM), _PAD_MULTIPLE)
+            if old:
+                log.warning("System budget %d -> %d (recompile)", old, self._system_budget)
+            changed = True
+
+        if changed or not self._budgets_ready:
+            self._allocate_buffers()
+            self._budgets_ready = True
+            log.info(
+                "Padding budgets: %d atoms, %d edges, %d systems "
+                "(real: %d, %d, %d)",
+                self._atom_budget, self._edge_budget, self._system_budget,
+                n_atoms, n_edges, n_systems,
+            )
+
+    def _allocate_buffers(self) -> None:
+        A = self._atom_budget
+        E = self._edge_budget
+        S = self._system_budget
+        dev = self._device
+        dt = self._dtype
+        cell_scale = self.r_max * 2.0
+
+        self._buf_positions = torch.zeros(A, 3, device=dev, dtype=dt)
+        self._buf_node_attrs = torch.zeros(A, self._n_elements, device=dev, dtype=dt)
+        self._buf_node_attrs[:, 0] = 1.0
+        self._buf_batch = torch.zeros(A, dtype=torch.long, device=dev)
+
+        self._buf_edge_index = torch.full((2, E), A - 1, dtype=torch.long, device=dev)
+        self._buf_shifts = torch.zeros(E, 3, device=dev, dtype=dt)
+        self._buf_shifts[:, 0] = cell_scale
+        self._buf_unit_shifts = torch.zeros(E, 3, device=dev, dtype=dt)
+        self._buf_unit_shifts[:, 0] = 1.0
+
+        self._buf_ptr = torch.full((S + 1,), A, dtype=torch.long, device=dev)
+        self._buf_ptr[0] = 0
+        self._buf_cell = (
+            torch.eye(3, device=dev, dtype=dt).unsqueeze(0).expand(S, -1, -1).clone()
+            * cell_scale
+        )
+        self._buf_head = torch.zeros(S, dtype=torch.long, device=dev)
+
+    def _fill_padded_data(
+        self,
+        data_dict: Dict[str, torch.Tensor],
+        n_real_atoms: int,
+        n_real_edges: int,
+        n_real_systems: int,
+    ) -> Dict[str, torch.Tensor]:
+        """Copy real data into fixed-size buffers; padding tail is pre-filled."""
+        A = self._atom_budget
+        S = self._system_budget
+
+        self._buf_node_attrs[:n_real_atoms] = data_dict["node_attrs"]
+        self._buf_batch[:n_real_atoms] = data_dict["batch"]
+        self._buf_batch[n_real_atoms:] = S - 1
+
+        self._buf_edge_index[:, :n_real_edges] = data_dict["edge_index"]
+        self._buf_edge_index[:, n_real_edges:] = A - 1
+        self._buf_shifts[:n_real_edges] = data_dict["shifts"]
+        self._buf_unit_shifts[:n_real_edges] = data_dict["unit_shifts"]
+
+        real_ptr = data_dict["ptr"]
+        self._buf_ptr[: n_real_systems + 1] = real_ptr
+        self._buf_ptr[n_real_systems + 1 : S] = n_real_atoms
+        self._buf_ptr[S] = A
+
+        self._buf_cell[:n_real_systems] = data_dict["cell"]
+        self._buf_head[:n_real_systems] = (
+            data_dict["head"] if "head" in data_dict
+            else torch.zeros(n_real_systems, dtype=torch.long, device=self._device)
+        )
+
+        pad_count = A - n_real_atoms
+        pad_pos = torch.zeros(pad_count, 3, device=self._device, dtype=self._dtype)
+        padded_positions = torch.cat([data_dict["positions"], pad_pos])
+
+        padded: Dict[str, torch.Tensor] = {
+            "positions": padded_positions,
+            "node_attrs": self._buf_node_attrs,
+            "batch": self._buf_batch,
+            "edge_index": self._buf_edge_index,
+            "shifts": self._buf_shifts,
+            "unit_shifts": self._buf_unit_shifts,
+            "ptr": self._buf_ptr,
+            "cell": self._buf_cell,
+            "head": self._buf_head,
+            "pbc": data_dict["pbc"],
+        }
+
+        if "displacement" in data_dict:
+            pad_disp = torch.zeros(
+                S - n_real_systems, 3, 3, device=self._device, dtype=self._dtype
+            )
+            padded["displacement"] = torch.cat([data_dict["displacement"], pad_disp])
+
+        return padded
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def compute_forces(self) -> bool:
+        return self._compute_forces
+
+    @property
+    def compute_stress(self) -> bool:
+        return self._compute_stress
+
+    def forward(self, state: Any) -> Dict[str, torch.Tensor]:
+        if ts is None:
+            raise RuntimeError(
+                "torch-sim is required to call MaceTorchSimModel.forward"
+            )
+
+        if isinstance(state, ts.SimState):
+            sim_state = state.clone()
+        else:
+            state_dict = dict(state)
+            if "masses" not in state_dict:
+                state_dict["masses"] = torch.ones_like(state_dict["positions"])
+            sim_state = ts.SimState(**state_dict)
+
+        if sim_state.device != self.device or sim_state.dtype != self.dtype:
+            sim_state = sim_state.to(self.device, self.dtype)
+
+        state_atomic_numbers = getattr(sim_state, "atomic_numbers", None)
+        if state_atomic_numbers is None and not self.atomic_numbers_in_init:
+            raise ValueError(
+                "atomic_numbers must be provided in the constructor or in forward."
+            )
+
+        if state_atomic_numbers is not None and self.atomic_numbers_in_init:
+            if not torch.equal(state_atomic_numbers, self.atomic_numbers):
+                raise ValueError(
+                    "atomic_numbers in state do not match constructor values."
+                )
+
+        if sim_state.system_idx is None:
+            if not hasattr(self, "system_idx"):
+                raise ValueError(
+                    "system_idx must be provided if not set during initialization"
+                )
+            sim_state.system_idx = self.system_idx
+
+        if not self.atomic_numbers_in_init:
+            cached_atomic_numbers = getattr(self, "atomic_numbers", None)
+            cached_system_idx = getattr(self, "system_idx", None)
+            needs_setup = state_atomic_numbers is not None and (
+                cached_atomic_numbers is None
+                or cached_system_idx is None
+                or not torch.equal(state_atomic_numbers, cached_atomic_numbers)
+                or not torch.equal(sim_state.system_idx, cached_system_idx)
+            )
+            if needs_setup:
+                self.setup_from_system_idx(state_atomic_numbers, sim_state.system_idx)
+
+        wrapped_positions = (
+            ts.transforms.pbc_wrap_batched(
+                sim_state.positions,
+                sim_state.cell,
+                sim_state.system_idx,
+                sim_state.pbc,
+            )
+            if sim_state.pbc.any()
+            else sim_state.positions
+        )
+
+        edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
+            wrapped_positions,
+            sim_state.row_vector_cell,
+            sim_state.pbc,
+            self.r_max,
+            sim_state.system_idx,
+        )
+        shifts = ts.transforms.compute_cell_shifts(
+            sim_state.row_vector_cell, unit_shifts, mapping_system
+        )
+
+        n_real_atoms = wrapped_positions.shape[0]
+        n_real_edges = edge_index.shape[1]
+        wrapped_positions = wrapped_positions.requires_grad_(True)
+
+        data_dict: Dict[str, torch.Tensor] = {
+            "ptr": self.ptr,
+            "node_attrs": self.node_attrs,
+            "batch": sim_state.system_idx,
+            "head": torch.zeros(
+                self.n_systems, dtype=torch.long, device=self._device
+            ),
+            "pbc": sim_state.pbc,
+            "cell": sim_state.row_vector_cell,
+            "positions": wrapped_positions,
+            "edge_index": edge_index,
+            "unit_shifts": unit_shifts,
+            "shifts": shifts,
+            "total_charge": sim_state.charge,
+            "total_spin": sim_state.spin,
+        }
+
+        oeq_compile = self._use_compile and self._enable_oeq
+        if oeq_compile and self._compute_stress:
+            displacement = torch.zeros(
+                (self.n_systems, 3, 3),
+                dtype=wrapped_positions.dtype,
+                device=self._device,
+            )
+            displacement = displacement + wrapped_positions.sum() * 0.0
+            data_dict["displacement"] = displacement
+
+        if self._use_compile:
+            self._ensure_budgets(n_real_atoms, n_real_edges, self.n_systems)
+            data_dict = self._fill_padded_data(
+                data_dict, n_real_atoms, n_real_edges, self.n_systems,
+            )
+
+        training = self._use_compile and not oeq_compile
+
+        out = self.model(
+            data_dict,
+            compute_force=self._compute_forces,
+            compute_stress=self._compute_stress,
+            training=training,
+        )
+
+        n_systems = self.n_systems
+        results: Dict[str, torch.Tensor] = {}
+
+        energy = out.get("energy")
+        if energy is None:
+            results["energy"] = torch.zeros(
+                n_systems, device=self.device, dtype=self.dtype
+            )
+        else:
+            results["energy"] = energy[:n_systems].detach()
+
+        if self._compute_forces:
+            forces = out.get("forces")
+            if forces is None:
+                forces = torch.zeros_like(sim_state.positions)
+            results["forces"] = forces[:n_real_atoms].detach()
+
+        if self._compute_stress:
+            stress = out.get("stress")
+            if stress is None:
+                stress = torch.zeros(
+                    n_systems, 3, 3, device=self.device, dtype=self.dtype
+                )
+            results["stress"] = stress[:n_systems].detach()
+
+        return results

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -62,6 +62,7 @@ class MaceTorchSimModel(ModelInterface):
         enable_cueq: bool = False,
         enable_oeq: bool = False,
         compile_mode: Optional[str] = None,
+        cudagraphs: bool = True,
         atomic_numbers: Optional[torch.Tensor] = None,
         system_idx: Optional[torch.Tensor] = None,
     ) -> None:
@@ -83,6 +84,7 @@ class MaceTorchSimModel(ModelInterface):
         self._enable_oeq = enable_oeq
         self._uses_accelerated = enable_cueq or enable_oeq
         self._use_compile = compile_mode is not None
+        self._use_cudagraphs = cudagraphs and compile_mode is not None
         self._memory_scales_with = "n_atoms_x_density"
         self.neighbor_list_fn = neighbor_list_fn or torchsim_nl
 
@@ -140,7 +142,7 @@ class MaceTorchSimModel(ModelInterface):
         self.model = self.model.to(device=self._device).eval()
 
         if compile_mode is not None:
-            self._setup_compile(compile_mode)
+            self._setup_compile(compile_mode, cudagraphs)
 
         for p in self.model.parameters():
             p.requires_grad = False
@@ -162,10 +164,14 @@ class MaceTorchSimModel(ModelInterface):
                 )
             self.setup_from_system_idx(atomic_numbers, system_idx)
 
-    def _setup_compile(self, compile_mode: str) -> None:
+    def _setup_compile(self, compile_mode: str, cudagraphs: bool = True) -> None:
         import torch._dynamo as dynamo
 
         from mace.tools.compile import simplify
+
+        if not cudagraphs:
+            inductor_cfg = torch._inductor.config  # pylint: disable=protected-access
+            inductor_cfg.triton.cudagraphs = False
 
         if self._enable_oeq:
             # oeq ops are opaque to AOTAutograd; autograd.grad must run in eager
@@ -365,6 +371,9 @@ class MaceTorchSimModel(ModelInterface):
                 "torch-sim is required to call MaceTorchSimModel.forward"
             )
 
+        if self._use_cudagraphs:
+            torch.compiler.cudagraph_mark_step_begin()
+
         if isinstance(state, ts.SimState):
             sim_state = state.clone()
         else:
@@ -408,7 +417,7 @@ class MaceTorchSimModel(ModelInterface):
                 self.setup_from_system_idx(state_atomic_numbers, sim_state.system_idx)
 
         wrapped_positions = (
-            ts.transforms.pbc_wrap_batched(
+            ts.transforms.pbc_wrap_batched(  # pylint: disable=too-many-function-args
                 sim_state.positions,
                 sim_state.cell,
                 sim_state.system_idx,
@@ -485,13 +494,15 @@ class MaceTorchSimModel(ModelInterface):
                 n_systems, device=self.device, dtype=self.dtype
             )
         else:
-            results["energy"] = energy[:n_systems].detach()
+            e = energy[:n_systems].detach()
+            results["energy"] = e.clone() if self._use_cudagraphs else e
 
         if self._compute_forces:
             forces = out.get("forces")
             if forces is None:
                 forces = torch.zeros_like(sim_state.positions)
-            results["forces"] = forces[:n_real_atoms].detach()
+            f = forces[:n_real_atoms].detach()
+            results["forces"] = f.clone() if self._use_cudagraphs else f
 
         if self._compute_stress:
             stress = out.get("stress")
@@ -499,6 +510,7 @@ class MaceTorchSimModel(ModelInterface):
                 stress = torch.zeros(
                     n_systems, 3, 3, device=self.device, dtype=self.dtype
                 )
-            results["stress"] = stress[:n_systems].detach()
+            s = stress[:n_systems].detach()
+            results["stress"] = s.clone() if self._use_cudagraphs else s
 
         return results

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -1,13 +1,14 @@
-"""TorchSim-compatible MACE model wrapper with cueq/oeq acceleration and torch.compile."""
+"""MACE TorchSim model interface."""
 
 from __future__ import annotations
 
 import logging
-import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
+
+from mace.tools import atomic_numbers_to_indices, utils
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +34,8 @@ except ImportError as exc:
     class ModelInterface(torch.nn.Module):  # type: ignore[no-redef]
         """Fallback base class when torch-sim is not installed."""
 
-from mace.tools import atomic_numbers_to_indices, utils
+        def forward(self, state):
+            raise NotImplementedError
 
 
 def to_one_hot(
@@ -88,6 +90,15 @@ class MaceTorchSimModel(ModelInterface):
         self._edge_budget = 0
         self._system_budget = 0
         self._budgets_ready = False
+        self._buf_positions = None
+        self._buf_node_attrs = None
+        self._buf_batch = None
+        self._buf_edge_index = None
+        self._buf_shifts = None
+        self._buf_unit_shifts = None
+        self._buf_ptr = None
+        self._buf_cell = None
+        self._buf_head = None
 
         if isinstance(model, (str, Path)):
             self.model = torch.load(
@@ -104,12 +115,23 @@ class MaceTorchSimModel(ModelInterface):
 
         if enable_cueq and enable_oeq:
             from mace.cli.convert_e3nn_hybrid import run as run_hybrid
+
             self.model = run_hybrid(self.model, device=self._device.type)
         elif enable_cueq:
             from mace.cli.convert_e3nn_cueq import run as run_cueq
-            self.model = run_cueq(self.model, device=self._device.type)
+
+            try:
+                self.model = run_cueq(self.model, device=self._device.type)
+            except (RuntimeError, ValueError):
+                log.warning(
+                    "cueq conv_fusion failed (non-uniform irreps), "
+                    "falling back to conv_fusion=False"
+                )
+                self.model = run_cueq(self.model, device="cpu")
+                self.model = self.model.to(self._device)
         elif enable_oeq:
             from mace.cli.convert_e3nn_oeq import run as run_oeq
+
             self.model = run_oeq(self.model, device=self._device.type)
 
         self.model = self.model.to(device=self._device).eval()
@@ -139,6 +161,7 @@ class MaceTorchSimModel(ModelInterface):
 
     def _setup_compile(self, compile_mode: str) -> None:
         import torch._dynamo as dynamo
+
         from mace.tools.compile import simplify
 
         if self._enable_oeq:
@@ -146,7 +169,7 @@ class MaceTorchSimModel(ModelInterface):
             try:
                 dynamo.allow_in_graph(torch.autograd.grad)
                 dynamo.disallow_in_graph(torch.autograd.grad)
-            except Exception:
+            except (TypeError, AttributeError):
                 pass
         else:
             dynamo.allow_in_graph(torch.autograd.grad)
@@ -195,9 +218,7 @@ class MaceTorchSimModel(ModelInterface):
             dtype=self._dtype,
         )
 
-    def _ensure_budgets(
-        self, n_atoms: int, n_edges: int, n_systems: int
-    ) -> None:
+    def _ensure_budgets(self, n_atoms: int, n_edges: int, n_systems: int) -> None:
         changed = False
         if n_atoms > self._atom_budget:
             old = self._atom_budget
@@ -213,19 +234,26 @@ class MaceTorchSimModel(ModelInterface):
             changed = True
         if n_systems > self._system_budget:
             old = self._system_budget
-            self._system_budget = _round_up(int(n_systems * _PAD_HEADROOM), _PAD_MULTIPLE)
+            self._system_budget = _round_up(
+                int(n_systems * _PAD_HEADROOM), _PAD_MULTIPLE
+            )
             if old:
-                log.warning("System budget %d -> %d (recompile)", old, self._system_budget)
+                log.warning(
+                    "System budget %d -> %d (recompile)", old, self._system_budget
+                )
             changed = True
 
         if changed or not self._budgets_ready:
             self._allocate_buffers()
             self._budgets_ready = True
             log.info(
-                "Padding budgets: %d atoms, %d edges, %d systems "
-                "(real: %d, %d, %d)",
-                self._atom_budget, self._edge_budget, self._system_budget,
-                n_atoms, n_edges, n_systems,
+                "Padding budgets: %d atoms, %d edges, %d systems (real: %d, %d, %d)",
+                self._atom_budget,
+                self._edge_budget,
+                self._system_budget,
+                n_atoms,
+                n_edges,
+                n_systems,
             )
 
     def _allocate_buffers(self) -> None:
@@ -282,7 +310,8 @@ class MaceTorchSimModel(ModelInterface):
 
         self._buf_cell[:n_real_systems] = data_dict["cell"]
         self._buf_head[:n_real_systems] = (
-            data_dict["head"] if "head" in data_dict
+            data_dict["head"]
+            if "head" in data_dict
             else torch.zeros(n_real_systems, dtype=torch.long, device=self._device)
         )
 
@@ -405,9 +434,7 @@ class MaceTorchSimModel(ModelInterface):
             "ptr": self.ptr,
             "node_attrs": self.node_attrs,
             "batch": sim_state.system_idx,
-            "head": torch.zeros(
-                self.n_systems, dtype=torch.long, device=self._device
-            ),
+            "head": torch.zeros(self.n_systems, dtype=torch.long, device=self._device),
             "pbc": sim_state.pbc,
             "cell": sim_state.row_vector_cell,
             "positions": wrapped_positions,
@@ -431,7 +458,10 @@ class MaceTorchSimModel(ModelInterface):
         if self._use_compile:
             self._ensure_budgets(n_real_atoms, n_real_edges, self.n_systems)
             data_dict = self._fill_padded_data(
-                data_dict, n_real_atoms, n_real_edges, self.n_systems,
+                data_dict,
+                n_real_atoms,
+                n_real_edges,
+                self.n_systems,
             )
 
         training = self._use_compile and not oeq_compile

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -123,12 +123,15 @@ class MaceTorchSimModel(ModelInterface):
             try:
                 self.model = run_cueq(self.model, device=self._device.type)
             except (RuntimeError, ValueError):
+                from mace.cli.convert_e3nn_hybrid import run as run_hybrid
+
                 log.warning(
                     "cueq conv_fusion failed (non-uniform irreps), "
-                    "falling back to conv_fusion=False"
+                    "falling back to hybrid (cueq + oeq)"
                 )
-                self.model = run_cueq(self.model, device="cpu")
-                self.model = self.model.to(self._device)
+                self.model = run_hybrid(self.model, device=self._device.type)
+                self._enable_oeq = True
+                self._uses_accelerated = True
         elif enable_oeq:
             from mace.cli.convert_e3nn_oeq import run as run_oeq
 

--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -1,0 +1,164 @@
+"""
+Hybrid cueq + openequivariance model converter.
+
+Uses cuequivariance for symmetric contractions and linear layers (which work
+fine regardless of segment uniformity) and openequivariance for the
+channelwise tensor product in the convolution (which handles non-uniform
+irreps like 128x0e+128x1o without requiring uniform_1d).
+"""
+
+import argparse
+import logging
+import os
+from typing import Optional
+
+import torch
+
+from mace.modules.wrapper_ops import CuEquivarianceConfig, OEQConfig
+from mace.tools.scripts_utils import extract_config_mace_model
+
+try:
+    from mace.cli.convert_e3nn_cueq import transfer_symmetric_contractions
+    from mace.tools.cg import O3_e3nn
+
+    CUEQ_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    CUEQ_AVAILABLE = False
+
+try:
+    import openequivariance as _oeq  # noqa: F401
+
+    OEQ_AVAILABLE = True
+except ImportError:
+    OEQ_AVAILABLE = False
+
+
+def run(
+    input_model,
+    output_model="_hybrid.model",
+    device="cpu",
+    return_model=True,
+):
+    if not CUEQ_AVAILABLE:
+        raise ImportError("cuequivariance is required for hybrid conversion")
+    if not OEQ_AVAILABLE:
+        raise ImportError("openequivariance is required for hybrid conversion")
+
+    if isinstance(input_model, str):
+        source_model = torch.load(input_model, map_location=device)
+    else:
+        source_model = input_model
+
+    default_dtype = next(source_model.parameters()).dtype
+    torch.set_default_dtype(default_dtype)
+
+    config = extract_config_mace_model(source_model)
+
+    num_product_irreps = len(config["hidden_irreps"].slices()) - 1
+    correlation = config["correlation"]
+    num_layers = config["num_interactions"]
+    use_reduced_cg = config.get("use_reduced_cg", True)
+
+    config["cueq_config"] = CuEquivarianceConfig(
+        enabled=True,
+        layout="ir_mul",
+        group="O3_e3nn",
+        optimize_all=False,
+        optimize_linear=True,
+        optimize_symmetric=True,
+        optimize_fctp=True,
+        optimize_channelwise=False,
+        conv_fusion=False,
+    )
+
+    config["oeq_config"] = OEQConfig(
+        enabled=True,
+        optimize_all=False,
+        optimize_channelwise=True,
+        conv_fusion="atomic",
+    )
+
+    logging.info(
+        "Creating hybrid model: cueq for symmetric/linear/fctp, "
+        "oeq TensorProductConv for channelwise TP"
+    )
+    target_model = source_model.__class__(**config).to(device)
+
+    source_dict = source_model.state_dict()
+    target_dict = target_model.state_dict()
+
+    transfer_symmetric_contractions(
+        source_dict,
+        target_dict,
+        num_product_irreps,
+        source_model.products,
+        correlation,
+        num_layers,
+        use_reduced_cg,
+    )
+
+    transferred_keys = set()
+    remaining_keys = (
+        set(source_dict.keys()) & set(target_dict.keys()) - transferred_keys
+    )
+    remaining_keys = {k for k in remaining_keys if "symmetric_contraction" not in k}
+    remaining_keys = {k for k in remaining_keys if ".conv_tp." not in k}
+
+    for key in remaining_keys:
+        src = source_dict[key]
+        tgt = target_dict[key]
+        if src.shape == tgt.shape:
+            target_dict[key] = src
+        elif _shapes_match_up_to_unsqueeze(src.shape, tgt.shape):
+            target_dict[key] = src.reshape(tgt.shape)
+        else:
+            logging.warning(
+                "Shape mismatch for key %s: source %s vs target %s",
+                key, src.shape, tgt.shape,
+            )
+
+    target_model.load_state_dict(target_dict)
+
+    for i in range(num_layers):
+        target_model.interactions[i].avg_num_neighbors = (
+            source_model.interactions[i].avg_num_neighbors
+        )
+
+    if return_model:
+        return target_model
+
+    if isinstance(input_model, str):
+        base = os.path.splitext(input_model)[0]
+        output_model = f"{base}.{output_model}"
+    logging.warning("Saving hybrid model to %s", output_model)
+    torch.save(target_model, output_model)
+    return None
+
+
+def _shapes_match_up_to_unsqueeze(a, b):
+    def drop(s):
+        return tuple(d for d in s if d != 1)
+    return drop(a) == drop(b)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_model", help="Path to input MACE model")
+    parser.add_argument(
+        "--output_model", default="hybrid_model.pt",
+        help="Path to output hybrid model",
+    )
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--return_model", action="store_false")
+    args = parser.parse_args()
+
+    run(
+        input_model=args.input_model,
+        output_model=args.output_model,
+        device=args.device,
+        return_model=args.return_model,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -1,16 +1,8 @@
-"""
-Hybrid cueq + openequivariance model converter.
-
-Uses cuequivariance for symmetric contractions and linear layers (which work
-fine regardless of segment uniformity) and openequivariance for the
-channelwise tensor product in the convolution (which handles non-uniform
-irreps like 128x0e+128x1o without requiring uniform_1d).
-"""
+"""Hybrid cueq + openequivariance model converter."""
 
 import argparse
 import logging
 import os
-from typing import Optional
 
 import torch
 
@@ -19,7 +11,6 @@ from mace.tools.scripts_utils import extract_config_mace_model
 
 try:
     from mace.cli.convert_e3nn_cueq import transfer_symmetric_contractions
-    from mace.tools.cg import O3_e3nn
 
     CUEQ_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
@@ -95,6 +86,7 @@ def run(
         correlation,
         num_layers,
         use_reduced_cg,
+        keep_last_layer_irreps=False,
     )
 
     transferred_keys = set()
@@ -114,15 +106,17 @@ def run(
         else:
             logging.warning(
                 "Shape mismatch for key %s: source %s vs target %s",
-                key, src.shape, tgt.shape,
+                key,
+                src.shape,
+                tgt.shape,
             )
 
     target_model.load_state_dict(target_dict)
 
     for i in range(num_layers):
-        target_model.interactions[i].avg_num_neighbors = (
-            source_model.interactions[i].avg_num_neighbors
-        )
+        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
+            i
+        ].avg_num_neighbors
 
     if return_model:
         return target_model
@@ -138,6 +132,7 @@ def run(
 def _shapes_match_up_to_unsqueeze(a, b):
     def drop(s):
         return tuple(d for d in s if d != 1)
+
     return drop(a) == drop(b)
 
 
@@ -145,7 +140,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input MACE model")
     parser.add_argument(
-        "--output_model", default="hybrid_model.pt",
+        "--output_model",
+        default="hybrid_model.pt",
         help="Path to output hybrid model",
     )
     parser.add_argument("--device", default="cpu")

--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -30,7 +30,7 @@ def run(
 
     # Add OEQ config
     config["oeq_config"] = OEQConfig(
-        enabled=False, optimize_all=True, conv_fusion="atomic"
+        enabled=True, optimize_all=True, conv_fusion="atomic"
     )
 
     # Create new model with oeq config
@@ -41,7 +41,8 @@ def run(
 
     for key in target_dict:
         if ".conv_tp." not in key:
-            target_dict[key] = source_dict[key]
+            if key in source_dict:
+                target_dict[key] = source_dict[key]
 
     target_model.load_state_dict(target_dict)
 

--- a/mace/data/__init__.py
+++ b/mace/data/__init__.py
@@ -1,4 +1,5 @@
 from .atomic_data import AtomicData
+from .padding_tools import build_fake_padding_graph
 from .hdf5_dataset import HDF5Dataset, dataset_from_sharded_hdf5
 from .lmdb_dataset import LMDBDataset
 from .neighborhood import get_neighborhood
@@ -39,4 +40,5 @@ __all__ = [
     "KeySpecification",
     "update_keyspec_from_kwargs",
     "LMDBDataset",
+    "build_fake_padding_graph",
 ]

--- a/mace/data/__init__.py
+++ b/mace/data/__init__.py
@@ -1,8 +1,8 @@
 from .atomic_data import AtomicData
-from .padding_tools import build_fake_padding_graph
 from .hdf5_dataset import HDF5Dataset, dataset_from_sharded_hdf5
 from .lmdb_dataset import LMDBDataset
 from .neighborhood import get_neighborhood
+from .padding_tools import build_fake_padding_graph
 from .utils import (
     Configuration,
     Configurations,

--- a/mace/data/padding_tools.py
+++ b/mace/data/padding_tools.py
@@ -1,0 +1,110 @@
+"""Helpers for fixed-shape graph padding."""
+
+import torch
+
+from mace.tools import torch_geometric
+
+
+def _zeros_with_size0(tensor: torch.Tensor, size0: int) -> torch.Tensor:
+    if tensor.dim() == 0:
+        return torch.zeros_like(tensor)
+    shape = list(tensor.shape)
+    shape[0] = size0
+    return torch.zeros(shape, dtype=tensor.dtype, device=tensor.device)
+
+
+_GRAPH_LEVEL_TENSOR_KEYS = {
+    "cell",
+    "pbc",
+    "stress",
+    "virials",
+    "dipole",
+    "polarizability",
+    "polarizability_sh",
+    "polarizability_weight",
+    "dipole_weight",
+}
+
+
+def build_fake_padding_graph(
+    reference_graph, num_atoms: int, num_edges: int, r_max: float
+):
+    """Build a fake graph used to pad a batch to fixed atom/edge counts."""
+    if num_atoms <= 0:
+        raise ValueError("Padding graph requires at least one fake atom.")
+
+    real_num_atoms = int(reference_graph["node_attrs"].shape[0])
+    real_num_edges = int(reference_graph["edge_index"].shape[1])
+
+    fake_graph = torch_geometric.data.Data.from_dict(
+        {
+            key: value.clone() if torch.is_tensor(value) else value
+            for key, value in reference_graph.to_dict().items()
+        }
+    )
+
+    # Pad explicit mandatory node fields first.
+    for key in ("node_attrs", "positions", "forces", "charges"):
+        if key in fake_graph and torch.is_tensor(fake_graph[key]) and fake_graph[key].dim() > 0:
+            fake_graph[key] = _zeros_with_size0(fake_graph[key], num_atoms)
+    fake_graph["node_attrs"][:, 0] = 1.0
+
+    # Pad other per-node / per-edge tensor fields generically so new AtomicData keys
+    # usually don't require changing this helper.
+    for key, value in fake_graph.to_dict().items():
+        if (
+            key in {"edge_index", "node_attrs", "positions", "forces", "charges", "shifts", "unit_shifts"}
+            or key in _GRAPH_LEVEL_TENSOR_KEYS
+            or not torch.is_tensor(value)
+            or value.dim() == 0
+        ):
+            continue
+        if value.shape[0] == real_num_edges and (
+            value.shape[0] != real_num_atoms or "edge" in key
+        ):
+            fake_graph[key] = _zeros_with_size0(value, num_edges)
+        elif value.shape[0] == real_num_atoms:
+            fake_graph[key] = _zeros_with_size0(value, num_atoms)
+
+    edge_index = torch.zeros(
+        (2, num_edges),
+        dtype=reference_graph["edge_index"].dtype,
+        device=reference_graph["edge_index"].device,
+    )
+    if num_edges > 0:
+        edge_ids = torch.arange(
+            num_edges, dtype=edge_index.dtype, device=edge_index.device
+        )
+        edge_index[0] = torch.remainder(edge_ids, num_atoms)
+        edge_index[1] = torch.remainder(edge_ids + 1, num_atoms)
+    fake_graph["edge_index"] = edge_index
+
+    for key in ("shifts", "unit_shifts"):
+        if key in fake_graph and torch.is_tensor(fake_graph[key]):
+            fake_graph[key] = _zeros_with_size0(fake_graph[key], num_edges)
+
+    cell_scale = max(float(r_max) * 2.0, 1.0)
+    cell_ref = reference_graph["cell"]
+    fake_graph["cell"] = torch.eye(
+        3, dtype=cell_ref.dtype, device=cell_ref.device
+    ) * cell_scale
+    if "pbc" in fake_graph and torch.is_tensor(fake_graph["pbc"]):
+        fake_graph["pbc"] = torch.zeros_like(fake_graph["pbc"], dtype=torch.bool)
+
+    if (
+        num_edges > 0
+        and "unit_shifts" in fake_graph
+        and torch.is_tensor(fake_graph["unit_shifts"])
+        and "shifts" in fake_graph
+        and torch.is_tensor(fake_graph["shifts"])
+    ):
+        fake_graph["unit_shifts"][:, 0] = 1.0
+        fake_graph["shifts"][:, 0] = cell_scale
+
+    if "total_charge" in fake_graph and torch.is_tensor(fake_graph["total_charge"]):
+        fake_graph["total_charge"] = torch.zeros_like(fake_graph["total_charge"])
+    if "total_spin" in fake_graph and torch.is_tensor(fake_graph["total_spin"]):
+        fake_graph["total_spin"] = torch.ones_like(fake_graph["total_spin"])
+
+    fake_graph.num_nodes = num_atoms
+    return fake_graph

--- a/mace/data/padding_tools.py
+++ b/mace/data/padding_tools.py
@@ -1,5 +1,3 @@
-"""Helpers for fixed-shape graph padding."""
-
 import torch
 
 from mace.tools import torch_geometric
@@ -43,17 +41,31 @@ def build_fake_padding_graph(
         }
     )
 
-    # Pad explicit mandatory node fields first.
-    for key in ("node_attrs", "positions", "forces", "charges"):
-        if key in fake_graph and torch.is_tensor(fake_graph[key]) and fake_graph[key].dim() > 0:
+    node_attrs = _zeros_with_size0(fake_graph["node_attrs"], num_atoms)
+    node_attrs[:, 0] = 1.0
+    fake_graph["node_attrs"] = node_attrs
+    for key in ("positions", "forces", "charges"):
+        if (
+            key in fake_graph
+            and torch.is_tensor(fake_graph[key])
+            and fake_graph[key].dim() > 0
+        ):
             fake_graph[key] = _zeros_with_size0(fake_graph[key], num_atoms)
-    fake_graph["node_attrs"][:, 0] = 1.0
 
     # Pad other per-node / per-edge tensor fields generically so new AtomicData keys
     # usually don't require changing this helper.
     for key, value in fake_graph.to_dict().items():
         if (
-            key in {"edge_index", "node_attrs", "positions", "forces", "charges", "shifts", "unit_shifts"}
+            key
+            in {
+                "edge_index",
+                "node_attrs",
+                "positions",
+                "forces",
+                "charges",
+                "shifts",
+                "unit_shifts",
+            }
             or key in _GRAPH_LEVEL_TENSOR_KEYS
             or not torch.is_tensor(value)
             or value.dim() == 0
@@ -79,27 +91,24 @@ def build_fake_padding_graph(
         edge_index[1] = torch.remainder(edge_ids + 1, num_atoms)
     fake_graph["edge_index"] = edge_index
 
+    cell_scale = max(float(r_max) * 2.0, 1.0)
+
     for key in ("shifts", "unit_shifts"):
         if key in fake_graph and torch.is_tensor(fake_graph[key]):
-            fake_graph[key] = _zeros_with_size0(fake_graph[key], num_edges)
+            t = _zeros_with_size0(fake_graph[key], num_edges)
+            if num_edges > 0:
+                if key == "unit_shifts":
+                    t[:, 0] = 1.0
+                elif key == "shifts":
+                    t[:, 0] = cell_scale
+            fake_graph[key] = t
 
-    cell_scale = max(float(r_max) * 2.0, 1.0)
     cell_ref = reference_graph["cell"]
-    fake_graph["cell"] = torch.eye(
-        3, dtype=cell_ref.dtype, device=cell_ref.device
-    ) * cell_scale
+    fake_graph["cell"] = (
+        torch.eye(3, dtype=cell_ref.dtype, device=cell_ref.device) * cell_scale
+    )
     if "pbc" in fake_graph and torch.is_tensor(fake_graph["pbc"]):
         fake_graph["pbc"] = torch.zeros_like(fake_graph["pbc"], dtype=torch.bool)
-
-    if (
-        num_edges > 0
-        and "unit_shifts" in fake_graph
-        and torch.is_tensor(fake_graph["unit_shifts"])
-        and "shifts" in fake_graph
-        and torch.is_tensor(fake_graph["shifts"])
-    ):
-        fake_graph["unit_shifts"][:, 0] = 1.0
-        fake_graph["shifts"][:, 0] = cell_scale
 
     if "total_charge" in fake_graph and torch.is_tensor(fake_graph["total_charge"]):
         fake_graph["total_charge"] = torch.zeros_like(fake_graph["total_charge"])

--- a/mace/data/padding_tools.py
+++ b/mace/data/padding_tools.py
@@ -78,17 +78,19 @@ def build_fake_padding_graph(
         elif value.shape[0] == real_num_atoms:
             fake_graph[key] = _zeros_with_size0(value, num_atoms)
 
+    # Self-loop edges on the last fake atom.  Combined with shifts at
+    # 2*r_max the edge length is always >= r_max so PolynomialCutoff
+    # returns exactly 0, contributing nothing to the real computation.
+    # This mirrors the isolated-system padding used in the TorchSim wrapper.
     edge_index = torch.zeros(
         (2, num_edges),
         dtype=reference_graph["edge_index"].dtype,
         device=reference_graph["edge_index"].device,
     )
     if num_edges > 0:
-        edge_ids = torch.arange(
-            num_edges, dtype=edge_index.dtype, device=edge_index.device
-        )
-        edge_index[0] = torch.remainder(edge_ids, num_atoms)
-        edge_index[1] = torch.remainder(edge_ids + 1, num_atoms)
+        last_atom = num_atoms - 1
+        edge_index[0] = last_atom
+        edge_index[1] = last_atom
     fake_graph["edge_index"] = edge_index
 
     cell_scale = max(float(r_max) * 2.0, 1.0)

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -25,6 +25,7 @@ from .blocks import (
     ScaleShiftBlock,
 )
 from .extensions import PolarMACE
+from .gate import GatedEquivariantBlock
 from .loss import (
     DipolePolarLoss,
     DipoleSingleLoss,

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1247,6 +1247,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
             shared_weights=False,
             internal_weights=False,
             cueq_config=self.cueq_config,
+            oeq_config=self.oeq_config,
         )
 
         # Convolution weights

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -12,6 +12,7 @@ import torch.nn.functional
 from e3nn import nn, o3
 from e3nn.util.jit import compile_mode
 
+from mace.modules.gate import GatedEquivariantBlock
 from mace.modules.wrapper_ops import (
     CuEquivarianceConfig,
     FullyConnectedTensorProduct,
@@ -19,7 +20,7 @@ from mace.modules.wrapper_ops import (
     OEQConfig,
     SymmetricContractionWrapper,
     TensorProduct,
-    TransposeIrrepsLayoutWrapper,
+    get_layout,
 )
 from mace.tools.compile import simplify_if_compile
 from mace.tools.scatter import scatter_sum
@@ -201,12 +202,13 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
             [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
         )
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[gate for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[gate] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -281,12 +283,13 @@ class NonLinearDipolePolarReadoutBlock(torch.nn.Module):
             [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
         )
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[gate for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[gate] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -327,12 +330,13 @@ class GeneralNonLinearBiasReadoutBlock(torch.nn.Module):
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
         activation_fn = gate if gate is not None else torch.nn.functional.silu
         act_gates_fn = torch.nn.functional.sigmoid
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[activation_fn for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[act_gates_fn] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -344,40 +348,11 @@ class GeneralNonLinearBiasReadoutBlock(torch.nn.Module):
         self.linear_2 = o3.Linear(
             irreps_in=self.hidden_irreps, irreps_out=self.irreps_out, biases=True
         )
-        layout_str = (
-            cueq_config.layout_str
-            if (cueq_config is not None and hasattr(cueq_config, "layout_str"))
-            else "mul_ir"
-        )
-        self._tp_to_mul_ir = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_nonlin,
-            source=layout_str,
-            target="mul_ir",
-            cueq_config=cueq_config,
-        )
-        self._tp_from_mul_ir_out = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_out,
-            source="mul_ir",
-            target=layout_str,
-            cueq_config=cueq_config,
-        )
 
-    def forward(
-        self,
-        x: torch.Tensor,
-    ) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
-        x = self.linear_1(x)
-        tp_to_mul_ir = getattr(self, "_tp_to_mul_ir", None)
-        if tp_to_mul_ir is not None:
-            x = tp_to_mul_ir(x)
-        x = self.equivariant_nonlin(x)
-        x = self.linear_mid(x)
-        x = self.equivariant_nonlin(x)
-        x = self.linear_2(x)
-        tp_from_mul_ir_out = getattr(self, "_tp_from_mul_ir_out", None)
-        if tp_from_mul_ir_out is not None:
-            x = tp_from_mul_ir_out(x)
-        return x  # [n_nodes, 1]
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.equivariant_nonlin(self.linear_1(x))
+        x = self.equivariant_nonlin(self.linear_mid(x))
+        return self.linear_2(x)
 
 
 @compile_mode("script")
@@ -521,7 +496,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         if use_cueq:
             if use_cueq_mul_ir:
                 node_feats = torch.transpose(node_feats, 1, 2)
-            index_attrs = torch.nonzero(node_attrs)[:, 1].int()
+            index_attrs = node_attrs.argmax(dim=-1).int()
             node_feats = self.symmetric_contractions(
                 node_feats.flatten(1),
                 index_attrs,
@@ -1275,12 +1250,13 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
         activation_fn = torch.nn.functional.silu
         act_gates_fn = torch.nn.functional.sigmoid
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[activation_fn for _ in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[act_gates_fn] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(self.cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
 
@@ -1315,19 +1291,6 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         )
         self.alpha = torch.nn.Parameter(torch.tensor(20.0), requires_grad=True)
         self.beta = torch.nn.Parameter(torch.tensor(0.0), requires_grad=True)
-
-        self.transpose_mul_ir = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_nonlin,
-            source="ir_mul",
-            target="mul_ir",
-            cueq_config=self.cueq_config,
-        )
-        self.transpose_ir_mul = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_out,
-            source="mul_ir",
-            target="ir_mul",
-            cueq_config=self.cueq_config,
-        )
 
     def forward(
         self,
@@ -1394,11 +1357,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         node_feats_res = self.truncate_ghosts(node_feats_res, n_real)
         message = self.linear_1(message) / (density * self.beta + self.alpha)
         message = message + node_feats_res
-        if self.transpose_mul_ir is not None:
-            message = self.transpose_mul_ir(message)
         message = self.equivariant_nonlin(message)
-        if self.transpose_ir_mul is not None:
-            message = self.transpose_ir_mul(message)
         message = self.linear_2(message)
         return (
             self.reshape(message),

--- a/mace/modules/gate.py
+++ b/mace/modules/gate.py
@@ -1,0 +1,250 @@
+"""
+Pure-torch gated equivariant nonlinearity, drop-in replacement for e3nn nn.Gate.
+
+Eliminates graph breaks caused by:
+  - if gates.shape[-1]: (data-dependent control flow)
+  - _Sortcut / Extract (fx.Graph codegen with dynamic slicing)
+  - ElementwiseTensorProduct (TorchScript)
+
+Supports both mul_ir (e3nn default) and ir_mul (cuequivariance) layouts,
+so callers can drop TransposeIrrepsLayout layers around the gate.
+"""
+
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import torch
+from e3nn import o3
+
+_NORM_CACHE: Dict[int, float] = {}
+
+
+def _normalize2mom_cst(fn: Callable) -> float:
+    """Compute the normalize2mom constant for an activation function.
+
+    Same logic as e3nn.math.normalize2mom: draw 1M samples from N(0,1),
+    compute sqrt(1 / E[f(z)^2]).  Results are cached by function identity.
+    """
+    key = id(fn)
+    cached = _NORM_CACHE.get(key)
+    if cached is not None:
+        return cached
+    gen = torch.Generator(device="cpu").manual_seed(0)
+    z = torch.randn(1_000_000, generator=gen, dtype=torch.float64)
+    second_moment = fn(z).pow(2).mean()
+    result = second_moment.pow(-0.5).item()
+    _NORM_CACHE[key] = result
+    return result
+
+
+class GatedEquivariantBlock(torch.nn.Module):
+    """Graph-break-free gated equivariant nonlinearity.
+
+    Drop-in replacement for ``e3nn.nn.Gate`` with identical numerics.
+    The input is the sorted direct sum of (scalars, gates, gated) irreps --
+    exactly the same convention as e3nn's Gate.
+
+    Supports ``layout="mul_ir"`` (e3nn default, multiplicity-first) and
+    ``layout="ir_mul"`` (cuequivariance, irrep-dimension-first).  When layout
+    is ``ir_mul``, the gated multiplication is adjusted so that no external
+    transpose layers are needed.
+
+    Parameters match ``e3nn.nn.Gate`` for compatibility, with the addition of
+    the ``layout`` keyword.
+    """
+
+    def __init__(
+        self,
+        irreps_scalars: o3.Irreps,
+        act_scalars: Sequence[Optional[Callable]],
+        irreps_gates: o3.Irreps,
+        act_gates: Sequence[Optional[Callable]],
+        irreps_gated: o3.Irreps,
+        layout: str = "mul_ir",
+    ):
+        super().__init__()
+        irreps_scalars = o3.Irreps(irreps_scalars)
+        irreps_gates = o3.Irreps(irreps_gates)
+        irreps_gated = o3.Irreps(irreps_gated)
+
+        if len(irreps_gates) > 0 and irreps_gates.lmax > 0:
+            raise ValueError(
+                f"Gate scalars must be scalars, got irreps_gates = {irreps_gates}"
+            )
+        if len(irreps_scalars) > 0 and irreps_scalars.lmax > 0:
+            raise ValueError(
+                f"Scalars must be scalars, got irreps_scalars = {irreps_scalars}"
+            )
+        if irreps_gates.num_irreps != irreps_gated.num_irreps:
+            raise ValueError(
+                f"irreps_gated has {irreps_gated.num_irreps} irreps but "
+                f"irreps_gates has {irreps_gates.num_irreps}"
+            )
+        if layout not in ("mul_ir", "ir_mul"):
+            raise ValueError(f"layout must be 'mul_ir' or 'ir_mul', got '{layout}'")
+
+        self._layout_is_ir_mul: bool = layout == "ir_mul"
+
+        irreps_in_unsorted = irreps_scalars + irreps_gates + irreps_gated
+        irreps_in_sorted, sort_perm, _ = irreps_in_unsorted.sort()
+        self._irreps_in = irreps_in_sorted.simplify()
+
+        irreps_scalars_out = self._compute_scalar_output_irreps(
+            irreps_scalars, act_scalars
+        )
+        self._irreps_out = irreps_scalars_out + irreps_gated
+
+        self.irreps_scalars = irreps_scalars
+        self.irreps_gates = irreps_gates
+        self.irreps_gated = irreps_gated
+
+        # ---------------------------------------------------------------
+        # Build slice indices as plain Python ints (compile-friendly,
+        # correct autograd through torch.narrow with int args).
+        # ---------------------------------------------------------------
+        n_scalar_groups = len(irreps_scalars)
+        n_gate_groups = len(irreps_gates)
+
+        scalar_sorted_indices: List[int] = []
+        gate_sorted_indices: List[int] = []
+        gated_sorted_indices: List[int] = []
+
+        for sorted_idx in range(len(irreps_in_unsorted)):
+            orig = int(sort_perm[sorted_idx])
+            if orig < n_scalar_groups:
+                scalar_sorted_indices.append(sorted_idx)
+            elif orig < n_scalar_groups + n_gate_groups:
+                gate_sorted_indices.append(sorted_idx)
+            else:
+                gated_sorted_indices.append(sorted_idx)
+
+        group_offsets: List[int] = []
+        offset = 0
+        for mul_ir in irreps_in_sorted:
+            group_offsets.append(offset)
+            offset += mul_ir.dim
+
+        if scalar_sorted_indices:
+            self._s_start: int = group_offsets[scalar_sorted_indices[0]]
+            self._s_len: int = sum(
+                irreps_in_sorted[i].dim for i in scalar_sorted_indices
+            )
+        else:
+            self._s_start = 0
+            self._s_len = 0
+
+        if gate_sorted_indices:
+            self._g_start: int = group_offsets[gate_sorted_indices[0]]
+            self._g_len: int = sum(irreps_in_sorted[i].dim for i in gate_sorted_indices)
+        else:
+            self._g_start = 0
+            self._g_len = 0
+
+        # Gated groups: (start, total_len, ir_dim, mul, gate_offset_in_gate_slice)
+        gate_offset_by_gated_orig: List[int] = []
+        cum = 0
+        for mul_ir in irreps_gated:
+            gate_offset_by_gated_orig.append(cum)
+            cum += mul_ir.mul
+
+        gated_info: List[Tuple[int, int, int, int, int]] = []
+        for si in gated_sorted_indices:
+            mul_ir = irreps_in_sorted[si]
+            gd_start = group_offsets[si]
+            gd_len = mul_ir.dim
+            ir_dim = mul_ir.ir.dim
+            mul = mul_ir.mul
+            gated_orig_idx = int(sort_perm[si]) - n_scalar_groups - n_gate_groups
+            g_off = gate_offset_by_gated_orig[gated_orig_idx]
+            gated_info.append((gd_start, gd_len, ir_dim, mul, g_off))
+
+        self._gated_info: List[Tuple[int, int, int, int, int]] = gated_info
+
+        if len(act_scalars) == 1 and len(irreps_scalars) > 1:
+            act_scalars = list(act_scalars) * len(irreps_scalars)
+        if len(act_gates) == 1 and len(irreps_gates) > 1:
+            act_gates = list(act_gates) * len(irreps_gates)
+
+        self._act_scalar: Optional[Callable] = None
+        self._scalar_cst: float = 1.0
+        if len(act_scalars) > 0 and act_scalars[0] is not None:
+            self._act_scalar = act_scalars[0]
+            self._scalar_cst = _normalize2mom_cst(act_scalars[0])
+
+        self._act_gate: Optional[Callable] = None
+        self._gate_cst: float = 1.0
+        if len(act_gates) > 0 and act_gates[0] is not None:
+            self._act_gate = act_gates[0]
+            self._gate_cst = _normalize2mom_cst(act_gates[0])
+
+    @staticmethod
+    def _compute_scalar_output_irreps(
+        irreps_scalars: o3.Irreps, act_scalars: Sequence[Optional[Callable]]
+    ) -> o3.Irreps:
+        """Determine output parity of scalar irreps after activation."""
+        if len(act_scalars) == 1 and len(irreps_scalars) > 1:
+            act_scalars = list(act_scalars) * len(irreps_scalars)
+
+        out = []
+        for (mul, (l_in, p_in)), act in zip(irreps_scalars, act_scalars):
+            if act is not None:
+                x = torch.linspace(0, 10, 256)
+                a1, a2 = act(x), act(-x)
+                if (a1 - a2).abs().max() < 1e-5:
+                    p_act = 1
+                elif (a1 + a2).abs().max() < 1e-5:
+                    p_act = -1
+                else:
+                    p_act = 0
+                p_out = p_act if p_in == -1 else p_in
+                out.append((mul, (0, p_out)))
+            else:
+                out.append((mul, (l_in, p_in)))
+        return o3.Irreps(out)
+
+    @property
+    def irreps_in(self) -> o3.Irreps:
+        return self._irreps_in
+
+    @property
+    def irreps_out(self) -> o3.Irreps:
+        return self._irreps_out
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        scalars = features.narrow(-1, self._s_start, self._s_len)
+        if self._act_scalar is not None:
+            scalars = self._act_scalar(scalars) * self._scalar_cst
+
+        if not self._gated_info:
+            return scalars
+
+        gates = features.narrow(-1, self._g_start, self._g_len)
+        if self._act_gate is not None:
+            gates = self._act_gate(gates) * self._gate_cst
+
+        ir_mul = self._layout_is_ir_mul
+        gated_parts: List[torch.Tensor] = []
+        for gd_start, gd_len, ir_dim, mul, g_off in self._gated_info:
+            gated_chunk = features.narrow(-1, gd_start, gd_len)
+            gate_chunk = gates.narrow(-1, g_off, mul)
+
+            batch_shape = features.shape[:-1]
+            if ir_mul:
+                # ir_mul: data is [c1_m1, c1_m2, ..., c2_m1, ...] → (ir_dim, mul)
+                gated_3d = gated_chunk.reshape(*batch_shape, ir_dim, mul)
+                gate_3d = gate_chunk.unsqueeze(-2)
+                result = (gated_3d * gate_3d).reshape(*batch_shape, ir_dim * mul)
+            else:
+                # mul_ir: data is [m1_c1, m1_c2, ..., m2_c1, ...] → (mul, ir_dim)
+                gated_3d = gated_chunk.reshape(*batch_shape, mul, ir_dim)
+                gate_3d = gate_chunk.unsqueeze(-1)
+                result = (gated_3d * gate_3d).reshape(*batch_shape, mul * ir_dim)
+            gated_parts.append(result)
+
+        return torch.cat([scalars] + gated_parts, dim=-1)
+
+    def __repr__(self) -> str:
+        layout = "ir_mul" if self._layout_is_ir_mul else "mul_ir"
+        return (
+            f"{self.__class__.__name__} "
+            f"({self.irreps_in} -> {self.irreps_out} | {layout})"
+        )

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -76,6 +76,7 @@ def get_symmetric_displacement(
     edge_index: torch.Tensor,
     num_graphs: int,
     batch: torch.Tensor,
+    displacement: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if cell is None:
         cell = torch.zeros(
@@ -85,12 +86,13 @@ def get_symmetric_displacement(
             device=positions.device,
         )
     sender = edge_index[0]
-    displacement = torch.zeros(
-        (num_graphs, 3, 3),
-        dtype=positions.dtype,
-        device=positions.device,
-    )
-    displacement.requires_grad_(True)
+    if displacement is None:
+        displacement = torch.zeros(
+            (num_graphs, 3, 3),
+            dtype=positions.dtype,
+            device=positions.device,
+        )
+        displacement = displacement + positions.sum() * 0.0
     symmetric_displacement = 0.5 * (
         displacement + displacement.transpose(-1, -2)
     )  # From https://github.com/mir-group/nequip
@@ -643,6 +645,7 @@ def prepare_graph(
                 edge_index=data["edge_index"],
                 num_graphs=num_graphs,
                 batch=data["batch"],
+                displacement=data.get("displacement"),
             )
             data["positions"], data["shifts"] = p, s
         vectors, lengths = get_edge_vectors_and_lengths(

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -170,8 +170,8 @@ def with_oeq_conv_fusion(
     conv_tp.original_forward = conv_tp.forward
     if not hasattr(conv_tp, "weight_numel"):
         conv_tp.weight_numel = conv_tp.input_args["problem"].weight_numel
-    conv_tp._transpose_in = transpose_in
-    conv_tp._transpose_out = transpose_out
+    conv_tp.layout_transpose_in = transpose_in
+    conv_tp.layout_transpose_out = transpose_out
 
     def forward(
         self,
@@ -182,8 +182,8 @@ def with_oeq_conv_fusion(
     ) -> torch.Tensor:
         sender = edge_index[0]
         receiver = edge_index[1]
-        if self._transpose_in is not None:
-            node_feats = self._transpose_in(node_feats)
+        if self.layout_transpose_in is not None:
+            node_feats = self.layout_transpose_in(node_feats)
         out = self.original_forward(
             node_feats,
             edge_attrs,
@@ -191,8 +191,8 @@ def with_oeq_conv_fusion(
             receiver,
             sender,
         )
-        if self._transpose_out is not None:
-            out = self._transpose_out(out)
+        if self.layout_transpose_out is not None:
+            out = self.layout_transpose_out(out)
         return out
 
     conv_tp.forward = types.MethodType(forward, conv_tp)

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -151,6 +151,76 @@ def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
     return conv_tp
 
 
+def with_oeq_conv_fusion(
+    conv_tp: torch.nn.Module,
+    transpose_in: Optional[torch.nn.Module] = None,
+    transpose_out: Optional[torch.nn.Module] = None,
+) -> torch.nn.Module:
+    """Wraps an oeq.TensorProductConv to match MACE's conv_tp calling convention.
+
+    oeq.TensorProductConv.forward(X, Y, W, rows, cols) performs a fused
+    tensor-product + scatter.  MACE interaction blocks call
+    conv_tp(node_feats, edge_attrs, tp_weights, edge_index) where
+    edge_index[0]=sender, edge_index[1]=receiver.
+
+    When cueq is active with ir_mul layout, optional transpose modules
+    convert node_feats from ir_mul → mul_ir before the oeq forward and
+    the output from mul_ir → ir_mul after, since oeq always uses mul_ir.
+    """
+    conv_tp.original_forward = conv_tp.forward
+    if not hasattr(conv_tp, "weight_numel"):
+        conv_tp.weight_numel = conv_tp.input_args["problem"].weight_numel
+    conv_tp._transpose_in = transpose_in
+    conv_tp._transpose_out = transpose_out
+
+    def forward(
+        self,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        tp_weights: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        if self._transpose_in is not None:
+            node_feats = self._transpose_in(node_feats)
+        out = self.original_forward(
+            node_feats,
+            edge_attrs,
+            tp_weights,
+            receiver,
+            sender,
+        )
+        if self._transpose_out is not None:
+            out = self._transpose_out(out)
+        return out
+
+    conv_tp.forward = types.MethodType(forward, conv_tp)
+    return conv_tp
+
+
+def with_oeq_scatter_sum(conv_tp: torch.nn.Module) -> torch.nn.Module:
+    """Wraps an oeq.TensorProduct (non-fused) to add scatter like e3nn path."""
+    conv_tp.original_forward = conv_tp.forward
+
+    def forward(
+        self,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        tp_weights: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        num_nodes = node_feats.shape[0]
+        mji = self.original_forward(node_feats[sender], edge_attrs, tp_weights)
+        message = scatter_sum(src=mji, index=receiver, dim=0, dim_size=num_nodes)
+        return message
+
+    conv_tp.forward = types.MethodType(forward, conv_tp)
+    return conv_tp
+
+
 class TensorProduct:
     """Wrapper around o3.TensorProduct/cuet.ChannelwiseTensorProduct/oeq.TensorProduct followed by a scatter sum"""
 
@@ -216,9 +286,32 @@ class TensorProduct:
             )
 
             if oeq_config.conv_fusion is None:
-                return oeq.TensorProduct(tpp)
+                return with_oeq_scatter_sum(oeq.TensorProduct(tpp))
             if oeq_config.conv_fusion == "atomic":
-                return oeq.TensorProductConv(tpp, deterministic=False)
+                t_in, t_out = None, None
+                if (
+                    CUET_AVAILABLE
+                    and cueq_config is not None
+                    and cueq_config.enabled
+                    and cueq_config.layout_str == "ir_mul"
+                ):
+                    t_in = cuet.TransposeIrrepsLayout(
+                        cue.Irreps(cueq_config.group, irreps_in1),
+                        source=cue.ir_mul,
+                        target=cue.mul_ir,
+                        use_fallback=True,
+                    )
+                    t_out = cuet.TransposeIrrepsLayout(
+                        cue.Irreps(cueq_config.group, irreps_out),
+                        source=cue.mul_ir,
+                        target=cue.ir_mul,
+                        use_fallback=True,
+                    )
+                return with_oeq_conv_fusion(
+                    oeq.TensorProductConv(tpp, deterministic=False),
+                    transpose_in=t_in,
+                    transpose_out=t_out,
+                )
 
             raise ValueError(f"Unknown conv_fusion option: {oeq_config.conv_fusion}")
 

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -55,6 +55,13 @@ class CuEquivarianceConfig:
             self.enabled = False
 
 
+def get_layout(cueq_config: Optional["CuEquivarianceConfig"] = None) -> str:
+    """Return the irreps layout string for the active backend."""
+    if cueq_config is not None and cueq_config.enabled:
+        return getattr(cueq_config, "layout_str", "mul_ir")
+    return "mul_ir"
+
+
 @dataclasses.dataclass
 class OEQConfig:
     """Configuration for cuequivariance acceleration"""

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -498,7 +498,7 @@ def remove_pt_head(
 
 def extract_model(model: torch.nn.Module, map_location: str = "cpu") -> torch.nn.Module:
     model_copy = model.__class__(**extract_config_mace_model(model))
-    model_copy.load_state_dict(model.state_dict())
+    model_copy.load_state_dict(model.state_dict(), strict=False)
     return model_copy.to(map_location)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,8 @@ dev =
     pytest-benchmark
     pylint
 schedulefree = schedulefree
+torchsim =
+    torch-sim-atomistic; python_version >= "3.12"
 cueq = cuequivariance-torch>=0.2.0
 cueq-cuda-11 = cuequivariance-ops-torch-cu11>=0.2.0
 cueq-cuda-12 = cuequivariance-ops-torch-cu12>=0.2.0

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -883,6 +883,7 @@ def test_calculator_padding(trained_model, fitting_configs):
     water_no_pad.calc = calc_no_pad
     e_no_pad = water_no_pad.get_potential_energy()
     f_no_pad = water_no_pad.get_forces()
+    s_no_pad = water_no_pad.get_stress()
 
     calc_pad = MACECalculator(
         models=trained_model.models[0],
@@ -895,6 +896,8 @@ def test_calculator_padding(trained_model, fitting_configs):
     water_pad.calc = calc_pad
     e_pad = water_pad.get_potential_energy()
     f_pad = water_pad.get_forces()
+    s_pad = water_pad.get_stress()
 
     assert np.allclose(e_no_pad, e_pad, atol=1e-6)
     assert np.allclose(f_no_pad, f_pad, atol=1e-6)
+    assert np.allclose(s_no_pad, s_pad, atol=1e-6)

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -870,3 +870,31 @@ def test_mace_omol_cueq(tmp_path, device="cpu"):
     assert np.allclose(forces, forces_cueq, atol=1e-6)
     assert np.allclose(energy, -2079.863496758961, atol=1e-9)
     write_extxyz_test(tmp_path, mol)
+
+
+def test_calculator_padding(trained_model, fitting_configs):
+    """Calculator with graph padding should give the same results as without."""
+    water = fitting_configs[2].copy()
+
+    calc_no_pad = MACECalculator(
+        models=trained_model.models[0], device="cpu", default_dtype="float64"
+    )
+    water_no_pad = water.copy()
+    water_no_pad.calc = calc_no_pad
+    e_no_pad = water_no_pad.get_potential_energy()
+    f_no_pad = water_no_pad.get_forces()
+
+    calc_pad = MACECalculator(
+        models=trained_model.models[0],
+        device="cpu",
+        default_dtype="float64",
+        pad_num_atoms=10,
+        pad_num_edges=128,
+    )
+    water_pad = water.copy()
+    water_pad.calc = calc_pad
+    e_pad = water_pad.get_potential_energy()
+    f_pad = water_pad.get_forces()
+
+    assert np.allclose(e_no_pad, e_pad, atol=1e-6)
+    assert np.allclose(f_no_pad, f_pad, atol=1e-6)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -169,10 +169,22 @@ def test_eager_benchmark(
 @pytest.mark.parametrize("enable_amp", [False, True], ids=["fp32", "mixed"])
 @pytest.mark.parametrize("enable_cueq", [False, True])
 def test_compile_benchmark(benchmark, compile_mode, enable_amp, enable_cueq):
+    _torch_version = tuple(
+        int(x) for x in torch.__version__.split("+")[0].split(".")[:2]
+    )
+    if (
+        enable_cueq
+        and compile_mode in ("reduce-overhead", "max-autotune")
+        and _torch_version < (2, 10)
+    ):
+        pytest.skip("cueq + CUDA graphs requires PyTorch >= 2.10")
     with tools.torch_tools.default_dtype(torch.float32):
-        batch = create_batch("cuda")
-        batch["positions"].requires_grad_(True)  # since compile_mode is not None
         torch.compiler.reset()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+        batch = create_batch("cuda")
+        batch["positions"].requires_grad_(True)
         model = mace_compile.prepare(create_mace)("cuda", enable_cueq=enable_cueq)
         model = torch.compile(model, mode=compile_mode)
         model = time_func(model)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -128,6 +128,29 @@ def test_mace(device, default_dtype):  # pylint: disable=W0621
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Not supported on Windows")
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_mace_compile_stress(device, default_dtype):  # pylint: disable=W0621
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip(reason="cuda is not available")
+
+    model_eager = create_mace(device)
+    batch_eager = create_batch(device)
+    output_eager = model_eager(batch_eager, compute_stress=True)
+
+    tmp_model = mace_compile.prepare(create_mace)(device)
+    model_compiled = torch.compile(tmp_model, mode="default", fullgraph=True)
+    batch_compiled = create_batch(device)
+    batch_compiled["positions"].requires_grad_(True)
+    output_compiled = model_compiled(batch_compiled, training=True, compute_stress=True)
+
+    assert_close(output_eager["energy"], output_compiled["energy"])
+    assert_close(output_eager["forces"], output_compiled["forces"])
+    assert output_eager["stress"] is not None
+    assert output_compiled["stress"] is not None
+    assert_close(output_eager["stress"], output_compiled["stress"])
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not supported on Windows")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda is not available")
 @pytest.mark.parametrize("enable_cueq", [True, False])
 def test_eager_benchmark(

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,365 @@
+"""Tests for GatedEquivariantBlock vs e3nn nn.Gate.
+
+Parametrized over irreps configs, dtypes, batch sizes, and layouts.
+Compares forward values, backward gradients, second derivatives, and
+verifies zero graph breaks under torch.compile for both mul_ir and ir_mul.
+"""
+
+import pytest
+import torch
+import torch.serialization
+
+torch.serialization.add_safe_globals([slice])
+
+from e3nn import nn as e3nn_nn  # noqa: E402
+from e3nn import o3
+
+from mace.modules.gate import GatedEquivariantBlock  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Irreps configurations matching MACE usage patterns
+# ---------------------------------------------------------------------------
+IRREPS_CONFIGS = {
+    "scalars_only": {
+        "irreps_scalars": o3.Irreps("128x0e"),
+        "irreps_gates": o3.Irreps(""),
+        "irreps_gated": o3.Irreps(""),
+    },
+    "scalars_l1": {
+        "irreps_scalars": o3.Irreps("128x0e"),
+        "irreps_gates": o3.Irreps("128x0e"),
+        "irreps_gated": o3.Irreps("128x1o"),
+    },
+    "scalars_l1_l2": {
+        "irreps_scalars": o3.Irreps("64x0e"),
+        "irreps_gates": o3.Irreps("64x0e+64x0e"),
+        "irreps_gated": o3.Irreps("64x1o+64x2e"),
+    },
+    "scalars_l1_l2_simplified_gates": {
+        "irreps_scalars": o3.Irreps("64x0e"),
+        "irreps_gates": o3.Irreps("128x0e"),
+        "irreps_gated": o3.Irreps("64x1o+64x2e"),
+    },
+}
+
+CONFIGS_WITH_GATED = [k for k, v in IRREPS_CONFIGS.items() if v["irreps_gated"].dim > 0]
+DTYPES = [torch.float32, torch.float64]
+BATCH_SIZES = [1, 32, 256]
+LAYOUTS = ["mul_ir", "ir_mul"]
+
+
+def _make_gates(config, layout="mul_ir", act_scalars=None, act_gates=None):
+    """Build both an e3nn Gate and a GatedEquivariantBlock from the same spec."""
+    irreps_scalars = config["irreps_scalars"]
+    irreps_gates = config["irreps_gates"]
+    irreps_gated = config["irreps_gated"]
+
+    if act_scalars is None:
+        act_scalars = [torch.nn.functional.silu for _ in irreps_scalars]
+    if act_gates is None:
+        act_gates = [torch.nn.functional.sigmoid] * len(irreps_gates)
+
+    ref = e3nn_nn.Gate(
+        irreps_scalars=irreps_scalars,
+        act_scalars=act_scalars,
+        irreps_gates=irreps_gates,
+        act_gates=act_gates,
+        irreps_gated=irreps_gated,
+    )
+    ours = GatedEquivariantBlock(
+        irreps_scalars=irreps_scalars,
+        act_scalars=act_scalars,
+        irreps_gates=irreps_gates,
+        act_gates=act_gates,
+        irreps_gated=irreps_gated,
+        layout=layout,
+    )
+    return ref, ours
+
+
+# ---------------------------------------------------------------------------
+# Layout transpose helper
+# ---------------------------------------------------------------------------
+def _transpose_group(x: torch.Tensor, mul: int, ir_dim: int, to_ir_mul: bool):
+    """Transpose a single (mul, ir) group between mul_ir and ir_mul layouts."""
+    batch_shape = x.shape[:-1]
+    if to_ir_mul:
+        return (
+            x.reshape(*batch_shape, mul, ir_dim)
+            .transpose(-1, -2)
+            .reshape(*batch_shape, mul * ir_dim)
+        )
+    return (
+        x.reshape(*batch_shape, ir_dim, mul)
+        .transpose(-1, -2)
+        .reshape(*batch_shape, mul * ir_dim)
+    )
+
+
+def _transpose_irreps(x: torch.Tensor, irreps: o3.Irreps, to_ir_mul: bool):
+    """Transpose a full irreps tensor between mul_ir and ir_mul layouts."""
+    parts = []
+    offset = 0
+    for mul_ir in irreps:
+        dim = mul_ir.dim
+        chunk = x.narrow(-1, offset, dim)
+        ir_dim = mul_ir.ir.dim
+        if ir_dim > 1:
+            chunk = _transpose_group(chunk, mul_ir.mul, ir_dim, to_ir_mul)
+        parts.append(chunk)
+        offset += dim
+    return torch.cat(parts, dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# Test: irreps_in / irreps_out properties
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_irreps_properties(config_name, layout):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout=layout)
+    assert (
+        ours.irreps_in == ref.irreps_in
+    ), f"irreps_in mismatch: {ours.irreps_in} vs {ref.irreps_in}"
+    assert (
+        ours.irreps_out == ref.irreps_out
+    ), f"irreps_out mismatch: {ours.irreps_out} vs {ref.irreps_out}"
+
+
+# ---------------------------------------------------------------------------
+# Test: forward values match e3nn (mul_ir layout, direct comparison)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=["B1", "B32", "B256"])
+def test_forward_matches_e3nn(config_name, dtype, batch_size):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(42)
+    x = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype)
+
+    y_ref = ref(x)
+    y_ours = ours(x)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(
+        y_ours, y_ref, atol=atol, rtol=0
+    ), f"Forward mismatch: max diff = {(y_ours - y_ref).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: ir_mul layout produces same result as mul_ir with manual transposes
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", CONFIGS_WITH_GATED)
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", [1, 64], ids=["B1", "B64"])
+def test_ir_mul_matches_mul_ir_via_transpose(config_name, dtype, batch_size):
+    """ir_mul gate on transposed input should give same output as mul_ir gate."""
+    config = IRREPS_CONFIGS[config_name]
+
+    gate_mul_ir = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="mul_ir",
+    ).to(dtype)
+
+    gate_ir_mul = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="ir_mul",
+    ).to(dtype)
+
+    torch.manual_seed(99)
+    x_mul_ir = torch.randn(batch_size, gate_mul_ir.irreps_in.dim, dtype=dtype)
+
+    x_ir_mul = _transpose_irreps(x_mul_ir, gate_mul_ir.irreps_in, to_ir_mul=True)
+
+    y_mul_ir = gate_mul_ir(x_mul_ir)
+    y_ir_mul = gate_ir_mul(x_ir_mul)
+
+    y_ir_mul_as_mul_ir = _transpose_irreps(
+        y_ir_mul, gate_ir_mul.irreps_out, to_ir_mul=False
+    )
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(y_mul_ir, y_ir_mul_as_mul_ir, atol=atol, rtol=0), (
+        f"Layout mismatch: max diff = "
+        f"{(y_mul_ir - y_ir_mul_as_mul_ir).abs().max().item()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: backward gradients match e3nn
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=["B1", "B32", "B256"])
+def test_backward_matches_e3nn(config_name, dtype, batch_size):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(42)
+    x_ref = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype, requires_grad=True)
+    x_ours = x_ref.detach().clone().requires_grad_(True)
+
+    y_ref = ref(x_ref)
+    y_ours = ours(x_ours)
+
+    grad_out = torch.randn_like(y_ref)
+    y_ref.backward(grad_out)
+    y_ours.backward(grad_out)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(
+        x_ours.grad, x_ref.grad, atol=atol, rtol=0
+    ), f"Backward mismatch: max diff = {(x_ours.grad - x_ref.grad).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: backward gradients for ir_mul layout
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", CONFIGS_WITH_GATED)
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_backward_ir_mul(config_name, dtype):
+    """Gradients through ir_mul gate should be self-consistent."""
+    config = IRREPS_CONFIGS[config_name]
+    gate = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="ir_mul",
+    ).to(dtype)
+
+    torch.manual_seed(77)
+    x = torch.randn(16, gate.irreps_in.dim, dtype=dtype, requires_grad=True)
+    y = gate(x)
+    loss = y.sum()
+    loss.backward()
+    assert x.grad is not None
+    assert not torch.isnan(x.grad).any()
+    assert not torch.isinf(x.grad).any()
+
+
+# ---------------------------------------------------------------------------
+# Test: second derivatives (Hessian-vector products) match e3nn
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_second_derivative_matches_e3nn(config_name, dtype):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    batch_size = 8
+    torch.manual_seed(42)
+    x_ref = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype, requires_grad=True)
+    x_ours = x_ref.detach().clone().requires_grad_(True)
+
+    grad_out = torch.randn(batch_size, ref.irreps_out.dim, dtype=dtype)
+    v = torch.randn_like(x_ref)
+
+    y_ref = ref(x_ref)
+    (g_ref,) = torch.autograd.grad(y_ref, x_ref, grad_out, create_graph=True)
+    (hvp_ref,) = torch.autograd.grad(g_ref, x_ref, v)
+
+    y_ours = ours(x_ours)
+    (g_ours,) = torch.autograd.grad(y_ours, x_ours, grad_out, create_graph=True)
+    (hvp_ours,) = torch.autograd.grad(g_ours, x_ours, v)
+
+    atol = 1e-4 if dtype == torch.float32 else 1e-10
+    assert torch.allclose(
+        hvp_ours, hvp_ref, atol=atol, rtol=0
+    ), f"Second-derivative mismatch: max diff = {(hvp_ours - hvp_ref).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: no graph breaks under torch.compile (both layouts)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "config_name", ["scalars_l1", "scalars_l1_l2", "scalars_l1_l2_simplified_gates"]
+)
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_no_graph_breaks(config_name, layout):
+    config = IRREPS_CONFIGS[config_name]
+    _, ours = _make_gates(config, layout=layout)
+
+    x = torch.randn(4, ours.irreps_in.dim)
+    explanation = torch._dynamo.explain(ours)(x)
+    assert explanation.graph_break_count == 0, (
+        f"Graph breaks found ({layout}): {explanation.graph_break_count}\n"
+        f"Break reasons: {explanation.break_reasons}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: custom activation functions
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_custom_activations(dtype):
+    config = IRREPS_CONFIGS["scalars_l1"]
+    act_scalars = [torch.tanh for _ in config["irreps_scalars"]]
+    act_gates = [torch.tanh] * len(config["irreps_gates"])
+
+    ref, ours = _make_gates(
+        config, layout="mul_ir", act_scalars=act_scalars, act_gates=act_gates
+    )
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(123)
+    x = torch.randn(16, ref.irreps_in.dim, dtype=dtype)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(ours(x), ref(x), atol=atol, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Test: invalid layout raises ValueError
+# ---------------------------------------------------------------------------
+def test_invalid_layout():
+    config = IRREPS_CONFIGS["scalars_l1"]
+    with pytest.raises(ValueError, match="layout must be"):
+        GatedEquivariantBlock(
+            irreps_scalars=config["irreps_scalars"],
+            act_scalars=[torch.nn.functional.silu],
+            irreps_gates=config["irreps_gates"],
+            act_gates=[torch.nn.functional.sigmoid],
+            irreps_gated=config["irreps_gated"],
+            layout="bad_layout",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: repr includes layout info
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_repr(layout):
+    config = IRREPS_CONFIGS["scalars_l1"]
+    _, ours = _make_gates(config, layout=layout)
+    r = repr(ours)
+    assert layout in r
+
+
+# ---------------------------------------------------------------------------
+# Test: _normalize2mom_cst caching
+# ---------------------------------------------------------------------------
+def test_normalize2mom_caching():
+    from mace.modules.gate import _NORM_CACHE, _normalize2mom_cst
+
+    _NORM_CACHE.clear()
+    fn = torch.nn.functional.silu
+    c1 = _normalize2mom_cst(fn)
+    c2 = _normalize2mom_cst(fn)
+    assert c1 == c2
+    assert id(fn) in _NORM_CACHE

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,0 +1,87 @@
+"""Tests for graph padding utilities and padded calculator inference."""
+
+import numpy as np
+import pytest
+import torch
+from ase import build
+
+from mace.data import AtomicData
+from mace.data.padding_tools import build_fake_padding_graph
+from mace.tools import torch_geometric, utils
+
+
+@pytest.fixture(scope="module")
+def water_graph():
+    water = build.molecule("H2O")
+    water.cell = [6.0] * 3
+    water.pbc = True
+    z_table = utils.AtomicNumberTable([1, 8])
+    from mace import data as mace_data
+
+    keyspec = mace_data.KeySpecification(info_keys={}, arrays_keys={})
+    config = mace_data.config_from_atoms(water, key_specification=keyspec)
+    graph = AtomicData.from_config(config, z_table=z_table, cutoff=3.5)
+    return graph
+
+
+class TestBuildFakePaddingGraph:
+    def test_basic_shape(self, water_graph):
+        pad_atoms = 10
+        pad_edges = 32
+        fake = build_fake_padding_graph(water_graph, pad_atoms, pad_edges, r_max=3.5)
+        assert fake["node_attrs"].shape[0] == pad_atoms
+        assert fake["edge_index"].shape[1] == pad_edges
+        assert fake["positions"].shape == (pad_atoms, 3)
+
+    def test_edge_index_within_bounds(self, water_graph):
+        pad_atoms = 5
+        pad_edges = 20
+        fake = build_fake_padding_graph(water_graph, pad_atoms, pad_edges, r_max=3.5)
+        assert fake["edge_index"].max() < pad_atoms
+        assert fake["edge_index"].min() >= 0
+
+    def test_zero_edges(self, water_graph):
+        fake = build_fake_padding_graph(
+            water_graph, num_atoms=3, num_edges=0, r_max=3.5
+        )
+        assert fake["edge_index"].shape[1] == 0
+        assert fake["node_attrs"].shape[0] == 3
+
+    def test_raises_on_zero_atoms(self, water_graph):
+        with pytest.raises(ValueError, match="at least one fake atom"):
+            build_fake_padding_graph(water_graph, num_atoms=0, num_edges=10, r_max=3.5)
+
+    def test_cell_scale(self, water_graph):
+        r_max = 5.0
+        fake = build_fake_padding_graph(
+            water_graph, num_atoms=2, num_edges=4, r_max=r_max
+        )
+        expected_scale = max(r_max * 2.0, 1.0)
+        assert torch.allclose(
+            fake["cell"],
+            torch.eye(3, dtype=fake["cell"].dtype) * expected_scale,
+        )
+
+    def test_pbc_disabled(self, water_graph):
+        fake = build_fake_padding_graph(
+            water_graph, num_atoms=2, num_edges=4, r_max=3.5
+        )
+        assert not fake["pbc"].any()
+
+    def test_batch_collation(self, water_graph):
+        """Padding graph can be batched with the real graph."""
+        fake = build_fake_padding_graph(
+            water_graph, num_atoms=5, num_edges=16, r_max=3.5
+        )
+        batch = torch_geometric.Batch.from_data_list([water_graph, fake])
+        total_atoms = water_graph["node_attrs"].shape[0] + 5
+        total_edges = water_graph["edge_index"].shape[1] + 16
+        assert batch["node_attrs"].shape[0] == total_atoms
+        assert batch["edge_index"].shape[1] == total_edges
+        assert batch["batch"].shape[0] == total_atoms
+
+    def test_node_attrs_first_species_set(self, water_graph):
+        fake = build_fake_padding_graph(
+            water_graph, num_atoms=4, num_edges=8, r_max=3.5
+        )
+        assert (fake["node_attrs"][:, 0] == 1.0).all()

--- a/tests/test_torchsim.py
+++ b/tests/test_torchsim.py
@@ -1,0 +1,239 @@
+"""Tests for the MACE TorchSim model interface."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from ase import build
+
+try:
+    import torch_sim as ts
+
+    TORCHSIM_AVAILABLE = True
+except ImportError:
+    TORCHSIM_AVAILABLE = False
+
+try:
+    import cuequivariance as cue  # noqa: F401
+
+    CUET_AVAILABLE = True
+except ImportError:
+    CUET_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not TORCHSIM_AVAILABLE, reason="torch-sim not installed"
+)
+
+pytest_mace_dir = Path(__file__).parent.parent
+run_train = Path(__file__).parent.parent / "mace" / "cli" / "run_train.py"
+
+
+@pytest.fixture(scope="module")
+def trained_model_path(tmp_path_factory):
+    """Train a minimal MACE model and return the path to the model file."""
+    from ase.atoms import Atoms
+
+    water = Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0, -2.0, 0], [1, 0, 0], [0, 1, 0]],
+        cell=[4] * 3,
+        pbc=[True] * 3,
+    )
+    fit_configs = [
+        Atoms(numbers=[8], positions=[[0, 0, 0]], cell=[6] * 3),
+        Atoms(numbers=[1], positions=[[0, 0, 0]], cell=[6] * 3),
+    ]
+    fit_configs[0].info["REF_energy"] = 1.0
+    fit_configs[0].info["config_type"] = "IsolatedAtom"
+    fit_configs[1].info["REF_energy"] = -0.5
+    fit_configs[1].info["config_type"] = "IsolatedAtom"
+
+    np.random.seed(42)
+    for _ in range(10):
+        c = water.copy()
+        c.positions += np.random.normal(0.1, size=c.positions.shape)
+        c.info["REF_energy"] = np.random.normal(0.1)
+        c.new_array("REF_forces", np.random.normal(0.1, size=c.positions.shape))
+        c.info["REF_stress"] = np.random.normal(0.1, size=6)
+        fit_configs.append(c)
+
+    tmp_path = tmp_path_factory.mktemp("torchsim_model_")
+    import ase.io
+
+    ase.io.write(tmp_path / "fit.xyz", fit_configs)
+
+    mace_params = {
+        "name": "MACE",
+        "valid_fraction": 0.05,
+        "energy_weight": 1.0,
+        "forces_weight": 10.0,
+        "stress_weight": 1.0,
+        "model": "MACE",
+        "hidden_irreps": "32x0e",
+        "r_max": 3.5,
+        "batch_size": 5,
+        "max_num_epochs": 5,
+        "device": "cpu",
+        "seed": 42,
+        "loss": "stress",
+        "energy_key": "REF_energy",
+        "forces_key": "REF_forces",
+        "stress_key": "REF_stress",
+        "eval_interval": 2,
+        "checkpoints_dir": str(tmp_path),
+        "model_dir": str(tmp_path),
+        "train_file": str(tmp_path / "fit.xyz"),
+    }
+
+    run_env = os.environ.copy()
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    run_env["PYTHONPATH"] = ":".join(sys.path)
+
+    cmd = (
+        sys.executable
+        + " "
+        + str(run_train)
+        + " "
+        + " ".join(
+            [
+                (f"--{k}={v}" if v is not None else f"--{k}")
+                for k, v in mace_params.items()
+            ]
+        )
+    )
+    p = subprocess.run(cmd.split(), env=run_env, check=True)
+    assert p.returncode == 0
+    return tmp_path / "MACE.model"
+
+
+@pytest.fixture(scope="module")
+def water_atoms():
+    from ase.atoms import Atoms
+
+    atoms = Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0, -2.0, 0], [1, 0, 0], [0, 1, 0]],
+        cell=[4] * 3,
+        pbc=[True] * 3,
+    )
+    return atoms
+
+
+def test_torchsim_basic(trained_model_path, water_atoms):
+    from mace.calculators.mace_torchsim import MaceTorchSimModel
+
+    model = MaceTorchSimModel(
+        model=trained_model_path,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+        compute_forces=True,
+        compute_stress=True,
+    )
+
+    state = ts.io.atoms_to_state(
+        water_atoms, device=torch.device("cpu"), dtype=torch.float64
+    )
+
+    results = model(state)
+    assert "energy" in results
+    assert "forces" in results
+    assert "stress" in results
+    assert results["energy"].shape == (1,)
+    assert results["forces"].shape[0] == len(water_atoms)
+    assert results["forces"].shape[1] == 3
+
+
+def test_torchsim_no_stress(trained_model_path, water_atoms):
+    from mace.calculators.mace_torchsim import MaceTorchSimModel
+
+    model = MaceTorchSimModel(
+        model=trained_model_path,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+        compute_forces=True,
+        compute_stress=False,
+    )
+
+    state = ts.io.atoms_to_state(
+        water_atoms, device=torch.device("cpu"), dtype=torch.float64
+    )
+
+    results = model(state)
+    assert "energy" in results
+    assert "forces" in results
+
+
+def test_torchsim_matches_ase_calculator(trained_model_path, water_atoms):
+    from mace.calculators.mace import MACECalculator
+    from mace.calculators.mace_torchsim import MaceTorchSimModel
+
+    ase_calc = MACECalculator(
+        model_paths=trained_model_path, device="cpu", default_dtype="float64"
+    )
+    atoms_ase = water_atoms.copy()
+    atoms_ase.calc = ase_calc
+    ase_energy = atoms_ase.get_potential_energy()
+    ase_forces = atoms_ase.get_forces()
+
+    ts_model = MaceTorchSimModel(
+        model=trained_model_path,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+    )
+    state = ts.io.atoms_to_state(
+        water_atoms, device=torch.device("cpu"), dtype=torch.float64
+    )
+    ts_results = ts_model(state)
+
+    np.testing.assert_allclose(
+        ts_results["energy"].item(), ase_energy, atol=1e-5, rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        ts_results["forces"].detach().cpu().numpy(), ase_forces, atol=1e-5, rtol=1e-5
+    )
+
+
+@pytest.mark.skipif(not CUET_AVAILABLE, reason="cuequivariance not installed")
+def test_torchsim_cueq(trained_model_path, water_atoms):
+    from mace.calculators.mace_torchsim import MaceTorchSimModel
+
+    model = MaceTorchSimModel(
+        model=trained_model_path,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+        enable_cueq=True,
+    )
+
+    state = ts.io.atoms_to_state(
+        water_atoms, device=torch.device("cpu"), dtype=torch.float64
+    )
+
+    results = model(state)
+    assert "energy" in results
+    assert "forces" in results
+
+
+def test_torchsim_batched(trained_model_path, water_atoms):
+    from mace.calculators.mace_torchsim import MaceTorchSimModel
+
+    w1 = water_atoms.copy()
+    w2 = water_atoms.copy()
+    w2.positions += np.random.RandomState(0).normal(0.01, size=w2.positions.shape)
+
+    model = MaceTorchSimModel(
+        model=trained_model_path,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+    )
+
+    state = ts.io.atoms_to_state(
+        [w1, w2], device=torch.device("cpu"), dtype=torch.float64
+    )
+
+    results = model(state)
+    assert results["energy"].shape == (2,)
+    assert results["forces"].shape == (len(w1) + len(w2), 3)

--- a/tests/test_torchsim.py
+++ b/tests/test_torchsim.py
@@ -168,6 +168,8 @@ def test_torchsim_no_stress(trained_model_path, water_atoms):
 
 
 def test_torchsim_matches_ase_calculator(trained_model_path, water_atoms):
+    from ase.stress import full_3x3_to_voigt_6_stress
+
     from mace.calculators.mace import MACECalculator
     from mace.calculators.mace_torchsim import MaceTorchSimModel
 
@@ -178,6 +180,7 @@ def test_torchsim_matches_ase_calculator(trained_model_path, water_atoms):
     atoms_ase.calc = ase_calc
     ase_energy = atoms_ase.get_potential_energy()
     ase_forces = atoms_ase.get_forces()
+    ase_stress = atoms_ase.get_stress()
 
     ts_model = MaceTorchSimModel(
         model=trained_model_path,
@@ -195,6 +198,10 @@ def test_torchsim_matches_ase_calculator(trained_model_path, water_atoms):
     np.testing.assert_allclose(
         ts_results["forces"].detach().cpu().numpy(), ase_forces, atol=1e-5, rtol=1e-5
     )
+    ts_stress_voigt = full_3x3_to_voigt_6_stress(
+        ts_results["stress"].detach().cpu().numpy().reshape(3, 3)
+    )
+    np.testing.assert_allclose(ts_stress_voigt, ase_stress, atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.skipif(not CUET_AVAILABLE, reason="cuequivariance not installed")


### PR DESCRIPTION
## Summary

- **Replace e3nn `nn.Gate` with `GatedEquivariantBlock`**: Pure-torch gated equivariant nonlinearity that eliminates all graph breaks from e3nn's Gate (data-dependent control flow, `_Sortcut`/`Extract` codegen, `ElementwiseTensorProduct` TorchScript). Supports both `mul_ir` and `ir_mul` layouts natively, removing the need for `TransposeIrrepsLayout` wrappers around the gate.
- **Add oeq/hybrid acceleration and torch.compile support**: openequivariance conv TP fusion, hybrid (cueq symcon + oeq conv) mode, external displacement for compile-compatible stress, isolated-system padding for fixed tensor shapes.
- **Add TorchSim interface** (`MaceTorchSimModel`): Full compile + kernel acceleration with CUDA graph support (`reduce-overhead` mode), auto-padding, and batched relaxation.
- **CUDA graph (reduce-overhead) support**: `cudagraph_mark_step_begin()`, output cloning for buffer reuse safety, per-step boundary marking. Requires PyTorch >= 2.10 for CUDA graph partitioning of custom ops.

## Key changes

| File | Change |
|------|--------|
| `mace/modules/gate.py` | New `GatedEquivariantBlock` with `layout` param, cached normalize2mom |
| `mace/modules/blocks.py` | Replace `nn.Gate` at all 4 call sites, remove transpose wrappers, `argmax` instead of `nonzero` |
| `mace/modules/wrapper_ops.py` | Add `get_layout()`, `with_oeq_conv_fusion`, `with_oeq_scatter_sum`, layout transposes in `TensorProduct.__new__` |
| `mace/modules/utils.py` | External displacement support in `get_symmetric_displacement` |
| `mace/calculators/mace.py` | Hybrid mode, compile with cueq/oeq, ASE padding |
| `mace/calculators/mace_torchsim.py` | New TorchSim wrapper with compile padding + CUDA graphs |
| `mace/cli/convert_e3nn_hybrid.py` | New hybrid converter (cueq symcon + oeq conv TP) |
| `mace/data/padding_tools.py` | Isolated-system self-loop padding (consistent with TorchSim) |
| `tests/test_gate.py` | 94 parametrized tests (forward/backward/HVP vs e3nn, ir_mul layout, compile) |
| `tests/test_torchsim.py` | TorchSim interface tests (basic, batched, ASE-match, cueq) |
| `tests/test_compile.py` | Stress test, PyTorch >= 2.10 skip for cueq + CUDA graphs |

## Benchmark results (H200, 1000 atoms)

| Backend | Forward (ms) | Speedup | Relaxation speedup |
|---------|-------------|---------|-------------------|
| baseline (e3nn) | 37.76 | 1.00x | 1.00x |
| hybrid+compile | 17.97 | **2.10x** | **2.21x** |
| cueq+compile (uniform irreps) | 10.82 | **3.49x** | -- |

## Test plan

- [x] 94 gate tests pass (both layouts, forward/backward/HVP match e3nn, zero graph breaks)
- [x] 8 padding tests pass (self-loop pattern)
- [x] Compile tests pass (CPU + CUDA, stress, graph breaks = 0)
- [x] cueq bidirectional conversion tests pass
- [x] TorchSim interface tests pass
- [x] cueq + reduce-overhead works on PyTorch 2.10 (H100)
- [x] Pre-commit: black, isort, pylint 10/10