### PR TITLE
Make U matrices non-persistent (optional) to shrink state_dict (closes #124)

### DIFF
--- a/mace/modules/symmetric_contraction.py
+++ b/mace/modules/symmetric_contraction.py
@@ -35,6 +35,7 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
         internal_weights: Optional[bool] = None,
         shared_weights: Optional[bool] = None,
         num_elements: Optional[int] = None,
+        persistent_U_matrices: bool = True,
     ) -> None:
         super().__init__()
 
@@ -79,6 +80,7 @@ class SymmetricContraction(CodeGenMixin, torch.nn.Module):
                     num_elements=num_elements,
                     weights=self.shared_weights,
                     use_reduced_cg=use_reduced_cg,
+                    persistent_U_matrices=persistent_U_matrices,
                 )
             )
 
@@ -98,12 +100,14 @@ class Contraction(torch.nn.Module):
         use_reduced_cg: bool = False,
         num_elements: Optional[int] = None,
         weights: Optional[torch.Tensor] = None,
+        persistent_U_matrices: bool = True,
     ) -> None:
         super().__init__()
 
         self.num_features = irreps_in.count((0, 1))
         self.coupling_irreps = o3.Irreps([irrep.ir for irrep in irreps_in])
         self.correlation = correlation
+        self._persistent_U_matrices = bool(persistent_U_matrices)
         dtype = torch.get_default_dtype()
 
         path_weight = []
@@ -116,7 +120,9 @@ class Contraction(torch.nn.Module):
                 dtype=dtype,
             )[-1]
             path_weight.append(not torch.equal(U_matrix, torch.zeros_like(U_matrix)))
-            self.register_buffer(f"U_matrix_{nu}", U_matrix)
+            self.register_buffer(
+                f"U_matrix_{nu}", U_matrix, persistent=self._persistent_U_matrices
+            )
 
         # Tensor contraction equations
         self.contractions_weighting = torch.nn.ModuleList()
@@ -259,6 +265,49 @@ class Contraction(torch.nn.Module):
 
     def U_tensors(self, nu: int):
         return dict(self.named_buffers())[f"U_matrix_{nu}"]
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        # `U_matrix_{nu}` buffers are computed deterministically in __init__
+        # from irreps_in / irrep_out / correlation, so state_dict entries for
+        # them are redundant. Accept checkpoints saved under either
+        # `persistent_U_matrices` setting: silently drop any incoming
+        # `U_matrix_*` values (buffers already hold the correct tensors)
+        # before delegating to the default loader.
+        for key in list(state_dict.keys()):
+            if key.startswith(prefix):
+                local_name = key[len(prefix) :]
+                if local_name.startswith("U_matrix_"):
+                    state_dict.pop(key)
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+        # If our buffers are persistent (default), the parent loader will have
+        # populated `missing_keys` with any `U_matrix_*` entries we already
+        # dropped above; strip them so strict-mode loading of a
+        # persistent=False checkpoint doesn't raise.
+        pruned = []
+        for key in missing_keys:
+            if key.startswith(prefix):
+                local_name = key[len(prefix) :]
+                if local_name.startswith("U_matrix_"):
+                    continue
+            pruned.append(key)
+        missing_keys[:] = pruned
 
 
 class EmptyParam(torch.nn.Parameter):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -186,6 +186,72 @@ def test_symmetric_contraction():
     assert operation.contractions[0].weights_max.shape == (2, 11, 16)
 
 
