### PR TITLE
Drop Python 3.9, make 3.12 the CI default

### DIFF
--- a/.github/actions/setup-mace/action.yml
+++ b/.github/actions/setup-mace/action.yml
@@ -7,7 +7,7 @@ inputs:
   python-version:
     description: Python version to set up
     required: false
-    default: "3.10"
+    default: "3.12"
   extras:
     description: 'Comma-separated pip extras to install, e.g. "dev, cueq"'
     required: false

--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-mace
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           extras: dev
           # The pylint hook is `language: system`: packages the linted code
           # imports must be importable in this environment.
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-mace
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.9","3.13"]') || fromJSON('["3.9","3.10","3.11","3.12","3.13"]') }}
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.10","3.13"]') || fromJSON('["3.10","3.11","3.12","3.13"]') }}
         split-group: [ 1, 2 ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         split-group: [ 1, 2 ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Build distribution
         run: |
           python -m pip install --upgrade pip build twine
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         # Frontier of the supported range.
-        python-version: [ '3.9', '3.13' ]
+        python-version: [ '3.10', '3.13' ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # Platform configuration
-python_version = 3.8
+python_version = 3.10
 
 # Untyped definitions and calls
 check_untyped_defs = True

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A partial documentation is available at: https://mace-docs.readthedocs.io
 
 ### 1. Requirements
 
-- Python >= 3.9
+- Python >= 3.10
 - [PyTorch](https://pytorch.org/) >= 1.12 **(training with float64 is not supported with PyTorch 2.1 but is supported with 2.2 and later, Pytorch 2.4.1 is not supported)**
 
 **Make sure to install PyTorch.** Please refer to the [official PyTorch installation](https://pytorch.org/get-started/locally/) for the installation instructions. Select the appropriate options for your system.

--- a/mace/cli/polar_density_cube.py
+++ b/mace/cli/polar_density_cube.py
@@ -2,8 +2,6 @@
 # Script for exporting MACE-Polar density coefficients to Gaussian cube files
 # This program is distributed under the MIT License (see MIT.md)
 # pylint: disable=wrong-import-position
-from __future__ import annotations
-
 import argparse
 import json
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ disable = [
 ]
 
 [tool.pylint.MASTER]
+# Lint against the supported floor, not the interpreter the lint job happens to
+# run on (that job tracks the default, currently 3.12).
+py-version = "3.10"
 ignore-paths = [
     "^mace/tools/torch_geometric/.*$",
     "^mace/tools/scatter.py$",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,20 @@
-target-version = "py38"
+# Intentionally BELOW the supported floor (python_requires = >=3.10), so that
+# FA102 keeps flagging PEP 604 (`X | Y`) annotations. At py310 it degrades to a
+# no-op, since both PEP 585 and PEP 604 are natively valid there.
+#
+# The constraint is torch, not Python: TorchScript rejects `X | Y` in a type
+# expression on torch < 2.2 ("Expression of type | cannot be used in a type
+# expression"), and `from __future__ import annotations` does NOT rescue it.
+# setup.cfg declares torch>=1.12, and mace/modules is scripted wholesale
+# (@compile_mode, jit.compile on the LAMMPS export and checkpoint-save paths),
+# so `X | Y` there would break users on torch 1.12-2.1.
+#
+# PEP 585 (`list[T]`, `dict[K, V]`) is safe: TorchScript accepts it as far back
+# as torch 1.13.
+#
+# NOTE: nothing currently RUNS ruff — it is absent from .pre-commit-config.yaml
+# and from every CI job, so this file documents intent more than it enforces it.
+target-version = "py39"
 
 [lint]
 select = ["FA102"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,20 +1,25 @@
-# Intentionally BELOW the supported floor (python_requires = >=3.10), so that
-# FA102 keeps flagging PEP 604 (`X | Y`) annotations. At py310 it degrades to a
-# no-op, since both PEP 585 and PEP 604 are natively valid there.
+# The declared floor (setup.cfg: python_requires >= 3.10). PEP 585 (`list[T]`)
+# and PEP 604 (`X | Y`) are both natively valid here, so FA102 is a no-op over
+# most of the tree — which is correct: those annotations are fine at runtime.
+target-version = "py310"
+
+# ...except in the code TorchScript parses. TorchScript rejects `X | Y` in a
+# type expression on torch < 2.2 ("Expression of type | cannot be used in a
+# type expression"), and `from __future__ import annotations` does NOT rescue
+# it. setup.cfg declares torch>=1.12, so `X | Y` in a scripted module would
+# break users on torch 1.12-2.1. Pinning these files to py39 keeps FA102 firing
+# on them as an early warning. PEP 585 is safe as far back as torch 1.13, so
+# only the union syntax is at issue.
 #
-# The constraint is torch, not Python: TorchScript rejects `X | Y` in a type
-# expression on torch < 2.2 ("Expression of type | cannot be used in a type
-# expression"), and `from __future__ import annotations` does NOT rescue it.
-# setup.cfg declares torch>=1.12, and mace/modules is scripted wholesale
-# (@compile_mode, jit.compile on the LAMMPS export and checkpoint-save paths),
-# so `X | Y` there would break users on torch 1.12-2.1.
-#
-# PEP 585 (`list[T]`, `dict[K, V]`) is safe: TorchScript accepts it as far back
-# as torch 1.13.
-#
-# NOTE: nothing currently RUNS ruff — it is absent from .pre-commit-config.yaml
-# and from every CI job, so this file documents intent more than it enforces it.
-target-version = "py39"
+# This is every file carrying @compile_mode("script"). Keep it in sync with
+#   git grep -l '@compile_mode' mace/
+[per-file-target-version]
+"mace/modules/**" = "py39"
+"mace/calculators/lammps_mace.py" = "py39"
+"mace/calculators/lammps_mliap_mace.py" = "py39"
 
 [lint]
 select = ["FA102"]
+
+# NOTE: nothing currently RUNS ruff — it is absent from .pre-commit-config.yaml
+# and from every CI job, so this file documents intent more than it enforces it.

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ dev =
     pytest-split
     pytest-timeout
     pytest-xdist
-    pylint
+    pylint==4.0.6
 schedulefree = schedulefree
 torchsim =
     torch-sim-atomistic; python_version >= "3.12"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ long_description_content_type = text/markdown
 url = https://github.com/ACEsuit/mace
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -17,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     torch>=1.12
     e3nn==0.4.4


### PR DESCRIPTION
Python 3.9 reached EOL in October 2025. The concrete cost in this repo was not the EOL date, though: **torch stopped publishing `cp39` wheels after 2.8.0**, so the `unit (py3.9)` job silently resolved to torch <=2.8 while every other job ran 2.9+. That matrix leg was validating a different stack than the one we ship.

### What changes

- `python_requires >= 3.10`; drop the 3.9 classifier and the README floor.
- `unit` / `workflows` / `workflows-full` matrices: **3.10–3.13**.
- PR and release frontiers move to **3.10 + 3.13**.
- `setup-mace`'s default, the `lint` job and the `release` build move to **3.12**.

The per-job pins that spread across 3.10/3.11/3.12 (polar/les, backends-cpu, lammps-contract) are left alone **on purpose**: collapsing them onto 3.12 would shrink the set of Python versions CI exercises outside the matrices.

### Tooling alignment

- **pylint**: `py-version = "3.10"` pinned to the floor, so lint tracks what we support rather than whichever interpreter the job happens to run on. This also neutralises the lint-job bump — verified the message set is identical at `py-version` 3.10 and 3.12.
- **mypy**: `python_version` 3.8 → 3.10. It was stale under the old floor too.
- **ruff**: `target-version` 3.8 → py310, with `per-file-target-version = py39` on the `@compile_mode("script")` surface (`mace/modules/**` plus the two LAMMPS calculators). FA102 is the only enabled rule and it degrades to a no-op at py310; keeping py39 on the scripted files preserves the `X | Y` warning where it matters. The constraint there is **torch, not Python**: TorchScript rejects `X | Y` in a type expression on torch < 2.2, and `from __future__ import annotations` does *not* rescue it. PEP 585 (`list[T]`) is safe back to 1.13.

### One 3.9 workaround reverted

`f358b99` added `from __future__ import annotations` to `mace/cli/polar_density_cube.py` because its PEP-604/585 annotations crashed the entry point at import time on 3.9. That workaround is now dead and is removed.

`mace/cli/plot_train.py` **keeps** its future import: that one is not a 3.9 workaround. matplotlib/pandas are import-guarded and `pd` is `None` when absent, so `data: pd.DataFrame` would be evaluated at def time and raise `AttributeError` — exactly the clean-install crash the guard exists to prevent.

### Verification

- `pip install` is refused on 3.9 (`does not satisfy Python>=3.10`) and succeeds on 3.10.
- All 12 console-script modules import on 3.10 and 3.12.
- ruff: tree clean; positive control (planting `int | None` in `modules/blocks.py`
  still trips FA102) and negative control (the same line under `mace/cli` does not).
- pylint message set unchanged between `py-version` 3.10 and 3.12.

### Known, not addressed here

The README line this PR touches still reads `PyTorch >= 1.12` alongside the new `Python >= 3.10`. That torch floor is **wrong** — `mace/modules/utils.py` calls `torch.compiler.is_compiling()` (torch >= 2.3) on the core forward path, and the test suite needs `torch.serialization.add_safe_globals` (torch >= 2.4). The measured floor is **2.4.0**. It survived unnoticed because **no CI job pins torch**. Left for a follow-up so this PR stays a clean, revertible Python-version change.