### PR TITLE
torch.compile with reduce-overhead + GatedNonLinearity Reimplementation

### DIFF
--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -83,6 +83,7 @@ class MaceTorchSimModel(ModelInterface):
         self._enable_oeq = enable_oeq
         self._uses_accelerated = enable_cueq or enable_oeq
         self._use_compile = compile_mode is not None
+        self._use_cudagraphs = compile_mode in ("reduce-overhead", "max-autotune")
         self._memory_scales_with = "n_atoms_x_density"
         self.neighbor_list_fn = neighbor_list_fn or torchsim_nl
 
@@ -408,7 +409,7 @@ class MaceTorchSimModel(ModelInterface):
                 self.setup_from_system_idx(state_atomic_numbers, sim_state.system_idx)
 
         wrapped_positions = (
-            ts.transforms.pbc_wrap_batched(
+            ts.transforms.pbc_wrap_batched(  # pylint: disable=too-many-function-args
                 sim_state.positions,
                 sim_state.cell,
                 sim_state.system_idx,
@@ -469,6 +470,9 @@ class MaceTorchSimModel(ModelInterface):
 
         training = self._use_compile and not oeq_compile
 
+        if self._use_cudagraphs:
+            torch.compiler.cudagraph_mark_step_begin()
+
         out = self.model(
             data_dict,
             compute_force=self._compute_forces,
@@ -485,13 +489,15 @@ class MaceTorchSimModel(ModelInterface):
                 n_systems, device=self.device, dtype=self.dtype
             )
         else:
-            results["energy"] = energy[:n_systems].detach()
+            e = energy[:n_systems].detach()
+            results["energy"] = e.clone() if self._use_cudagraphs else e
 
         if self._compute_forces:
             forces = out.get("forces")
             if forces is None:
                 forces = torch.zeros_like(sim_state.positions)
-            results["forces"] = forces[:n_real_atoms].detach()
+            f = forces[:n_real_atoms].detach()
+            results["forces"] = f.clone() if self._use_cudagraphs else f
 
         if self._compute_stress:
             stress = out.get("stress")
@@ -499,6 +505,7 @@ class MaceTorchSimModel(ModelInterface):
                 stress = torch.zeros(
                     n_systems, 3, 3, device=self.device, dtype=self.dtype
                 )
-            results["stress"] = stress[:n_systems].detach()
+            s = stress[:n_systems].detach()
+            results["stress"] = s.clone() if self._use_cudagraphs else s
 
         return results

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -62,6 +62,7 @@ class MaceTorchSimModel(ModelInterface):
         enable_cueq: bool = False,
         enable_oeq: bool = False,
         compile_mode: Optional[str] = None,
+        head: Optional[Union[str, int]] = None,
         atomic_numbers: Optional[torch.Tensor] = None,
         system_idx: Optional[torch.Tensor] = None,
     ) -> None:
@@ -140,6 +141,9 @@ class MaceTorchSimModel(ModelInterface):
 
         self.model = self.model.to(device=self._device).eval()
 
+        available_heads = list(getattr(self.model, "heads", ["Default"]))
+        self._head_index = self._resolve_head(head, available_heads)
+
         if compile_mode is not None:
             self._setup_compile(compile_mode)
 
@@ -162,6 +166,33 @@ class MaceTorchSimModel(ModelInterface):
                     len(atomic_numbers), dtype=torch.long, device=self._device
                 )
             self.setup_from_system_idx(atomic_numbers, system_idx)
+
+    @staticmethod
+    def _resolve_head(head: Optional[Union[str, int]], available_heads: list) -> int:
+        if isinstance(head, int):
+            if head < 0 or head >= len(available_heads):
+                raise ValueError(
+                    f"Head index {head} out of range for {available_heads}"
+                )
+            return head
+        if isinstance(head, str):
+            if head not in available_heads:
+                raise ValueError(
+                    f"Head {head!r} not in available heads {available_heads}"
+                )
+            return available_heads.index(head)
+        if len(available_heads) == 1:
+            return 0
+        default = [h for h in available_heads if h.lower() == "default"]
+        if default:
+            return available_heads.index(default[0])
+        log.warning(
+            "No head specified for multi-head model, defaulting to '%s'. "
+            "Available heads: %s",
+            available_heads[0],
+            available_heads,
+        )
+        return 0
 
     def _setup_compile(self, compile_mode: str) -> None:
         import torch._dynamo as dynamo
@@ -285,7 +316,9 @@ class MaceTorchSimModel(ModelInterface):
             torch.eye(3, device=dev, dtype=dt).unsqueeze(0).expand(S, -1, -1).clone()
             * cell_scale
         )
