### PR TITLE
Fix non-PBC fake-cell sizing in get_neighborhood

### DIFF
--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -24,16 +24,23 @@ def get_neighborhood(
     pbc_y = pbc[1]
     pbc_z = pbc[2]
     identity = np.identity(3, dtype=float)
-    max_positions = np.max(np.absolute(positions)) + 1
-    # Extend cell in non-periodic directions
-    # For models with more than 5 layers, the multiplicative constant needs to be increased.
-    # temp_cell = np.copy(cell)
+    # Extend cell in non-periodic directions so an atom's receptive field cannot
+    # reach its periodic image. Use molecular extent (translation-invariant) plus
+    # an additive safety margin equal to receptive-field × cutoff; the additive
+    # form prevents the matscipy linked-cell grid from exploding when
+    # the molecule is far from the origin. Bump the safety
+    # multiplier if the model uses more than 5 message-passing layers.
+    if positions.size:
+        extent = positions.max(axis=0) - positions.min(axis=0)
+    else:
+        extent = np.zeros(3, dtype=float)
+    safety = 5 * cutoff
     if not pbc_x:
-        cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
+        cell[0, :] = (extent[0] + safety) * identity[0, :]
     if not pbc_y:
-        cell[1, :] = max_positions * 5 * cutoff * identity[1, :]
+        cell[1, :] = (extent[1] + safety) * identity[1, :]
     if not pbc_z:
-        cell[2, :] = max_positions * 5 * cutoff * identity[2, :]
+        cell[2, :] = (extent[2] + safety) * identity[2, :]
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",


### PR DESCRIPTION
The previous formula sized the fake cell as `max(|positions|) * 5 * cutoff`, which depended on where the molecule sat relative to the origin rather than its actual extent, and used a multiplicative safety margin instead of an additive one. A molecule with max|positions|=237 A and cutoff=5 produced a fake cell of ~5948 A per side. matscipy's neighbour_list then allocated a linked-cell grid of ~1.7 billion bins (~6 GiB CPU RAM) just to find a few hundred edges among ~50 atoms. In production this propagated into multi-hundred-GiB tensor allocations on accelerators and triggered uncatchable GPU page faults that took down 12 000-rank MPI runs.

Replace with cell = extent + 5 * cutoff so the cell scales with the molecular bounding box and is translation-invariant. For a 200 A molecule the cell drops from ~6000 A to ~232 A; for a typical 10 A molecule from 250 A to ~35 A. Edge counts are unchanged; matscipy allocation goes from O(GiB) to O(MiB).

PS: I had out of memory errors for some geometries and opus4.7 found the bug and helped me patch.