### PR TITLE
Only plot head-specific test set in results for multihead models

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -993,7 +993,7 @@ def run(args) -> None:
     for head_config in head_configs:
         if all(check_path_ase_read(f) for f in head_config.train_file):
             for name, subset in head_config.collections.tests:
-                test_sets[name] = [
+                test_sets[head_config.head_name + "_" + name] = [
                     data.AtomicData.from_config(
                         config, z_table=z_table, cutoff=args.r_max, heads=heads
                     )

--- a/mace/cli/visualise_train.py
+++ b/mace/cli/visualise_train.py
@@ -386,8 +386,11 @@ def plot_inference_from_results(
 
         # Plot test data (single legend entry)
         for name, result in test_dict.items():
+            if head not in name:
+                continue
             # Initialize scatter to None to avoid possibly used before assignment
             scatter = None
+            test_label = f"Test ({name})"
 
             if key == "energy" and "energy" in result:
                 e_key = "energy" if not plot_interaction_e else "interaction_energy"
@@ -396,7 +399,7 @@ def plot_inference_from_results(
                     result[e_key]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label="Test",
+                    label=test_label,
                 )
 
             elif key == "force" and "forces" in result:
@@ -405,7 +408,7 @@ def plot_inference_from_results(
                     result["forces"]["predicted"],
                     marker="o",
                     color=fixed_color_test,
-                    label="Test",
+                    label=test_label,
                 )
 
             elif key == "stress" and "stress" in result:
@@ -414,7 +417,7 @@ def plot_inference_from_results(
                     result["stress"]["predicted"],
                     marker="o",
                     color=fixed_color_test,
-                    label="Test",
+                    label=test_label,
                 )
 
             elif key == "virials" and "virials" in result:
@@ -423,7 +426,7 @@ def plot_inference_from_results(
                     result["virials"]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label="Test",
+                    label=test_label,
                 )
 
             elif key == "dipole" and "dipole" in result:
@@ -432,7 +435,7 @@ def plot_inference_from_results(
                     result["dipole"]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label="Test",
+                    label=test_label,
                 )
 
             # Only add to legend_labels if scatter was assigned

--- a/mace/cli/visualise_train.py
+++ b/mace/cli/visualise_train.py
@@ -384,13 +384,12 @@ def plot_inference_from_results(
 
         fixed_color_test = colors[2]  # Color for test dataset
 
-        # Plot test data (single legend entry)
+        # Plot test data (single legend entry per head)
         for name, result in test_dict.items():
             if head not in name:
                 continue
             # Initialize scatter to None to avoid possibly used before assignment
             scatter = None
-            test_label = f"Test ({name})"
 
             if key == "energy" and "energy" in result:
                 e_key = "energy" if not plot_interaction_e else "interaction_energy"
@@ -399,7 +398,6 @@ def plot_inference_from_results(
                     result[e_key]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label=test_label,
                 )
 
             elif key == "force" and "forces" in result:
@@ -408,7 +406,6 @@ def plot_inference_from_results(
                     result["forces"]["predicted"],
                     marker="o",
                     color=fixed_color_test,
-                    label=test_label,
                 )
 
             elif key == "stress" and "stress" in result:
@@ -417,7 +414,6 @@ def plot_inference_from_results(
                     result["stress"]["predicted"],
                     marker="o",
                     color=fixed_color_test,
-                    label=test_label,
                 )
 
             elif key == "virials" and "virials" in result:
@@ -426,7 +422,6 @@ def plot_inference_from_results(
                     result["virials"]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label=test_label,
                 )
 
             elif key == "dipole" and "dipole" in result:
@@ -435,12 +430,11 @@ def plot_inference_from_results(
                     result["dipole"]["predicted_per_atom"],
                     marker="o",
                     color=fixed_color_test,
-                    label=test_label,
                 )
 
             # Only add to legend_labels if scatter was assigned
             if scatter is not None:
-                legend_labels["Test"] = scatter
+                legend_labels[f"Test {head}"] = scatter
 
         # Add diagonal line for guide
         min_val = min(ax.get_xlim()[0], ax.get_ylim()[0])


### PR DESCRIPTION
**Issue**:
  When training a multi-head model, all heads' test sets are plotted on every head's results panel. For a 3-head
  model, each panel shows test data from all 3 heads (each evaluated with its own readout), all labelled "Test".
  This has two consequences:                                                                                           
  - The relevant per-head test scatter is obscured by test data from other heads
  - When heads span different energy/force ranges, the axes are forced to accommodate all heads' ranges, reducing resolution on the head of interest

**Solution**:
- `run_train.py`: Label each test set with its head name before passing to the plotter 
- `visualise_train.py`: only plot the test data for the current head + add the head name to the legend label

**Testing**
- 2 epochs with: single head, multihead, naive FT, mutlihead FT

- Multihead before (3 heads) (cropped out training plots as not relevant here):
<img width="1312" height="1113" alt="mutlihead_plotting_before" src="https://github.com/user-attachments/assets/ad9a4425-8a7c-4fca-aa41-87628362d271" />

- Multihead after:
<img width="1294" height="1122" alt="mutlihead_plotting_after" src="https://github.com/user-attachments/assets/cfbbb856-41b4-43c5-8ee9-9225d2262563" />
