### PR TITLE
Fix forces acting on constrained atoms when reading from extxyz database

### DIFF
--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -273,7 +273,7 @@ def load_from_xyz(
         key_specification.arrays_keys["forces"] = "REF_forces"
         for atoms in atoms_list:
             try:
-                atoms.arrays["REF_forces"] = atoms.get_forces()
+                atoms.arrays["REF_forces"] = atoms.get_forces(apply_constraint=False)
             except Exception as e:  # pylint: disable=W0703
                 logging.error(f"Failed to extract forces: {e}")
                 atoms.arrays["REF_forces"] = None


### PR DESCRIPTION
I have noticed that forces from xyz training inputs (example: attached) are not always loaded correctly.
When the inputs contain structures with constrained atoms, the forces used for training are set to 0 instead of the real values obtained from the DFT data.

This seems to happen only with newer ASE versions, after ASE started storing the constraint info in the xyz data. See https://ase-lib.org/changelog.html#id18

In https://github.com/ACEsuit/mace/blob/667eee4e58d23a38ff5a75122109ec2025809649/mace/data/utils.py#L276, `get_forces` method is used, which automatically sets forces to 0 by default, if constraints are present. See https://ase-lib.org/ase/atoms.html#ase.Atoms.get_forces

AtomsToGraphs might also be affected, but I did not check in details. There are also a couple more instances of `get_forces` in the code, but those look safe. (Although, explicitly passing `apply_constraint=False` might be a good measure if that's what is implied in the code).

Potentially related: #1148 

CC: @anfeus


[data.xyz.gz](https://github.com/user-attachments/files/27059320/data.xyz.gz)
