### PR TITLE
Fix CPU DDP, broken console entry points, and pre-commit checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 build/
 *.egg-info/
 
+# virtual environments
+.venv/
+
 # pytest
 .pytest_cache/
 
@@ -17,6 +20,7 @@ build/
 .idea/
 .vscode/
 *.txt
+!requirements/*.txt
 *.log
 
 # Distribution
@@ -38,5 +42,16 @@ dist/
 
 .benchmarks
 *.png
+# Personal/scratch scripts stay untracked; the repo's own wrappers in
+# scripts/ remain tracked (gitignore does not affect already-tracked files).
 /scripts
 *.cube
+
+# coverage artifacts
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# local planning docs (not for the public repo)
+/doc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,21 +9,21 @@ exclude: &exclude_files >
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v6.0.0
     hooks:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
         exclude: *exclude_files
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.0
+    rev: 26.5.1
     hooks:
       - id: black
         name: Black Formating
         exclude: *exclude_files
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         name: Sort imports

--- a/mace/cli/plot_train.py
+++ b/mace/cli/plot_train.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import dataclasses
 import glob
@@ -6,11 +8,21 @@ import os
 import re
 from typing import List
 
-import matplotlib.pyplot as plt
-import pandas as pd
+# matplotlib/pandas are not mace-torch dependencies: guard the import so the
+# console entry point resolves (and --help works) in a clean install, and
+# main() can explain what to install instead of crashing with ImportError.
+try:
+    import matplotlib.pyplot as plt
+    import pandas as pd
 
-plt.rcParams.update({"font.size": 8})
-plt.style.use("seaborn-v0_8-paper")
+    plt.rcParams.update({"font.size": 8})
+    plt.style.use("seaborn-v0_8-paper")
+
+    PLOT_DEPS_AVAILABLE = True
+except ImportError:
+    plt = None
+    pd = None
+    PLOT_DEPS_AVAILABLE = False
 
 
 colors = [
@@ -313,6 +325,11 @@ def get_paths(path: str) -> List[str]:
 
 
 def main() -> None:
+    if not PLOT_DEPS_AVAILABLE:
+        raise SystemExit(
+            "mace_plot_train requires matplotlib and pandas: "
+            "pip install matplotlib pandas"
+        )
     args = parse_args()
     run(args)
 

--- a/mace/cli/polar_density_cube.py
+++ b/mace/cli/polar_density_cube.py
@@ -1,6 +1,8 @@
 # Copyright (c) MACE contributors
 # Script for exporting MACE-Polar density coefficients to Gaussian cube files
 # This program is distributed under the MIT License (see MIT.md)
+# pylint: disable=wrong-import-position
+from __future__ import annotations
 
 import argparse
 import json
@@ -104,9 +106,7 @@ def coefficient_dipole(atoms, multipoles: np.ndarray) -> np.ndarray:
     dipoles = np.zeros((multipoles.shape[0], 3))
     if multipoles.shape[1] > 1:
         dipoles = multipoles[:, 1:4][:, [2, 0, 1]]
-    return np.sum(atoms.positions * charges[:, None], axis=0) + np.sum(
-        dipoles, axis=0
-    )
+    return np.sum(atoms.positions * charges[:, None], axis=0) + np.sum(dipoles, axis=0)
 
 
 def cube_boundary_max_abs(density: np.ndarray) -> float:
@@ -208,13 +208,9 @@ class PotentialInterpolator:
     def _total_charge_dipole(
         multipoles: torch.Tensor, node_positions: torch.Tensor, batch: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        total_charge = torch.zeros(
-            1, dtype=multipoles.dtype, device=multipoles.device
-        )
+        total_charge = torch.zeros(1, dtype=multipoles.dtype, device=multipoles.device)
         total_charge.index_add_(0, batch, multipoles[:, 0])
-        dipole_q = torch.zeros(
-            (1, 3), dtype=multipoles.dtype, device=multipoles.device
-        )
+        dipole_q = torch.zeros((1, 3), dtype=multipoles.dtype, device=multipoles.device)
         dipole_q.index_add_(0, batch, node_positions * multipoles[:, 0].unsqueeze(-1))
         if multipoles.shape[-1] > 1:
             dipole_p = torch.zeros_like(dipole_q)
@@ -342,14 +338,17 @@ class PotentialInterpolator:
             sample_batch=sample_batch,
             k0_mask=k0_mask,
         )
-        samples_potential = evaluate_fourier_series_at_points_flat(
-            k_vectors=k_vectors,
-            k_vector_batch=k_vector_batch,
-            fourier_coefficients=potential,
-            sample_points=sample_points,
-            sample_batch=sample_batch,
-            k0_mask=k0_mask,
-        ) + fermi_level
+        samples_potential = (
+            evaluate_fourier_series_at_points_flat(
+                k_vectors=k_vectors,
+                k_vector_batch=k_vector_batch,
+                fourier_coefficients=potential,
+                sample_points=sample_points,
+                sample_batch=sample_batch,
+                k0_mask=k0_mask,
+            )
+            + fermi_level
+        )
         samples_potential_corrected = (
             samples_potential
             + correction_field_z[sample_batch] * sample_points[:, 2]
@@ -446,9 +445,9 @@ class RealSpaceDensityInterpolator:
         density = torch.empty(
             sample_points.shape[0], dtype=self.dtype, device=self.device
         )
-        image_positions = (
-            node_positions[None, :, :] + shifts[:, None, :]
-        ).reshape(-1, 3)
+        image_positions = (node_positions[None, :, :] + shifts[:, None, :]).reshape(
+            -1, 3
+        )
         image_charges = charges.repeat(shifts.shape[0])
         image_dipoles = dipoles.repeat(shifts.shape[0], 1)
 

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -893,7 +893,11 @@ def run(args) -> None:
     if args.wandb:
         setup_wandb(args)
     if args.distributed:
-        distributed_model = DDP(model, device_ids=[local_rank])
+        # device_ids is only valid for single-device CUDA modules; CPU (gloo)
+        # requires device_ids=None.
+        distributed_model = DDP(
+            model, device_ids=[local_rank] if args.device == "cuda" else None
+        )
     else:
         distributed_model = None
 
@@ -1053,7 +1057,9 @@ def run(args) -> None:
             # after param.requires_grad = False was called before evaluating stage-one model
             for param in model.parameters():
                 param.requires_grad = True
-            distributed_model = DDP(model, device_ids=[local_rank])
+            distributed_model = DDP(
+                model, device_ids=[local_rank] if args.device == "cuda" else None
+            )
         model_to_evaluate = model if not args.distributed else distributed_model
         if swa_eval:
             logging.info(f"Loaded Stage two model from epoch {epoch} for evaluation")

--- a/mace/tools/distributed_tools.py
+++ b/mace/tools/distributed_tools.py
@@ -56,4 +56,11 @@ def init_distributed(args):
                 backend="ccl",
                 init_method="env://",
             )
+        else:
+            # CPU (tests, debugging): gloo. Previously no process group was
+            # created here at all, so --distributed on CPU could never work.
+            torch.distributed.init_process_group(
+                backend="gloo",
+                init_method="env://",
+            )
     return rank, local_rank, world_size

--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -1,4 +1,4 @@
-## Wrapper for mace.cli.run_train.main ##
+## Wrapper for mace.cli.preprocess_data.main ##
 
 from mace.cli.preprocess_data import main
 


### PR DESCRIPTION
This is the first of 4 stacked PRs that rework our CI and test suite. Merge in order: this one goes first. It only contains bug fixes, so it should be easy to review, no CI or test changes yet.

While setting up the new CI we ran into a few things that were simply broken:

**Distributed training on CPU never worked.** If you passed `--distributed` with `device=cpu`, no process group was ever created (only cuda and xpu had one), and even if it had been, we were passing `device_ids` to DDP, which PyTorch rejects for CPU modules. Both are fixed, and there is now a gloo backend for CPU. This matters mostly for testing DDP without burning GPU time.

**Two console commands crashed for users.** `mace_polar_density_cube` died on Python 3.9 the moment you ran it (it uses `str | Path` annotations without the future import), and it has shipped like that in every release. `mace_plot_train` crashed on a clean install because matplotlib and pandas are not dependencies of the package; now it tells you what to install instead of dumping a traceback.

**Our formatting check could never fail.** The CI workflow ran `black .` (which rewrites files) right before checking formatting, so any badly formatted PR passed anyway. The hooks now run in check mode only, and I updated the hook versions while at it (they were from 2020).

There is also a small `.gitignore` cleanup: allow `requirements/*.txt` (the next PRs pin external git dependencies there), ignore `.venv/` and coverage artifacts, and a comment documenting that `/scripts` stays ignored on purpose.
