### PR TITLE
Small fix for stress calculation in low-dimensional systems

### DIFF
--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -28,17 +28,18 @@ def get_neighborhood(
     # Extend cell in non-periodic directions
     # For models with more than 5 layers, the multiplicative constant needs to be increased.
     # temp_cell = np.copy(cell)
+    cell_for_nl = np.copy(cell)
     if not pbc_x:
-        cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
+        cell_for_nl[0, :] = max_positions * 5 * cutoff * identity[0, :]
     if not pbc_y:
-        cell[1, :] = max_positions * 5 * cutoff * identity[1, :]
+        cell_for_nl[1, :] = max_positions * 5 * cutoff * identity[1, :]
     if not pbc_z:
-        cell[2, :] = max_positions * 5 * cutoff * identity[2, :]
+        cell_for_nl[2, :] = max_positions * 5 * cutoff * identity[2, :]
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",
         pbc=pbc,
-        cell=cell,
+        cell=cell_for_nl,
         positions=positions,
         cutoff=cutoff,
         # self_interaction=True,  # we want edges from atom to itself in different periodic images


### PR DESCRIPTION
In the previous implementation, when the system is non-periodic along certain directions, the simulation cell is expanded to construct the neighbor list. However, this modification also alters the cell volume, which is then incorrectly used in the stress calculation.
Here I introduced a temporary expanded cell used exclusively for generating the neighbor list, ensuring that the original cell volume remains unchanged for the stress evaluation.