### PR TITLE
Fix types.MethodType of cueq_conv_fusion with CueqConvFusionWrapper for LAMMPS compatibility

### DIFF
--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -130,13 +130,29 @@ def with_scatter_sum(conv_tp: torch.nn.Module) -> torch.nn.Module:
     conv_tp.forward = types.MethodType(forward, conv_tp)
     return conv_tp
 
+class CueqConvFusionWrapper(torch.nn.Module):
+    """A serializable wrapper around cuet.SegmentedPolynomial / mptp.ff.
 
-def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
-    """Wraps a cuet.ConvTensorProduct to use conv fusion"""
-    conv_tp.original_forward = conv_tp.forward
-    num_segment = conv_tp.m.buffer_num_segments[0]
-    num_operands = conv_tp.m.operand_extent
-    conv_tp.weight_numel = num_segment * num_operands
+    It adapts MACE conv-style forward:
+
+        forward(node_feats, edge_attrs, tp_weights, edge_index)
+
+    to cuEq SegmentedPolynomial forward:
+
+        forward([tp_weights, node_feats, edge_attrs], input_indices, output_shapes, output_indices)
+    """
+
+    def __init__(self, conv_tp: torch.nn.Module):
+        super().__init__()
+        self.conv_tp = conv_tp
+
+        num_segment = conv_tp.m.buffer_num_segments[0]
+        num_operands = conv_tp.m.operand_extent
+        self.weight_numel = num_segment * num_operands
+
+    @property
+    def m(self):
+        return self.conv_tp.m
 
     def forward(
         self,
@@ -147,15 +163,18 @@ def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
     ) -> torch.Tensor:
         sender = edge_index[0]
         receiver = edge_index[1]
-        return self.original_forward(
+
+        return self.conv_tp(
             [tp_weights, node_feats, edge_attrs],
             {1: sender},
             {0: node_feats},
             {0: receiver},
         )[0]
 
-    conv_tp.forward = types.MethodType(forward, conv_tp)
-    return conv_tp
+
+def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
+    """Wraps a cuet.SegmentedPolynomial / ConvTensorProduct to use conv fusion."""
+    return CueqConvFusionWrapper(conv_tp)
 
 
 def with_oeq_conv_fusion(


### PR DESCRIPTION
## Summary

This PR replaces the previous runtime `types.MethodType`-based `forward` monkey patch with a standard `torch.nn.Module` wrapper: `CueqConvFusionWrapper`.

## Motivation

Before the fix, `with_cueq_conv_fusion` replaced the `forward` method of the underlying cuEq module dynamically via `types.MethodType`. This worked in the regular Python/ASE execution path, but was not reliably preserved when the model
was exported and loaded through the LAMMPS MLIAP path.

As a result, LAMMPS could call a raw `cuet.SegmentedPolynomial` with the
MACE-style convolution signature:

```python
conv_tp(node_feats, edge_attrs, tp_weights, edge_index)
```

while cuet.SegmentedPolynomial.forward expects:

```python
conv_tp(inputs, input_indices, output_shapes, output_indices)
```

Therefore, node_feats was interpreted as the inputs sequence. For example, for node_feats.shape == [1586, 128], cuEq observed len(inputs) == 1586, instead of the expected 3, which triggered:
```bash
AssertionError: the number of inputs must match the number of inputs of the polynomial
```