+def _build_symmetric_contraction(persistent_U_matrices):
+    return SymmetricContraction(
+        irreps_in=o3.Irreps("16x0e + 16x1o + 16x2e"),
+        irreps_out=o3.Irreps("16x0e + 16x1o"),
+        correlation=3,
+        num_elements=2,
+        persistent_U_matrices=persistent_U_matrices,
+    )
+
+
+def test_symmetric_contraction_persistent_u_matrices_default_true():
+    op = _build_symmetric_contraction(persistent_U_matrices=True)
+    state_dict = op.state_dict()
+    u_keys = [k for k in state_dict if "U_matrix_" in k]
+    assert len(u_keys) > 0, "default (persistent=True) should include U_matrix_* keys"
+
+
+def test_symmetric_contraction_persistent_u_matrices_false_omits_from_state_dict():
+    op = _build_symmetric_contraction(persistent_U_matrices=False)
+    state_dict = op.state_dict()
+    u_keys = [k for k in state_dict if "U_matrix_" in k]
+    assert u_keys == [], (
+        "persistent_U_matrices=False should omit U_matrix_* from state_dict; "
+        f"found: {u_keys}"
+    )
+    # buffers still present on the live module (recomputed in __init__)
+    for contraction in op.contractions:
+        for nu in range(1, contraction.correlation + 1):
+            assert hasattr(contraction, f"U_matrix_{nu}")
+
+
+def test_symmetric_contraction_cross_persistence_strict_load():
+    # Save under one persistence setting, load into a module built with the
+    # other setting; strict-mode load must succeed and forward must be
+    # equivalent to a fresh module with the same weights.
+    torch.manual_seed(7)
+    features = torch.randn(12, 16, 9)
+    one_hots = torch.nn.functional.one_hot(torch.arange(0, 12) % 2).to(
+        torch.get_default_dtype()
+    )
+
+    persistent = _build_symmetric_contraction(persistent_U_matrices=True)
+    non_persistent = _build_symmetric_contraction(persistent_U_matrices=False)
+
+    # Cross-load: persistent-saved checkpoint into a non_persistent instance.
+    missing, unexpected = non_persistent.load_state_dict(
+        persistent.state_dict(), strict=True
+    )
+    assert missing == [] and unexpected == []
+    torch.testing.assert_close(
+        non_persistent(features, one_hots), persistent(features, one_hots)
+    )
+
+    # And the reverse: non_persistent-saved checkpoint into a persistent
+    # instance (state_dict lacks U_matrix_* keys; hook must drop them from
+    # missing_keys).
+    persistent2 = _build_symmetric_contraction(persistent_U_matrices=True)
+    missing, unexpected = persistent2.load_state_dict(
+        non_persistent.state_dict(), strict=True
+    )
+    assert missing == [] and unexpected == []
+    torch.testing.assert_close(
+        persistent2(features, one_hots), non_persistent(features, one_hots)
+    )
+
+
 def test_bessel_basis():
     d = torch.linspace(start=0.5, end=5.5, steps=10)
     bessel_basis = BesselBasis(r_max=6.0, num_basis=5)


### PR DESCRIPTION
Closes #124.

## Summary

\`Contraction\` registers \`U_matrix_{nu}\` buffers whose values are computed deterministically in \`__init__\` from \`irreps_in\` / \`irrep_out\` / \`correlation\`, but they are persistent by default so they land in the state_dict. For higher L / correlation, those U tensors dominate the checkpoint size (see the reproducer in #124: 400 MB U matrices vs 5 MB parameters at max angular momentum 4, correlation 3; 680 MB → 26 MB overall in the reporter's case).

## What this PR does

- Add a \`persistent_U_matrices: bool = True\` argument on both \`SymmetricContraction\` and \`Contraction\`. **Default stays \`True\` for backward compatibility** — existing checkpoints continue to load unchanged. Users opt into the smaller checkpoint by constructing with \`persistent_U_matrices=False\`.
- Override \`Contraction._load_from_state_dict\` so a checkpoint saved under either persistence setting can be loaded strictly into a module built with the other setting: \`U_matrix_*\` entries in the incoming state_dict are silently discarded (the buffers are already correct after \`__init__\`), and missing \`U_matrix_*\` keys are pruned from \`missing_keys\` before strict validation.

Follows the plan discussed in the issue ([this comment](https://github.com/ACEsuit/mace/issues/124#issuecomment-1633991017): keep default \`True\`, expose it as an argument).

## Tests

Three new tests in \`tests/test_modules.py\`:

- \`test_symmetric_contraction_persistent_u_matrices_default_true\` — default keeps \`U_matrix_*\` in the state_dict.
- \`test_symmetric_contraction_persistent_u_matrices_false_omits_from_state_dict\` — opt-in setting removes them (~99% checkpoint-size reduction for typical high-L configs).
- \`test_symmetric_contraction_cross_persistence_strict_load\` — round-trips a checkpoint between the two settings with \`strict=True\` in both directions, and verifies the forward output matches.

All 11 tests in \`test_modules.py\` pass locally.

## Backward compatibility

- Default behavior unchanged (all existing checkpoints keep loading).
- Cross-loading between the two settings works with \`strict=True\` in both directions (see the round-trip test).
- TorchScript: the change only affects \`register_buffer(persistent=...)\` and adds a plain-Python \`_load_from_state_dict\` override; TorchScript exports of the module are not affected (\`@compile_mode("script")\` is preserved).

## Test plan

- [x] \`pytest tests/test_modules.py\` — 11 / 11 pass
- [ ] confirm CI green on ACEsuit/mace