### PR TITLE
Honor the CLI key specification in LMDBDataset

### DIFF
--- a/mace/data/lmdb_dataset.py
+++ b/mace/data/lmdb_dataset.py
@@ -44,9 +44,12 @@ class LMDBDataset(Dataset):
             if "stress" in atoms.calc.results:
                 atoms.info[DefaultKeys.STRESS.value] = atoms.calc.results["stress"]
 
+        key_specification = self.kwargs.get("key_specification")
+        if key_specification is None:
+            key_specification = KeySpecification.from_defaults()
         config = config_from_atoms(
             atoms,
-            key_specification=KeySpecification.from_defaults(),
+            key_specification=key_specification,
         )
 
         # Set head if not already set

--- a/mace/tools/run_train_utils.py
+++ b/mace/tools/run_train_utils.py
@@ -87,6 +87,7 @@ def load_dataset_for_path(
                 z_table=z_table,
                 heads=heads,
                 head=head_config.head_name,
+                key_specification=head_config.key_specification,
             )
 
         h5_files = list(filepath.glob("*.h5")) + list(filepath.glob("*.hdf5"))
@@ -112,6 +113,7 @@ def load_dataset_for_path(
                 z_table=z_table,
                 heads=heads,
                 head=head_config.head_name,
+                key_specification=head_config.key_specification,
             )
 
         logging.info(f"Attempting to load directory as HDF5 dataset: {file_path}")
@@ -146,6 +148,7 @@ def load_dataset_for_path(
             z_table=z_table,
             heads=heads,
             head=head_config.head_name,
+            key_specification=head_config.key_specification,
         )
 
     logging.info(f"Attempting to load as LMDB: {file_path}")
@@ -155,6 +158,7 @@ def load_dataset_for_path(
         z_table=z_table,
         heads=heads,
         head=head_config.head_name,
+        key_specification=head_config.key_specification,
     )
 
 

--- a/tests/test_lmdb_database.py
+++ b/tests/test_lmdb_database.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from types import SimpleNamespace
 
 import numpy as np
 import torch
@@ -7,8 +8,10 @@ from ase.build import molecule
 from ase.calculators.singlepoint import SinglePointCalculator
 
 from mace.data.lmdb_dataset import LMDBDataset
+from mace.data.utils import KeySpecification, update_keyspec_from_kwargs
 from mace.tools import AtomicNumberTable, torch_geometric
 from mace.tools.fairchem_dataset.lmdb_dataset_tools import LMDBDatabase
+from mace.tools.run_train_utils import load_dataset_for_path
 
 
 def test_lmdb_dataset():
@@ -132,3 +135,73 @@ def test_lmdb_dataset():
         assert (
             len(all_batches) == 3
         )  # Should have 3 batches (12 configs with batch size 4)
+
+
+def test_lmdb_dataset_honors_key_specification():
+    """A CLI key specification must reach the loaded data.
+
+    OMol-style data stores charge/spin under the row ``data`` dict (surfaced as
+    ``atoms.info["charge"]`` / ``["spin"]``). A key specification built from
+    ``--total_charge_key=charge --total_spin_key=spin`` must be honored; without
+    one the defaults apply and ``total_charge`` / ``total_spin`` silently fall
+    back to 0 / 1.
+    """
+    torch.set_default_dtype(torch.float64)
+
+    charge, spin = -1, 3
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "sample.aselmdb")
+        db = LMDBDatabase(db_path, readonly=False)
+        db.write(molecule("H2O"), data={"charge": charge, "spin": spin})
+        db.close()
+
+        z_table = AtomicNumberTable([1, 8])  # H and O
+
+        # Key spec as built by --total_charge_key=charge --total_spin_key=spin
+        key_spec = KeySpecification.from_defaults()
+        update_keyspec_from_kwargs(
+            key_spec, {"total_charge_key": "charge", "total_spin_key": "spin"}
+        )
+        item = LMDBDataset(
+            file_path=db_path,
+            r_max=5.0,
+            z_table=z_table,
+            key_specification=key_spec,
+        )[0]
+        assert float(item.total_charge) == charge
+        assert float(item.total_spin) == spin
+
+        # Without a key spec the defaults apply (backward-compatible fallback)
+        default_item = LMDBDataset(file_path=db_path, r_max=5.0, z_table=z_table)[0]
+        assert float(default_item.total_charge) == 0.0
+        assert float(default_item.total_spin) == 1.0
+
+
+def test_load_dataset_for_path_forwards_key_specification():
+    """`load_dataset_for_path` must forward the head's key specification to
+    `LMDBDataset` for an ``.aselmdb`` input (the dispatch half of the fix)."""
+    torch.set_default_dtype(torch.float64)
+
+    charge, spin = -1, 3
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "sample.aselmdb")
+        db = LMDBDatabase(db_path, readonly=False)
+        db.write(molecule("H2O"), data={"charge": charge, "spin": spin})
+        db.close()
+
+        key_spec = KeySpecification.from_defaults()
+        update_keyspec_from_kwargs(
+            key_spec, {"total_charge_key": "charge", "total_spin_key": "spin"}
+        )
+        head_config = SimpleNamespace(head_name="Default", key_specification=key_spec)
+
+        dataset = load_dataset_for_path(
+            file_path=db_path,
+            r_max=5.0,
+            z_table=AtomicNumberTable([1, 8]),
+            heads=["Default"],
+            head_config=head_config,
+        )
+        item = dataset[0]
+        assert float(item.total_charge) == charge
+        assert float(item.total_spin) == spin


