### PR TITLE
suppress TorchScript instance-level annotation warning

### DIFF
--- a/mace/__init__.py
+++ b/mace/__init__.py
@@ -1,5 +1,11 @@
 import os
+import warnings
 
 from .__version__ import __version__
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*TorchScript type system.*instance-level annotations.*",
+)
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"

--- a/mace/__init__.py
+++ b/mace/__init__.py
@@ -5,7 +5,10 @@ from .__version__ import __version__
 
 warnings.filterwarnings(
     "ignore",
-    message=".*TorchScript type system.*instance-level annotations.*",
+    category=UserWarning,
+    module=r"torch\.jit",
+    message=r"The TorchScript type system doesn't support instance-level annotations "
+    r"on empty non-base types in `__init__`",
 )
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"

--- a/mace/__init__.py
+++ b/mace/__init__.py
@@ -1,11 +1,5 @@
 import os
-import warnings
 
 from .__version__ import __version__
-
-warnings.filterwarnings(
-    "ignore",
-    message=".*TorchScript type system.*instance-level annotations.*",
-)
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"

--- a/mace/__init__.py
+++ b/mace/__init__.py
@@ -5,10 +5,7 @@ from .__version__ import __version__
 
 warnings.filterwarnings(
     "ignore",
-    category=UserWarning,
-    module=r"torch\.jit",
-    message=r"The TorchScript type system doesn't support instance-level annotations "
-    r"on empty non-base types in `__init__`",
+    message=".*TorchScript type system.*instance-level annotations.*",
 )
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"

--- a/mace/cli/create_lammps_model.py
+++ b/mace/cli/create_lammps_model.py
@@ -2,6 +2,8 @@
 import argparse
 import copy
 import os
+import re
+import warnings
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
 
@@ -106,7 +108,17 @@ def main():
     if args.format == "mliap":
         torch.save(lammps_model, model_path + "-mliap_lammps.pt")
     else:
-        lammps_model_compiled = jit.compile(lammps_model)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=re.escape(
+                    "The TorchScript type system doesn't support instance-level annotations on empty non-base types "
+                    "in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type "
+                    "in `torch.jit.Attribute`."
+                ),
+                category=UserWarning,
+            )
+            lammps_model_compiled = jit.compile(lammps_model)
         lammps_model_compiled.save(model_path + "-lammps.pt")
 
 

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -9,6 +9,8 @@ import glob
 import json
 import logging
 import os
+import re
+import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional
@@ -1096,7 +1098,17 @@ def run(args) -> None:
                         args.name + "_stagetwo_compiled.model"
                     )
                     logging.info(f"Compiling model, saving metadata {path_complied}")
-                    model_compiled = jit.compile(deepcopy(model_to_save))
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            "ignore",
+                            message=re.escape(
+                                "The TorchScript type system doesn't support instance-level annotations on empty non-base types "
+                                "in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type "
+                                "in `torch.jit.Attribute`."
+                            ),
+                            category=UserWarning,
+                        )
+                        model_compiled = jit.compile(deepcopy(model_to_save))
                     torch.jit.save(
                         model_compiled,
                         path_complied,
@@ -1111,7 +1123,17 @@ def run(args) -> None:
                         args.name + "_compiled.model"
                     )
                     logging.info(f"Compiling model, saving metadata to {path_complied}")
-                    model_compiled = jit.compile(deepcopy(model_to_save))
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(
+                            "ignore",
+                            message=re.escape(
+                                "The TorchScript type system doesn't support instance-level annotations on empty non-base types "
+                                "in `__init__`. Instead, either 1) use a type annotation in the class body, or 2) wrap the type "
+                                "in `torch.jit.Attribute`."
+                            ),
+                            category=UserWarning,
+                        )
+                        model_compiled = jit.compile(deepcopy(model_to_save))
                     torch.jit.save(
                         model_compiled,
                         path_complied,


### PR DESCRIPTION
Closes #1485.

Suppresses a cosmetic warning from PyTorch issue pytorch#89064 that appears during MACE import. The warning is triggered by instance-level type annotations in `GatedEquivariantBlock.__init__` (`mace/modules/gate.py`). e3nn already suppresses this in its `compile()` path.

Harmless, no impact on functionality.