### PR TITLE
Fix multi-GPU finetuning crash caused by zero-size bias parameters

### DIFF
--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -236,8 +236,7 @@ def load_foundations_elements(
                     readout.linear_1.weight = torch.nn.Parameter(
                         model_readouts_one_linear_1_weight
                     )
-                    if readout.linear_1.bias is not None:
-                        model_readouts_one_linear_1_bias = readout.linear_1.bias.clone()
+                    if readout.linear_1.bias is not None and readout.linear_1.bias.numel() > 0:
                         model_readouts_one_linear_1_bias = (
                             model_foundations.readouts[i]
                             .linear_1.bias.view(-1)
@@ -260,7 +259,7 @@ def load_foundations_elements(
                         / ((shape_input_1) / (shape_output_1)) ** 0.5
                     )
                     # if it has biases transfer them too
-                    if readout.linear_mid.bias is not None:
+                    if readout.linear_mid.bias is not None and readout.linear_mid.bias.numel() > 0:
                         readout.linear_mid.bias = torch.nn.Parameter(
                             model_foundations.readouts[i]
                             .linear_mid.bias.repeat(len(model_heads))
@@ -278,8 +277,7 @@ def load_foundations_elements(
                     readout.linear_2.weight = torch.nn.Parameter(
                         model_readouts_one_linear_2_weight
                     )
-                    if readout.linear_2.bias is not None:
-                        model_readouts_one_linear_2_bias = readout.linear_2.bias.clone()
+                    if readout.linear_2.bias is not None and readout.linear_2.bias.numel() > 0:
                         model_readouts_one_linear_2_bias = (
                             model_foundations.readouts[i]
                             .linear_2.bias.view(-1)


### PR DESCRIPTION
## Summary

- Fix DDP crash during multi-GPU finetuning of foundation models (mace-mp, mace-off) caused by zero-size `o3.Linear` bias buffers being promoted to `torch.nn.Parameter` in `load_foundations_elements`
- Added `numel() > 0` guards on three readout bias checks so only real biases (from `NonLinearBiasReadoutBlock`, used in mace-polar/omol) are promoted
- Models with real biases (mace-polar) are unaffected by this change

## Root cause

`o3.Linear` (without `biases=True`) stores bias as a zero-element buffer of shape `[0]`. In `load_foundations_elements`, the check `if readout.linear_X.bias is not None` passes for this buffer, and it gets wrapped in `torch.nn.Parameter(...)`. These zero-element parameters exist in the model but can never receive gradients, so DDP's all-reduce crashes on the second forward pass:

```
RuntimeError: Expected to have finished reduction in the prior iteration before
starting a new one. This error indicates that your module has parameters that were
not used in producing loss.
Parameters which did not receive grad: readouts.1.linear_2.bias, readouts.1.linear_1.bias
Parameter indices which did not receive grad for rank 0: 26 28
```

## Test plan

Verified with:
- [x] Round-trip weight loading tests for mace-mp small, mace-off small, mace-polar-1-s (single and multi-head) -- all pass, no zero-size parameters created, all real biases preserved
- [x] 8-GPU SLURM training from scratch -- passes (before and after)
- [x] 8-GPU SLURM multihead finetuning (mace-mp small) -- was crashing, now passes
- [x] 8-GPU SLURM naive finetuning (multiheads_finetuning=False) -- was crashing, now passes
- [x] 8-GPU SLURM LoRA finetuning -- passes (before and after, LoRA freezes base params)
- [x] 8-GPU SLURM mace-polar-1-s finetuning -- passes (before and after, no NonLinearReadoutBlock in readouts)