### PR DESCRIPTION
## Problem

`LMDBDataset.__getitem__` hardcodes `KeySpecification.from_defaults()` when building each config:

```python
config = config_from_atoms(
    atoms,
    key_specification=KeySpecification.from_defaults(),   # ignores CLI overrides
)
```

So CLI key overrides such as `--total_charge_key` / `--total_spin_key` are **silently ignored** for `.aselmdb` / `.lmdb` datasets — `load_dataset_for_path` never passes the parsed key specification to `LMDBDataset`, and `__getitem__` would ignore it even if it did.

This bites OMol-style data. The defaults map `total_charge <- "total_charge"` and `total_spin <- "total_spin"`, but OMol stores these under `data["charge"]` / `data["spin"]` (surfaced by `get_atoms` as `atoms.info["charge"]` / `["spin"]`). The mapped keys are absent, so `total_charge` / `total_spin` fall back to `0.0` / `1.0` — **every system is loaded as a neutral closed-shell singlet**, regardless of the flags on the command line.

## Fix

Thread `head_config.key_specification` through `load_dataset_for_path` into the `LMDBDataset` constructors, and honor it in `__getitem__` — falling back to `KeySpecification.from_defaults()` when none is supplied, so existing behavior is unchanged. `LMDBDataset` is the only on-the-fly reader that applied `config_from_atoms` with a hardcoded spec; HDF5 datasets bake the key mapping in at write time.

## Affected training recipes (mace-foundations)

- **`mace_omol/mace-omol.sh`** already passes `--total_charge_key="charge" --total_spin_key="spin"` and `--energy_key=REF_energy --forces_key=REF_forces`. Those charge/spin flags are currently dead and start working with this change; its energy/forces keys are unaffected.
- **`mace_polar_1/mace-polar-1-{medium,large}.sh`** do **not** pass charge/spin keys, and set `--forces_key='forces'`. Companion PR: **ACEsuit/mace-foundations#79**.

  ⚠️ **Coupling worth noting for reviewers:** on current `develop`, `--forces_key='forces'` is silently ignored and forces fall back to the `REF_forces` default, so they load correctly *by accident*. Once overrides are honored (this PR), `--forces_key='forces'` actively selects the empty `atoms.arrays["forces"]` and forces load as **zero**. The companion PR updates the polar scripts to `REF_forces` (and adds the charge/spin keys), matching `mace-omol.sh`. Verified empirically both ways.

## Tests

Two regression tests in `tests/test_lmdb_database.py`, each writing a one-molecule `.aselmdb` with `data={"charge": -1, "spin": 3}` (the OMol layout) and asserting a key spec built from `--total_charge_key=charge --total_spin_key=spin` yields `total_charge == -1`, `total_spin == 3`:

- `test_lmdb_dataset_honors_key_specification` — constructs `LMDBDataset(..., key_specification=...)` directly (also checks the no-spec default still gives `0 / 1`). Guards the `lmdb_dataset.py` half.
- `test_load_dataset_for_path_forwards_key_specification` — calls `load_dataset_for_path` with a minimal `SimpleNamespace(head_name=..., key_specification=...)`. Guards the `run_train_utils.py` dispatch half.

Both fail on the corresponding pre-fix code.

## Reproduction

Self-contained (synthesizes a one-molecule `.aselmdb`, no external data):

```python
import tempfile, os
from ase.build import molecule
from mace.tools import AtomicNumberTable
from mace.data.utils import KeySpecification, update_keyspec_from_kwargs
from mace.data.lmdb_dataset import LMDBDataset
from mace.tools.fairchem_dataset.lmdb_dataset_tools import LMDBDatabase

CHARGE, SPIN = -1, 3
tmp = tempfile.mkdtemp()
path = os.path.join(tmp, "sample.aselmdb")
with LMDBDatabase(path, readonly=False) as db:
    db.write(molecule("H2O"), data={"charge": CHARGE, "spin": SPIN})

key_spec = KeySpecification.from_defaults()
update_keyspec_from_kwargs(key_spec, {"total_charge_key": "charge", "total_spin_key": "spin"})

ds = LMDBDataset(path, r_max=5.0, z_table=AtomicNumberTable([1, 8]), key_specification=key_spec)
sample = ds[0]
print("total_charge =", float(sample.total_charge), " (expected", CHARGE, ")")
print("total_spin   =", float(sample.total_spin),   " (expected", SPIN, ")")
```

**Before:** `total_charge = 0.0`, `total_spin = 1.0` — **After:** `total_charge = -1.0`, `total_spin = 3.0`.
