### PR TITLE
accelerate stress calculations

### DIFF
--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -101,11 +101,18 @@ def get_symmetric_displacement(
     )
     cell = cell.view(-1, 3, 3)
     cell = cell + torch.matmul(cell, symmetric_displacement)
-    shifts = torch.einsum(
-        "be,bec->bc",
-        unit_shifts,
-        cell[batch[sender]],
-    )
+    if num_graphs == 1:
+        shifts = torch.einsum(
+                "be,ec->bc",
+                unit_shifts,
+                cell[0],
+            )
+    else:
+        shifts = torch.einsum(
+            "be,bec->bc",
+            unit_shifts,
+            cell[batch[sender]],
+        )
     return positions, shifts, displacement
 
 


### PR DESCRIPTION
This avoids redundant indexing when computing shifts for a batch containing only one graph. Previously, `cell[batch[sender]]` selected the graph cell for each edge, which creates a hard to parallelise reduction in the backward pass. For batch size 1, all edges use the same cell, so this can be replaced by indexing `cell[0]` directly.

In measured large Cu, Si, and Fe systems, this improved inference performance by more than 80% when stress calculation was enabled.