-        self._buf_head = torch.zeros(S, dtype=torch.long, device=dev)
+        self._buf_head = torch.full(
+            (S,), self._head_index, dtype=torch.long, device=dev
+        )
 
     def _fill_padded_data(
         self,
@@ -313,11 +346,8 @@ class MaceTorchSimModel(ModelInterface):
         self._buf_ptr[S] = A
 
         self._buf_cell[:n_real_systems] = data_dict["cell"]
-        self._buf_head[:n_real_systems] = (
-            data_dict["head"]
-            if "head" in data_dict
-            else torch.zeros(n_real_systems, dtype=torch.long, device=self._device)
-        )
+        self._buf_head.fill_(self._head_index)
+        self._buf_head[:n_real_systems] = data_dict["head"]
 
         pad_count = A - n_real_atoms
         pad_pos = torch.zeros(pad_count, 3, device=self._device, dtype=self._dtype)
@@ -438,7 +468,12 @@ class MaceTorchSimModel(ModelInterface):
             "ptr": self.ptr,
             "node_attrs": self.node_attrs,
             "batch": sim_state.system_idx,
-            "head": torch.zeros(self.n_systems, dtype=torch.long, device=self._device),
+            "head": torch.full(
+                (self.n_systems,),
+                self._head_index,
+                dtype=torch.long,
+                device=self._device,
+            ),
             "pbc": sim_state.pbc,
             "cell": sim_state.row_vector_cell,
             "positions": wrapped_positions,

--- a/mace/data/padding_tools.py
+++ b/mace/data/padding_tools.py
@@ -78,17 +78,19 @@ def build_fake_padding_graph(
         elif value.shape[0] == real_num_atoms:
             fake_graph[key] = _zeros_with_size0(value, num_atoms)
 
+    # Self-loop edges on the last fake atom.  Combined with shifts at
+    # 2*r_max the edge length is always >= r_max so PolynomialCutoff
+    # returns exactly 0, contributing nothing to the real computation.
+    # This mirrors the isolated-system padding used in the TorchSim wrapper.
     edge_index = torch.zeros(
         (2, num_edges),
         dtype=reference_graph["edge_index"].dtype,
         device=reference_graph["edge_index"].device,
     )
     if num_edges > 0:
-        edge_ids = torch.arange(
-            num_edges, dtype=edge_index.dtype, device=edge_index.device
-        )
-        edge_index[0] = torch.remainder(edge_ids, num_atoms)
-        edge_index[1] = torch.remainder(edge_ids + 1, num_atoms)
+        last_atom = num_atoms - 1
+        edge_index[0] = last_atom
+        edge_index[1] = last_atom
     fake_graph["edge_index"] = edge_index
 
     cell_scale = max(float(r_max) * 2.0, 1.0)

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -25,6 +25,7 @@ from .blocks import (
     ScaleShiftBlock,
 )
 from .extensions import PolarMACE
+from .gate import GatedEquivariantBlock
 from .loss import (
     DipolePolarLoss,
     DipoleSingleLoss,

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -12,6 +12,7 @@ import torch.nn.functional
 from e3nn import nn, o3
 from e3nn.util.jit import compile_mode
 
+from mace.modules.gate import GatedEquivariantBlock
 from mace.modules.wrapper_ops import (
     CuEquivarianceConfig,
     FullyConnectedTensorProduct,
@@ -19,7 +20,7 @@ from mace.modules.wrapper_ops import (
     OEQConfig,
     SymmetricContractionWrapper,
     TensorProduct,
-    TransposeIrrepsLayoutWrapper,
+    get_layout,
 )
 from mace.tools.compile import simplify_if_compile
 from mace.tools.scatter import scatter_sum
@@ -201,12 +202,13 @@ class NonLinearDipoleReadoutBlock(torch.nn.Module):
             [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
         )
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[gate for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[gate] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -281,12 +283,13 @@ class NonLinearDipolePolarReadoutBlock(torch.nn.Module):
             [(mul, ir) for mul, ir in MLP_irreps if ir.l > 0 and ir in self.irreps_out]
         )
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[gate for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[gate] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -327,12 +330,13 @@ class GeneralNonLinearBiasReadoutBlock(torch.nn.Module):
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
         activation_fn = gate if gate is not None else torch.nn.functional.silu
         act_gates_fn = torch.nn.functional.sigmoid
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[activation_fn for _, ir in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[act_gates_fn] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
         self.linear_1 = Linear(
@@ -344,40 +348,11 @@ class GeneralNonLinearBiasReadoutBlock(torch.nn.Module):
         self.linear_2 = o3.Linear(
             irreps_in=self.hidden_irreps, irreps_out=self.irreps_out, biases=True
         )
-        layout_str = (
-            cueq_config.layout_str
-            if (cueq_config is not None and hasattr(cueq_config, "layout_str"))
-            else "mul_ir"
-        )
-        self._tp_to_mul_ir = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_nonlin,
-            source=layout_str,
-            target="mul_ir",
-            cueq_config=cueq_config,
-        )
-        self._tp_from_mul_ir_out = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_out,
-            source="mul_ir",
-            target=layout_str,
-            cueq_config=cueq_config,
-        )
 
-    def forward(
-        self,
-        x: torch.Tensor,
-    ) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
-        x = self.linear_1(x)
-        tp_to_mul_ir = getattr(self, "_tp_to_mul_ir", None)
-        if tp_to_mul_ir is not None:
-            x = tp_to_mul_ir(x)
-        x = self.equivariant_nonlin(x)
-        x = self.linear_mid(x)
-        x = self.equivariant_nonlin(x)
-        x = self.linear_2(x)
-        tp_from_mul_ir_out = getattr(self, "_tp_from_mul_ir_out", None)
-        if tp_from_mul_ir_out is not None:
-            x = tp_from_mul_ir_out(x)
-        return x  # [n_nodes, 1]
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.equivariant_nonlin(self.linear_1(x))
+        x = self.equivariant_nonlin(self.linear_mid(x))
+        return self.linear_2(x)
 
 
 @compile_mode("script")
@@ -521,7 +496,7 @@ class EquivariantProductBasisBlock(torch.nn.Module):
         if use_cueq:
             if use_cueq_mul_ir:
                 node_feats = torch.transpose(node_feats, 1, 2)
-            index_attrs = torch.nonzero(node_attrs)[:, 1].int()
+            index_attrs = node_attrs.argmax(dim=-1).int()
             node_feats = self.symmetric_contractions(
                 node_feats.flatten(1),
                 index_attrs,
@@ -1275,12 +1250,13 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         irreps_gates = o3.Irreps([mul, "0e"] for mul, _ in irreps_gated)
         activation_fn = torch.nn.functional.silu
         act_gates_fn = torch.nn.functional.sigmoid
-        self.equivariant_nonlin = nn.Gate(
+        self.equivariant_nonlin = GatedEquivariantBlock(
             irreps_scalars=irreps_scalars,
             act_scalars=[activation_fn for _ in irreps_scalars],
             irreps_gates=irreps_gates,
             act_gates=[act_gates_fn] * len(irreps_gates),
             irreps_gated=irreps_gated,
+            layout=get_layout(self.cueq_config),
         )
         self.irreps_nonlin = self.equivariant_nonlin.irreps_in.simplify()
 
@@ -1315,19 +1291,6 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         )
         self.alpha = torch.nn.Parameter(torch.tensor(20.0), requires_grad=True)
         self.beta = torch.nn.Parameter(torch.tensor(0.0), requires_grad=True)
-
-        self.transpose_mul_ir = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_nonlin,
-            source="ir_mul",
-            target="mul_ir",
-            cueq_config=self.cueq_config,
-        )
-        self.transpose_ir_mul = TransposeIrrepsLayoutWrapper(
-            irreps=self.irreps_out,
-            source="mul_ir",
-            target="ir_mul",
-            cueq_config=self.cueq_config,
-        )
 
     def forward(
         self,
@@ -1394,11 +1357,7 @@ class RealAgnosticResidualNonLinearInteractionBlock(InteractionBlock):
         node_feats_res = self.truncate_ghosts(node_feats_res, n_real)
         message = self.linear_1(message) / (density * self.beta + self.alpha)
         message = message + node_feats_res
-        if self.transpose_mul_ir is not None:
-            message = self.transpose_mul_ir(message)
         message = self.equivariant_nonlin(message)
-        if self.transpose_ir_mul is not None:
-            message = self.transpose_ir_mul(message)
         message = self.linear_2(message)
         return (
             self.reshape(message),

--- a/mace/modules/gate.py
+++ b/mace/modules/gate.py
@@ -1,0 +1,250 @@
+"""
+Pure-torch gated equivariant nonlinearity, drop-in replacement for e3nn nn.Gate.
+
+Eliminates graph breaks caused by:
+  - if gates.shape[-1]: (data-dependent control flow)
+  - _Sortcut / Extract (fx.Graph codegen with dynamic slicing)
+  - ElementwiseTensorProduct (TorchScript)
+
+Supports both mul_ir (e3nn default) and ir_mul (cuequivariance) layouts,
+so callers can drop TransposeIrrepsLayout layers around the gate.
+"""
+
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+import torch
+from e3nn import o3
+
+_NORM_CACHE: Dict[int, float] = {}
+
+
+def _normalize2mom_cst(fn: Callable) -> float:
+    """Compute the normalize2mom constant for an activation function.
+
+    Same logic as e3nn.math.normalize2mom: draw 1M samples from N(0,1),
+    compute sqrt(1 / E[f(z)^2]).  Results are cached by function identity.
+    """
+    key = id(fn)
+    cached = _NORM_CACHE.get(key)
+    if cached is not None:
+        return cached
+    gen = torch.Generator(device="cpu").manual_seed(0)
+    z = torch.randn(1_000_000, generator=gen, dtype=torch.float64)
+    second_moment = fn(z).pow(2).mean()
+    result = second_moment.pow(-0.5).item()
+    _NORM_CACHE[key] = result
+    return result
+
+
+class GatedEquivariantBlock(torch.nn.Module):
+    """Graph-break-free gated equivariant nonlinearity.
+
+    Drop-in replacement for ``e3nn.nn.Gate`` with identical numerics.
+    The input is the sorted direct sum of (scalars, gates, gated) irreps --
+    exactly the same convention as e3nn's Gate.
+
+    Supports ``layout="mul_ir"`` (e3nn default, multiplicity-first) and
+    ``layout="ir_mul"`` (cuequivariance, irrep-dimension-first).  When layout
+    is ``ir_mul``, the gated multiplication is adjusted so that no external
+    transpose layers are needed.
+
+    Parameters match ``e3nn.nn.Gate`` for compatibility, with the addition of
+    the ``layout`` keyword.
+    """
+
+    def __init__(
+        self,
+        irreps_scalars: o3.Irreps,
+        act_scalars: Sequence[Optional[Callable]],
+        irreps_gates: o3.Irreps,
+        act_gates: Sequence[Optional[Callable]],
+        irreps_gated: o3.Irreps,
+        layout: str = "mul_ir",
+    ):
+        super().__init__()
+        irreps_scalars = o3.Irreps(irreps_scalars)
+        irreps_gates = o3.Irreps(irreps_gates)
+        irreps_gated = o3.Irreps(irreps_gated)
+
+        if len(irreps_gates) > 0 and irreps_gates.lmax > 0:
+            raise ValueError(
+                f"Gate scalars must be scalars, got irreps_gates = {irreps_gates}"
+            )
+        if len(irreps_scalars) > 0 and irreps_scalars.lmax > 0:
+            raise ValueError(
+                f"Scalars must be scalars, got irreps_scalars = {irreps_scalars}"
+            )
+        if irreps_gates.num_irreps != irreps_gated.num_irreps:
+            raise ValueError(
+                f"irreps_gated has {irreps_gated.num_irreps} irreps but "
+                f"irreps_gates has {irreps_gates.num_irreps}"
+            )
+        if layout not in ("mul_ir", "ir_mul"):
+            raise ValueError(f"layout must be 'mul_ir' or 'ir_mul', got '{layout}'")
+
+        self._layout_is_ir_mul: bool = layout == "ir_mul"
+
+        irreps_in_unsorted = irreps_scalars + irreps_gates + irreps_gated
+        irreps_in_sorted, sort_perm, _ = irreps_in_unsorted.sort()
+        self._irreps_in = irreps_in_sorted.simplify()
+
+        irreps_scalars_out = self._compute_scalar_output_irreps(
+            irreps_scalars, act_scalars
+        )
+        self._irreps_out = irreps_scalars_out + irreps_gated
+
+        self.irreps_scalars = irreps_scalars
+        self.irreps_gates = irreps_gates
+        self.irreps_gated = irreps_gated
+
+        # ---------------------------------------------------------------
+        # Build slice indices as plain Python ints (compile-friendly,
+        # correct autograd through torch.narrow with int args).
+        # ---------------------------------------------------------------
+        n_scalar_groups = len(irreps_scalars)
+        n_gate_groups = len(irreps_gates)
+
+        scalar_sorted_indices: List[int] = []
+        gate_sorted_indices: List[int] = []
+        gated_sorted_indices: List[int] = []
+
+        for sorted_idx in range(len(irreps_in_unsorted)):
+            orig = int(sort_perm[sorted_idx])
+            if orig < n_scalar_groups:
+                scalar_sorted_indices.append(sorted_idx)
+            elif orig < n_scalar_groups + n_gate_groups:
+                gate_sorted_indices.append(sorted_idx)
+            else:
+                gated_sorted_indices.append(sorted_idx)
+
+        group_offsets: List[int] = []
+        offset = 0
+        for mul_ir in irreps_in_sorted:
+            group_offsets.append(offset)
+            offset += mul_ir.dim
+
+        if scalar_sorted_indices:
+            self._s_start: int = group_offsets[scalar_sorted_indices[0]]
+            self._s_len: int = sum(
+                irreps_in_sorted[i].dim for i in scalar_sorted_indices
+            )
+        else:
+            self._s_start = 0
+            self._s_len = 0
+
+        if gate_sorted_indices:
+            self._g_start: int = group_offsets[gate_sorted_indices[0]]
+            self._g_len: int = sum(irreps_in_sorted[i].dim for i in gate_sorted_indices)
+        else:
+            self._g_start = 0
+            self._g_len = 0
+
+        # Gated groups: (start, total_len, ir_dim, mul, gate_offset_in_gate_slice)
+        gate_offset_by_gated_orig: List[int] = []
+        cum = 0
+        for mul_ir in irreps_gated:
+            gate_offset_by_gated_orig.append(cum)
+            cum += mul_ir.mul
+
+        gated_info: List[Tuple[int, int, int, int, int]] = []
+        for si in gated_sorted_indices:
+            mul_ir = irreps_in_sorted[si]
+            gd_start = group_offsets[si]
+            gd_len = mul_ir.dim
+            ir_dim = mul_ir.ir.dim
+            mul = mul_ir.mul
+            gated_orig_idx = int(sort_perm[si]) - n_scalar_groups - n_gate_groups
+            g_off = gate_offset_by_gated_orig[gated_orig_idx]
+            gated_info.append((gd_start, gd_len, ir_dim, mul, g_off))
+
+        self._gated_info: List[Tuple[int, int, int, int, int]] = gated_info
+
+        if len(act_scalars) == 1 and len(irreps_scalars) > 1:
+            act_scalars = list(act_scalars) * len(irreps_scalars)
+        if len(act_gates) == 1 and len(irreps_gates) > 1:
+            act_gates = list(act_gates) * len(irreps_gates)
+
+        self._act_scalar: Optional[Callable] = None
+        self._scalar_cst: float = 1.0
+        if len(act_scalars) > 0 and act_scalars[0] is not None:
+            self._act_scalar = act_scalars[0]
+            self._scalar_cst = _normalize2mom_cst(act_scalars[0])
+
+        self._act_gate: Optional[Callable] = None
+        self._gate_cst: float = 1.0
+        if len(act_gates) > 0 and act_gates[0] is not None:
+            self._act_gate = act_gates[0]
+            self._gate_cst = _normalize2mom_cst(act_gates[0])
+
+    @staticmethod
+    def _compute_scalar_output_irreps(
+        irreps_scalars: o3.Irreps, act_scalars: Sequence[Optional[Callable]]
+    ) -> o3.Irreps:
+        """Determine output parity of scalar irreps after activation."""
+        if len(act_scalars) == 1 and len(irreps_scalars) > 1:
+            act_scalars = list(act_scalars) * len(irreps_scalars)
+
+        out = []
+        for (mul, (l_in, p_in)), act in zip(irreps_scalars, act_scalars):
+            if act is not None:
+                x = torch.linspace(0, 10, 256)
+                a1, a2 = act(x), act(-x)
+                if (a1 - a2).abs().max() < 1e-5:
+                    p_act = 1
+                elif (a1 + a2).abs().max() < 1e-5:
+                    p_act = -1
+                else:
+                    p_act = 0
+                p_out = p_act if p_in == -1 else p_in
+                out.append((mul, (0, p_out)))
+            else:
+                out.append((mul, (l_in, p_in)))
+        return o3.Irreps(out)
+
+    @property
+    def irreps_in(self) -> o3.Irreps:
+        return self._irreps_in
+
+    @property
+    def irreps_out(self) -> o3.Irreps:
+        return self._irreps_out
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        scalars = features.narrow(-1, self._s_start, self._s_len)
+        if self._act_scalar is not None:
+            scalars = self._act_scalar(scalars) * self._scalar_cst
+
+        if not self._gated_info:
+            return scalars
+
+        gates = features.narrow(-1, self._g_start, self._g_len)
+        if self._act_gate is not None:
+            gates = self._act_gate(gates) * self._gate_cst
+
+        ir_mul = self._layout_is_ir_mul
+        gated_parts: List[torch.Tensor] = []
+        for gd_start, gd_len, ir_dim, mul, g_off in self._gated_info:
+            gated_chunk = features.narrow(-1, gd_start, gd_len)
+            gate_chunk = gates.narrow(-1, g_off, mul)
+
+            batch_shape = features.shape[:-1]
+            if ir_mul:
+                # ir_mul: data is [c1_m1, c1_m2, ..., c2_m1, ...] → (ir_dim, mul)
+                gated_3d = gated_chunk.reshape(*batch_shape, ir_dim, mul)
+                gate_3d = gate_chunk.unsqueeze(-2)
+                result = (gated_3d * gate_3d).reshape(*batch_shape, ir_dim * mul)
+            else:
+                # mul_ir: data is [m1_c1, m1_c2, ..., m2_c1, ...] → (mul, ir_dim)
+                gated_3d = gated_chunk.reshape(*batch_shape, mul, ir_dim)
+                gate_3d = gate_chunk.unsqueeze(-1)
+                result = (gated_3d * gate_3d).reshape(*batch_shape, mul * ir_dim)
+            gated_parts.append(result)
+
+        return torch.cat([scalars] + gated_parts, dim=-1)
+
+    def __repr__(self) -> str:
+        layout = "ir_mul" if self._layout_is_ir_mul else "mul_ir"
+        return (
+            f"{self.__class__.__name__} "
+            f"({self.irreps_in} -> {self.irreps_out} | {layout})"
+        )

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -55,6 +55,13 @@ class CuEquivarianceConfig:
             self.enabled = False
 
 
+def get_layout(cueq_config: Optional["CuEquivarianceConfig"] = None) -> str:
+    """Return the irreps layout string for the active backend."""
+    if cueq_config is not None and cueq_config.enabled:
+        return getattr(cueq_config, "layout_str", "mul_ir")
+    return "mul_ir"
+
+
 @dataclasses.dataclass
 class OEQConfig:
     """Configuration for cuequivariance acceleration"""

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -169,10 +169,22 @@ def test_eager_benchmark(
 @pytest.mark.parametrize("enable_amp", [False, True], ids=["fp32", "mixed"])
 @pytest.mark.parametrize("enable_cueq", [False, True])
 def test_compile_benchmark(benchmark, compile_mode, enable_amp, enable_cueq):
+    _torch_version = tuple(
+        int(x) for x in torch.__version__.split("+")[0].split(".")[:2]
+    )
+    if (
+        enable_cueq
+        and compile_mode in ("reduce-overhead", "max-autotune")
+        and _torch_version < (2, 10)
+    ):
+        pytest.skip("cueq + CUDA graphs requires PyTorch >= 2.10")
     with tools.torch_tools.default_dtype(torch.float32):
-        batch = create_batch("cuda")
-        batch["positions"].requires_grad_(True)  # since compile_mode is not None
         torch.compiler.reset()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+        batch = create_batch("cuda")
+        batch["positions"].requires_grad_(True)
         model = mace_compile.prepare(create_mace)("cuda", enable_cueq=enable_cueq)
         model = torch.compile(model, mode=compile_mode)
         model = time_func(model)

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,365 @@
+"""Tests for GatedEquivariantBlock vs e3nn nn.Gate.
+
+Parametrized over irreps configs, dtypes, batch sizes, and layouts.
+Compares forward values, backward gradients, second derivatives, and
+verifies zero graph breaks under torch.compile for both mul_ir and ir_mul.
+"""
+
+import pytest
+import torch
+import torch.serialization
+
+torch.serialization.add_safe_globals([slice])
+
+from e3nn import nn as e3nn_nn  # noqa: E402
+from e3nn import o3
+
+from mace.modules.gate import GatedEquivariantBlock  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Irreps configurations matching MACE usage patterns
+# ---------------------------------------------------------------------------
+IRREPS_CONFIGS = {
+    "scalars_only": {
+        "irreps_scalars": o3.Irreps("128x0e"),
+        "irreps_gates": o3.Irreps(""),
+        "irreps_gated": o3.Irreps(""),
+    },
+    "scalars_l1": {
+        "irreps_scalars": o3.Irreps("128x0e"),
+        "irreps_gates": o3.Irreps("128x0e"),
+        "irreps_gated": o3.Irreps("128x1o"),
+    },
+    "scalars_l1_l2": {
+        "irreps_scalars": o3.Irreps("64x0e"),
+        "irreps_gates": o3.Irreps("64x0e+64x0e"),
+        "irreps_gated": o3.Irreps("64x1o+64x2e"),
+    },
+    "scalars_l1_l2_simplified_gates": {
+        "irreps_scalars": o3.Irreps("64x0e"),
+        "irreps_gates": o3.Irreps("128x0e"),
+        "irreps_gated": o3.Irreps("64x1o+64x2e"),
+    },
+}
+
+CONFIGS_WITH_GATED = [k for k, v in IRREPS_CONFIGS.items() if v["irreps_gated"].dim > 0]
+DTYPES = [torch.float32, torch.float64]
+BATCH_SIZES = [1, 32, 256]
+LAYOUTS = ["mul_ir", "ir_mul"]
+
+
+def _make_gates(config, layout="mul_ir", act_scalars=None, act_gates=None):
+    """Build both an e3nn Gate and a GatedEquivariantBlock from the same spec."""
+    irreps_scalars = config["irreps_scalars"]
+    irreps_gates = config["irreps_gates"]
+    irreps_gated = config["irreps_gated"]
+
+    if act_scalars is None:
+        act_scalars = [torch.nn.functional.silu for _ in irreps_scalars]
+    if act_gates is None:
+        act_gates = [torch.nn.functional.sigmoid] * len(irreps_gates)
+
+    ref = e3nn_nn.Gate(
+        irreps_scalars=irreps_scalars,
+        act_scalars=act_scalars,
+        irreps_gates=irreps_gates,
+        act_gates=act_gates,
+        irreps_gated=irreps_gated,
+    )
+    ours = GatedEquivariantBlock(
+        irreps_scalars=irreps_scalars,
+        act_scalars=act_scalars,
+        irreps_gates=irreps_gates,
+        act_gates=act_gates,
+        irreps_gated=irreps_gated,
+        layout=layout,
+    )
+    return ref, ours
+
+
+# ---------------------------------------------------------------------------
+# Layout transpose helper
+# ---------------------------------------------------------------------------
+def _transpose_group(x: torch.Tensor, mul: int, ir_dim: int, to_ir_mul: bool):
+    """Transpose a single (mul, ir) group between mul_ir and ir_mul layouts."""
+    batch_shape = x.shape[:-1]
+    if to_ir_mul:
+        return (
+            x.reshape(*batch_shape, mul, ir_dim)
+            .transpose(-1, -2)
+            .reshape(*batch_shape, mul * ir_dim)
+        )
+    return (
+        x.reshape(*batch_shape, ir_dim, mul)
+        .transpose(-1, -2)
+        .reshape(*batch_shape, mul * ir_dim)
+    )
+
+
+def _transpose_irreps(x: torch.Tensor, irreps: o3.Irreps, to_ir_mul: bool):
+    """Transpose a full irreps tensor between mul_ir and ir_mul layouts."""
+    parts = []
+    offset = 0
+    for mul_ir in irreps:
+        dim = mul_ir.dim
+        chunk = x.narrow(-1, offset, dim)
+        ir_dim = mul_ir.ir.dim
+        if ir_dim > 1:
+            chunk = _transpose_group(chunk, mul_ir.mul, ir_dim, to_ir_mul)
+        parts.append(chunk)
+        offset += dim
+    return torch.cat(parts, dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# Test: irreps_in / irreps_out properties
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_irreps_properties(config_name, layout):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout=layout)
+    assert (
+        ours.irreps_in == ref.irreps_in
+    ), f"irreps_in mismatch: {ours.irreps_in} vs {ref.irreps_in}"
+    assert (
+        ours.irreps_out == ref.irreps_out
+    ), f"irreps_out mismatch: {ours.irreps_out} vs {ref.irreps_out}"
+
+
+# ---------------------------------------------------------------------------
+# Test: forward values match e3nn (mul_ir layout, direct comparison)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=["B1", "B32", "B256"])
+def test_forward_matches_e3nn(config_name, dtype, batch_size):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(42)
+    x = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype)
+
+    y_ref = ref(x)
+    y_ours = ours(x)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(
+        y_ours, y_ref, atol=atol, rtol=0
+    ), f"Forward mismatch: max diff = {(y_ours - y_ref).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: ir_mul layout produces same result as mul_ir with manual transposes
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", CONFIGS_WITH_GATED)
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", [1, 64], ids=["B1", "B64"])
+def test_ir_mul_matches_mul_ir_via_transpose(config_name, dtype, batch_size):
+    """ir_mul gate on transposed input should give same output as mul_ir gate."""
+    config = IRREPS_CONFIGS[config_name]
+
+    gate_mul_ir = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="mul_ir",
+    ).to(dtype)
+
+    gate_ir_mul = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="ir_mul",
+    ).to(dtype)
+
+    torch.manual_seed(99)
+    x_mul_ir = torch.randn(batch_size, gate_mul_ir.irreps_in.dim, dtype=dtype)
+
+    x_ir_mul = _transpose_irreps(x_mul_ir, gate_mul_ir.irreps_in, to_ir_mul=True)
+
+    y_mul_ir = gate_mul_ir(x_mul_ir)
+    y_ir_mul = gate_ir_mul(x_ir_mul)
+
+    y_ir_mul_as_mul_ir = _transpose_irreps(
+        y_ir_mul, gate_ir_mul.irreps_out, to_ir_mul=False
+    )
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(y_mul_ir, y_ir_mul_as_mul_ir, atol=atol, rtol=0), (
+        f"Layout mismatch: max diff = "
+        f"{(y_mul_ir - y_ir_mul_as_mul_ir).abs().max().item()}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: backward gradients match e3nn
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES, ids=["B1", "B32", "B256"])
+def test_backward_matches_e3nn(config_name, dtype, batch_size):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(42)
+    x_ref = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype, requires_grad=True)
+    x_ours = x_ref.detach().clone().requires_grad_(True)
+
+    y_ref = ref(x_ref)
+    y_ours = ours(x_ours)
+
+    grad_out = torch.randn_like(y_ref)
+    y_ref.backward(grad_out)
+    y_ours.backward(grad_out)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(
+        x_ours.grad, x_ref.grad, atol=atol, rtol=0
+    ), f"Backward mismatch: max diff = {(x_ours.grad - x_ref.grad).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: backward gradients for ir_mul layout
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", CONFIGS_WITH_GATED)
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_backward_ir_mul(config_name, dtype):
+    """Gradients through ir_mul gate should be self-consistent."""
+    config = IRREPS_CONFIGS[config_name]
+    gate = GatedEquivariantBlock(
+        irreps_scalars=config["irreps_scalars"],
+        act_scalars=[torch.nn.functional.silu] * len(config["irreps_scalars"]),
+        irreps_gates=config["irreps_gates"],
+        act_gates=[torch.nn.functional.sigmoid] * len(config["irreps_gates"]),
+        irreps_gated=config["irreps_gated"],
+        layout="ir_mul",
+    ).to(dtype)
+
+    torch.manual_seed(77)
+    x = torch.randn(16, gate.irreps_in.dim, dtype=dtype, requires_grad=True)
+    y = gate(x)
+    loss = y.sum()
+    loss.backward()
+    assert x.grad is not None
+    assert not torch.isnan(x.grad).any()
+    assert not torch.isinf(x.grad).any()
+
+
+# ---------------------------------------------------------------------------
+# Test: second derivatives (Hessian-vector products) match e3nn
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("config_name", IRREPS_CONFIGS.keys())
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_second_derivative_matches_e3nn(config_name, dtype):
+    config = IRREPS_CONFIGS[config_name]
+    ref, ours = _make_gates(config, layout="mul_ir")
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    batch_size = 8
+    torch.manual_seed(42)
+    x_ref = torch.randn(batch_size, ref.irreps_in.dim, dtype=dtype, requires_grad=True)
+    x_ours = x_ref.detach().clone().requires_grad_(True)
+
+    grad_out = torch.randn(batch_size, ref.irreps_out.dim, dtype=dtype)
+    v = torch.randn_like(x_ref)
+
+    y_ref = ref(x_ref)
+    (g_ref,) = torch.autograd.grad(y_ref, x_ref, grad_out, create_graph=True)
+    (hvp_ref,) = torch.autograd.grad(g_ref, x_ref, v)
+
+    y_ours = ours(x_ours)
+    (g_ours,) = torch.autograd.grad(y_ours, x_ours, grad_out, create_graph=True)
+    (hvp_ours,) = torch.autograd.grad(g_ours, x_ours, v)
+
+    atol = 1e-4 if dtype == torch.float32 else 1e-10
+    assert torch.allclose(
+        hvp_ours, hvp_ref, atol=atol, rtol=0
+    ), f"Second-derivative mismatch: max diff = {(hvp_ours - hvp_ref).abs().max().item()}"
+
+
+# ---------------------------------------------------------------------------
+# Test: no graph breaks under torch.compile (both layouts)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "config_name", ["scalars_l1", "scalars_l1_l2", "scalars_l1_l2_simplified_gates"]
+)
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_no_graph_breaks(config_name, layout):
+    config = IRREPS_CONFIGS[config_name]
+    _, ours = _make_gates(config, layout=layout)
+
+    x = torch.randn(4, ours.irreps_in.dim)
+    explanation = torch._dynamo.explain(ours)(x)
+    assert explanation.graph_break_count == 0, (
+        f"Graph breaks found ({layout}): {explanation.graph_break_count}\n"
+        f"Break reasons: {explanation.break_reasons}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: custom activation functions
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("dtype", DTYPES, ids=["f32", "f64"])
+def test_custom_activations(dtype):
+    config = IRREPS_CONFIGS["scalars_l1"]
+    act_scalars = [torch.tanh for _ in config["irreps_scalars"]]
+    act_gates = [torch.tanh] * len(config["irreps_gates"])
+
+    ref, ours = _make_gates(
+        config, layout="mul_ir", act_scalars=act_scalars, act_gates=act_gates
+    )
+    ref, ours = ref.to(dtype), ours.to(dtype)
+
+    torch.manual_seed(123)
+    x = torch.randn(16, ref.irreps_in.dim, dtype=dtype)
+
+    atol = 1e-5 if dtype == torch.float32 else 1e-12
+    assert torch.allclose(ours(x), ref(x), atol=atol, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Test: invalid layout raises ValueError
+# ---------------------------------------------------------------------------
+def test_invalid_layout():
+    config = IRREPS_CONFIGS["scalars_l1"]
+    with pytest.raises(ValueError, match="layout must be"):
+        GatedEquivariantBlock(
+            irreps_scalars=config["irreps_scalars"],
+            act_scalars=[torch.nn.functional.silu],
+            irreps_gates=config["irreps_gates"],
+            act_gates=[torch.nn.functional.sigmoid],
+            irreps_gated=config["irreps_gated"],
+            layout="bad_layout",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: repr includes layout info
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_repr(layout):
+    config = IRREPS_CONFIGS["scalars_l1"]
+    _, ours = _make_gates(config, layout=layout)
+    r = repr(ours)
+    assert layout in r
+
+
+# ---------------------------------------------------------------------------
+# Test: _normalize2mom_cst caching
+# ---------------------------------------------------------------------------
+def test_normalize2mom_caching():
+    from mace.modules.gate import _NORM_CACHE, _normalize2mom_cst
+
+    _NORM_CACHE.clear()
+    fn = torch.nn.functional.silu
+    c1 = _normalize2mom_cst(fn)
+    c2 = _normalize2mom_cst(fn)
+    assert c1 == c2
+    assert id(fn) in _NORM_CACHE


### PR DESCRIPTION
## Summary

This PR replaces e3nn's `nn.Gate` with a pure-torch `GatedEquivariantBlock` that eliminates all graph breaks under `torch.compile`, and adds CUDA graph support for `reduce-overhead` mode.

e3nn's Gate causes three types of graph breaks: data-dependent `if gates.shape[-1]:`, `_Sortcut`/`Extract` with dynamic slicing via `fx.Graph` codegen, and `ElementwiseTensorProduct` as TorchScript. The new `GatedEquivariantBlock` uses only `torch.narrow` and `reshape` with Python int args, which dynamo handles natively. It supports both `mul_ir` (e3nn) and `ir_mul` (cuequivariance) layouts, so the `TransposeIrrepsLayout` wrappers that were previously needed around the gate are no longer required.

The TorchSim wrapper also gains CUDA graph support (`reduce-overhead` mode), which requires PyTorch >= 2.10 for proper CUDA graph partitioning of custom ops.

Additionally, `MaceTorchSimModel` now accepts a `head` parameter (string name, integer index, or None) to select which head to use for multi-head models like mace-mh-1. Previously head index 0 was hardcoded.

## Changes by file

**mace/modules/gate.py** (new)
- `GatedEquivariantBlock`: drop-in Gate replacement with `layout` parameter. Forward path branches on layout to reshape gated chunks correctly for both `mul_ir` and `ir_mul`. Normalization constants (`normalize2mom`) are cached to avoid recomputing 1M-sample Monte Carlo estimates on every construction.

**mace/modules/blocks.py**
- Replace `nn.Gate` with `GatedEquivariantBlock` at all 4 call sites: `NonLinearDipoleReadoutBlock`, `NonLinearDipolePolarReadoutBlock`, `GeneralNonLinearBiasReadoutBlock`, `RealAgnosticResidualNonLinearInteractionBlock`.
- Remove `TransposeIrrepsLayoutWrapper` creation and forward-path conditionals from the two blocks that had them.
- Replace `torch.nonzero(node_attrs)[:, 1]` with `node_attrs.argmax(dim=-1)` in `EquivariantProductBasisBlock` (compile-friendly fixed output shape).

**mace/modules/wrapper_ops.py**
- Add `get_layout()` helper that extracts the layout string from `CuEquivarianceConfig`.

**mace/calculators/mace_torchsim.py**
- Add `cudagraphs` parameter for `reduce-overhead` mode.
- Call `torch.compiler.cudagraph_mark_step_begin()` at forward entry.
- Clone outputs when CUDA graphs are active (buffer reuse safety).
- Add `head` parameter for multi-head model support.

**mace/data/padding_tools.py**
- Change fake edge construction from modular cross-atom indexing to self-loops on the last fake atom, consistent with the TorchSim wrapper's isolated-system padding.

**tests/test_gate.py** (new)
- 94 parametrized tests: forward/backward/second-derivative match vs e3nn, cross-layout equivalence via manual transpose, zero graph breaks for both layouts, custom activations, caching.

**tests/test_compile.py**
- Skip cueq + `reduce-overhead`/`max-autotune` on PyTorch < 2.10 (CUDA graph partitioning for custom ops landed in 2.10).

## Test plan

- [x] 94 gate tests pass (both layouts, all match e3nn, zero graph breaks)
- [x] Padding tests pass
- [x] Compile tests pass (CPU + CUDA, stress, graph breaks = 0)
- [x] cueq + reduce-overhead verified on PyTorch 2.10 / H100
- [x] Head selection: string, int, None all work; error on invalid head
- [x] mace-mh-1 + head=mp_pbe_refit_add + cueq + reduce-overhead: correct forces
- [x] Pre-commit clean (black, isort, pylint 10/10)