### PR TITLE
Fix SWA documentation

### DIFF
--- a/docs/guide/training.rst
+++ b/docs/guide/training.rst
@@ -92,7 +92,7 @@ If you prefer not to use or do not know the energies of the isolated atoms, you 
 SWA and EMA
 -----------
 
-If the keyword `--swa` is enabled, the energy weight of the loss is increased for the last ~20% of the training epochs (from `--start_swa` epochs).
+If the keyword `--swa` is enabled, the energy weight of the loss is increased for the last ~25% of the training epochs (or from `--start_swa` epochs).
 This setting usually helps lower the energy errors.
 
 


### PR DESCRIPTION
Hey :wave: 

I noticed a small discrepancy in the docs for SWA. In the code, the second-stage learning (with increased energy weights in the loss function) starts at 75% of total epochs, not 80%.

https://github.com/ACEsuit/mace/blob/667eee4e58d23a38ff5a75122109ec2025809649/mace/tools/arg_parser_tools.py#L107

(It would also be nice to define what the SWA acronym means :-) )

Currently, the docs say:

> This setting usually helps lower the energy errors.

Based on people's experience, is there any more guidance that could be added here?