### PR TITLE
Fix dataset content logging to count labels, not sum weights

### DIFF
--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -34,10 +34,13 @@ class SubsetCollection:
 def log_dataset_contents(dataset: data.Configurations, dataset_name: str) -> None:
     log_string = f"{dataset_name} ["
     for prop_name in dataset[0].properties.keys():
+        count = sum(
+            1 for config in dataset if config.properties.get(prop_name) is not None
+        )
         if prop_name == "dipole":
-            log_string += f"{prop_name} components: {int(np.sum([np.sum(config.property_weights[prop_name]) for config in dataset]))}, "
+            log_string += f"{prop_name} components: {count}, "
         else:
-            log_string += f"{prop_name}: {int(np.sum([config.property_weights[prop_name] for config in dataset]))}, "
+            log_string += f"{prop_name}: {count}, "
     log_string = log_string[:-2] + "]"
     logging.info(log_string)
 


### PR DESCRIPTION
`log_dataset_contents` reported energy/force/etc. counts by summing `config.property_weights[prop_name]` across the dataset. This relied on weights being 0.0 (missing) or 1.0 (present), and produced inflated counts whenever users set `config_<name>_weight `to a non-unit value. Replaced with a direct count of configs where the label is present (`properties[prop_name] is not None`), so the logged numbers match the actual number of labels in train/valid/test sets.