### PR TITLE
Fixes bug preventing early stopping from exiting the training loop when not running in distributed mode (issue 1384)

### DIFF
--- a/mace/tools/train.py
+++ b/mace/tools/train.py
@@ -205,7 +205,7 @@ def train(
     valid_loss = valid_loss_head  # consider only the last head for the checkpoint
 
     # variable used for broadcast by rank == 0 if epoch loop is exited early, e.g. patience
-    exit_now = torch.zeros(1, device=device) if distributed else None
+    exit_now = torch.zeros(1, device=device)
     while epoch < max_num_epochs:
         # LR scheduler and SWA update
         if swa is None or epoch < swa.start:
@@ -308,8 +308,7 @@ def train(
                             logging.info(
                                 f"Stopping optimization after {patience_counter} epochs without improvement"
                             )
-                            if exit_now is not None:
-                                exit_now.fill_(1)
+                            exit_now.fill_(1)
                     if save_all_checkpoints:
                         param_context = (
                             ema.average_parameters()
@@ -337,10 +336,9 @@ def train(
                         keep_last = False or save_all_checkpoints
         if distributed:
             torch.distributed.barrier()
-        if exit_now is not None:
             torch.distributed.broadcast(exit_now, src=0)
-            if exit_now == 1:
-                break
+        if exit_now == 1:
+            break
 
         epoch += 1
 

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -1,6 +1,8 @@
 # pylint: disable=too-many-lines
 
+import importlib
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -108,6 +110,75 @@ _mace_params = {
     "eval_interval": 2,
     "use_reduced_cg": False,
 }
+
+
+@pytest.mark.parametrize(
+    ("save_all_checkpoints", "expected_saved_epochs"),
+    [
+        (False, [(0, False)]),
+        (True, [(0, False), (1, True)]),
+    ],
+)
+def test_train_non_distributed_early_stopping_exits_loop(
+    monkeypatch, caplog, save_all_checkpoints, expected_saved_epochs
+):
+    train_module = importlib.import_module("mace.tools.train")
+    trained_epochs = []
+    scheduler_metrics = []
+    saved_epochs = []
+
+    def fake_evaluate(**_kwargs):
+        return 1.0, {}
+
+    def fake_train_one_epoch(*_args, epoch, **_kwargs):
+        trained_epochs.append(epoch)
+
+    class DummyScheduler:
+        def step(self, metrics=None):
+            scheduler_metrics.append(metrics)
+
+    class DummyCheckpointHandler:
+        def save(self, state, epochs, keep_last):  # pylint: disable=unused-argument
+            saved_epochs.append((epochs, keep_last))
+
+    class DummyLogger:
+        def log(self, _metrics):
+            pass
+
+    monkeypatch.setattr(train_module, "evaluate", fake_evaluate)
+    monkeypatch.setattr(train_module, "train_one_epoch", fake_train_one_epoch)
+    monkeypatch.setattr(train_module, "valid_err_log", lambda *_args, **_kwargs: None)
+
+    with caplog.at_level(logging.INFO):
+        train_module.train(
+            model=torch.nn.Linear(1, 1),
+            loss_fn=torch.nn.MSELoss(),
+            train_loader=object(),
+            valid_loaders={"valid": object()},
+            optimizer=object(),
+            lr_scheduler=DummyScheduler(),
+            start_epoch=0,
+            max_num_epochs=100,
+            patience=1,
+            checkpoint_handler=DummyCheckpointHandler(),
+            logger=DummyLogger(),
+            eval_interval=1,
+            output_args={},
+            device=torch.device("cpu"),
+            log_errors="TotalRMSE",
+            max_grad_norm=None,
+            distributed=False,
+            save_all_checkpoints=save_all_checkpoints,
+        )
+
+    assert trained_epochs == [0, 1]
+    assert scheduler_metrics == [1.0]
+    assert saved_epochs == expected_saved_epochs
+    assert any(
+        record.levelno == logging.INFO
+        and "Stopping optimization after 1 epochs without improvement" in record.message
+        for record in caplog.records
+    )
 
 
 def test_run_train(tmp_path, fitting_configs):

--- a/tests/test_run_train.py
+++ b/tests/test_run_train.py
@@ -158,7 +158,7 @@ def test_train_non_distributed_early_stopping_exits_loop(
             optimizer=object(),
             lr_scheduler=DummyScheduler(),
             start_epoch=0,
-            max_num_epochs=100,
+            max_num_epochs=10,
             patience=1,
             checkpoint_handler=DummyCheckpointHandler(),
             logger=DummyLogger(),


### PR DESCRIPTION
[Issue 1384](https://github.com/ACEsuit/mace/issues/1384) describes a bug where early stopping fails to stop the training loop when distributed training is not enabled. The bug appears to have been introduced in [this PR](https://github.com/ACEsuit/mace/pull/1216), which updated `mace/tools/train.py` so that all ranks exit from the training loop correctly if `patience` is exceeded. In addressing this issue, the PR introduced a bug that meant the training loop never checks correctly for `patience` being exceeded when *not* running in distributed mode.

This is a minimal fix that ensures patience being exceeded exits the loop in serial mode, and adds a test.

I've tested this locally on my laptop with a small training run with `--max_num_epochs=10000` and `--patience=1`, and the training loop correctly exits due to patience being exceeded:

```
2026-06-16 22:47:40.107 INFO: ===========TRAINING===========
2026-06-16 22:47:40.107 INFO: Started training, reporting errors on validation set
2026-06-16 22:47:40.107 INFO: Loss metrics on validation set
/redacted/path/info/mace/.venv/lib/python3.11/site-packages/torch/utils/data/dataloader.py:752: UserWarning: 'pin_memory' argument is set as true but not supported on MPS now, device pinned memory won't be used.
  super().__init__(loader)
2026-06-16 22:47:40.200 INFO: Initial: head: Default, loss=0.11416074, RMSE_E_per_atom=  337.88 meV, RMSE_F=    0.00 meV / A
2026-06-16 22:47:40.898 INFO: Epoch 0: head: Default, loss=0.11416074, RMSE_E_per_atom=  337.88 meV, RMSE_F=    0.00 meV / A
2026-06-16 22:47:41.364 INFO: Epoch 1: head: Default, loss=0.11416074, RMSE_E_per_atom=  337.88 meV, RMSE_F=    0.00 meV / A
2026-06-16 22:47:41.365 INFO: Stopping optimization after 1 epochs without improvement
2026-06-16 22:47:41.365 INFO: Training complete
```

**NB** I have not tested this in distributed training mode on a machine with a GPU.

