### PR TITLE
cast torch.Tensor to int type

### DIFF
--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -110,7 +110,7 @@ class MACELES(ScaleShiftMACE):
         no_pbc_mask_cfg = ~pbc_tensor.any(dim=-1)
         no_pbc_mask_rows = no_pbc_mask_cfg.repeat_interleave(3)
         cell_les[no_pbc_mask_rows] = torch.zeros(
-            (no_pbc_mask_rows.sum(), 3), dtype=cell_les.dtype, device=cell_les.device
+            (int(no_pbc_mask_rows.sum()), 3), dtype=cell_les.dtype, device=cell_les.device
         )
 
         # Atomic energies


### PR DESCRIPTION
The following error is raised when running `mace_create_lammps_model`, which can be fixed by simply cast `torch.Tensor` type to `int`.

```
RuntimeError:
Arguments for call are not valid.
The following variants are available:

  aten::zeros.names(int[] size, *, str[]? names, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor:
  Expected a value of type 'int' for argument '<varargs>' but instead found type 'Tuple[Tensor, int]'.

  aten::zeros(SymInt[] size, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor:
  Expected a value of type 'int' for argument '<varargs>' but instead found type 'Tuple[Tensor, int]'.

  aten::zeros.names_out(int[] size, *, str[]? names, Tensor(a!) out) -> Tensor(a!):
  Expected a value of type 'int' for argument '<varargs>' but instead found type 'Tuple[Tensor, int]'.

  aten::zeros.out(SymInt[] size, *, Tensor(a!) out) -> Tensor(a!):
  Expected a value of type 'int' for argument '<varargs>' but instead found type 'Tuple[Tensor, int]'.

The original call is:
  File "/public/groups/ai4ec/libs/conda/mace/latest/lib/python3.12/site-packages/mace/modules/extensions.py", line 141
        no_pbc_mask_cfg = ~pbc_tensor.any(dim=-1)
        no_pbc_mask_rows = no_pbc_mask_cfg.repeat_interleave(3)
        cell_les[no_pbc_mask_rows] = torch.zeros(
                                     ~~~~~~~~~~~ <--- HERE
            (no_pbc_mask_rows.sum(), 3), dtype=cell_les.dtype, device=cell_les.device
        )
```
