### PR TITLE
Make node_energy Mac Silicon MPS-compatible (avoid hardcoded float64)

### DIFF
--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -23,7 +23,12 @@ from mace.modules.blocks import (
     NonLinearReadoutBlock,
 )
 from mace.modules.models import ScaleShiftMACE
-from mace.modules.utils import get_atomic_virials_stresses, get_outputs, prepare_graph
+from mace.modules.utils import (
+    get_atomic_virials_stresses,
+    get_outputs,
+    prepare_graph,
+    safe_double,
+)
 from mace.modules.wrapper_ops import (
     CuEquivarianceConfig,
     OEQConfig,
@@ -237,7 +242,7 @@ class MACELES(ScaleShiftMACE):
         inter_e = scatter_sum(node_inter_es, data["batch"], dim=-1, dim_size=num_graphs)
 
         total_energy = e0 + inter_e
-        node_energy = node_e0.clone().double() + node_inter_es.clone().double()
+        node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
         les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1)
         les_result = self.les(
@@ -740,7 +745,7 @@ class PolarMACE(ScaleShiftMACE):
             fukui_input = fukui_to_mul_ir(fukui_input)
         fukui_sources = self.fukui_source_map(fukui_input)
         fukui_norm = scatter_sum(
-            src=fukui_sources.double(),
+            src=safe_double(fukui_sources),
             index=data["batch"],
             dim=0,
             dim_size=num_graphs,
@@ -752,7 +757,7 @@ class PolarMACE(ScaleShiftMACE):
         Q_p_S = (data["total_charge"] + (data["total_spin"] - 1))[data["batch"]]
         Q_m_S = (data["total_charge"] - (data["total_spin"] - 1))[data["batch"]]
         pred_total_charges_0 = scatter_sum(
-            src=spin_charge_density[:, :, 0].double(),
+            src=safe_double(spin_charge_density[:, :, 0]),
             index=data["batch"],
             dim=0,
             dim_size=num_graphs,
@@ -798,7 +803,7 @@ class PolarMACE(ScaleShiftMACE):
 
             # Add external field contribution and subtract barycenter for gauge invariance
             barycenter = scatter_mean(
-                src=positions.double(),
+                src=safe_double(positions),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -840,7 +845,7 @@ class PolarMACE(ScaleShiftMACE):
             spin_charge_density = spin_charge_density + spin_charge_density_sources
 
             fukui_norm2 = scatter_sum(
-                src=current_fukui_sources.double(),
+                src=safe_double(current_fukui_sources),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -850,7 +855,7 @@ class PolarMACE(ScaleShiftMACE):
             )
             current_fukui_sources = current_fukui_sources / fukui_norm2
             pred_total_charges = scatter_sum(
-                src=spin_charge_density[:, :, 0].double(),
+                src=safe_double(spin_charge_density[:, :, 0]),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -958,7 +963,8 @@ class PolarMACE(ScaleShiftMACE):
 
         return {
             "energy": total_energy,
-            "node_energy": node_e0.clone().double() + node_inter_es.clone().double(),
+            "node_energy": safe_double(node_e0.clone())
+            + safe_double(node_inter_es.clone()),
             "interaction_energy": inter_e,
             "forces": forces,
             "edge_forces": edge_forces,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -578,7 +578,8 @@ class ScaleShiftMACE(MACE):
         inter_e = scatter_sum(node_inter_es, data["batch"], dim=-1, dim_size=num_graphs)
 
         total_energy = e0 + inter_e
-        node_energy = node_e0.clone().double() + node_inter_es.clone().double()
+        energy_dtype = node_e0.dtype if node_e0.device.type == "mps" else torch.float64
+        node_energy = node_e0.clone().to(energy_dtype) + node_inter_es.clone().to(energy_dtype)
 
         forces, virials, stress, hessian, edge_forces = get_outputs(
             energy=inter_e,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -39,6 +39,7 @@ from .utils import (
     get_outputs,
     get_symmetric_displacement,
     prepare_graph,
+    safe_double,
 )
 
 
@@ -578,8 +579,7 @@ class ScaleShiftMACE(MACE):
         inter_e = scatter_sum(node_inter_es, data["batch"], dim=-1, dim_size=num_graphs)
 
         total_energy = e0 + inter_e
-        energy_dtype = node_e0.dtype if node_e0.device.type == "mps" else torch.float64
-        node_energy = node_e0.clone().to(energy_dtype) + node_inter_es.clone().to(energy_dtype)
+        node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
         forces, virials, stress, hessian, edge_forces = get_outputs(
             energy=inter_e,

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -19,6 +19,17 @@ from mace.tools.torch_geometric.batch import Batch
 from .blocks import AtomicEnergiesBlock
 
 
+def safe_double(t: torch.Tensor) -> torch.Tensor:
+    """Cast to float64 for accumulation precision, except on MPS.
+
+    The Apple-Silicon MPS backend does not support float64, so there the
+    tensor is returned unchanged in its working dtype.
+    """
+    if t.device.type == "mps":
+        return t
+    return t.double()
+
+
 def compute_forces(
     energy: torch.Tensor, positions: torch.Tensor, training: bool = True
 ) -> torch.Tensor:


### PR DESCRIPTION
## Issue

The Apple-Silicon GPU MPS backend does not support float64, so this raises at inference on `device="mps"`, even when the model is loaded/run in float32:

**TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.**

## Fix

Keep the float64 on CPU/CUDA (unchanged behaviour) and fall back to the tensor's working dtype only on MPS:

```python
energy_dtype = node_e0.dtype if node_e0.device.type == "mps" else torch.float64
node_energy = node_e0.clone().to(energy_dtype) + node_inter_es.clone().to(energy_dtype)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral change in ScaleShiftMACE forward; MPS gets float32 node_energy instead of crashing, CPU/CUDA behavior unchanged.
> 
> **Overview**
> Fixes **ScaleShiftMACE** inference on Apple Silicon when tensors live on **MPS**, where PyTorch cannot use float64.
> 
> **`node_energy`** was built by cloning **`node_e0`** and **`node_inter_es`** with **`.double()`**, which crashes on MPS. The forward pass now picks **`energy_dtype`**: **`node_e0.dtype`** on MPS (typically float32) and **`torch.float64`** on CPU/CUDA, then sums the clones in that dtype. **`total_energy`**, forces, and other outputs are unchanged; only the per-atom energy tensor’s accumulation dtype is device-aware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7117d352cccd4c6d7fba5e15777fbc40be66cdf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->