### PR TITLE
Break the mace.data import cycle

### DIFF
--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -4,8 +4,10 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+from __future__ import annotations
+
 from copy import deepcopy
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence
 
 import torch.utils.data
 
@@ -18,7 +20,9 @@ from mace.tools import (
 )
 
 from .neighborhood import get_neighborhood
-from .utils import Configuration
+
+if TYPE_CHECKING:
+    from .utils import Configuration
 
 
 class AtomicData(torch_geometric.data.Data):

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -456,7 +456,7 @@ def estimate_e0s_from_foundation(
         for i, config in enumerate(valid_configs):
             # Convert to AtomicData for model prediction
             # Import here to avoid circular dependency
-            from mace.data import AtomicData
+            from mace.data.atomic_data import AtomicData
             from mace.tools import torch_geometric
 
             atomic_data = AtomicData.from_config(


### PR DESCRIPTION
Fixes the `lint` failure on #1244 , which is red on a message that has nothing to do with that PR's code:

mace/calculators/lammps_mliap_mace.py:1:0: R0401: Cyclic import (mace.data -> mace.data.utils) (cyclic-import)

### The cycle

`mace.data` → `mace.data.atomic_data` → `mace.data.utils` → back into `mace.data`.

- `atomic_data.py` imports `Configuration` under `TYPE_CHECKING` only, with `from __future__ import annotations` so the `config: Configuration` annotation stays lazy. **That future import is load-bearing** — removing it raises `NameError: name 'Configuration' is not defined` at import time. It is not a leftover compatibility shim; please don't "clean it up".
- `utils.py` imports the leaf module (`from mace.data.atomic_data import AtomicData`) instead of the package, so its local-import workaround no longer reaches back through `mace/data/__init__.py`.

No behaviour change: same classes, same call sites.

### Why this only surfaced now

The cycle is old. The pre-commit pylint hook is `language: system`, so its `rev: pylint-2.5.2` is decorative and CI lints with whatever pylint the `dev` extra installs — today, pylint 4.0.6, which reports `cyclic-import` where older versions did not. Pinning pylint so a release cannot redden PRs is handled separately, in #1520, where the floor is raised to 3.10 (pylint 4 requires `>=3.10.0`, so the pin is not satisfiable on the current 3.9 floor).

### Heads-up for reviewers reproducing locally

`pre-commit` shards the file list across `os.cpu_count()` concurrent pylint invocations, and `R0401` is only emitted when the cycle's modules land in the same invocation. On a many-core machine `pre-commit run pylint --all-files` **passes on the broken tree**. To reproduce the CI `lint` job faithfully:

```sh
PRE_COMMIT_NO_CONCURRENCY=1 pre-commit run --all-files
```

Verification

- On #1244's head with only this commit cherry-picked, the serialized pre-commit run --all-files passes all five hooks, exit=0, pylint 10.00/10, 0 messages. Python 3.9 support untouched.
- Control: the same tree without this commit reports 4 R0401 serialized.
- On this branch: serialized lint green, tests/unit -m "not slow" 240 passed, 21 skipped.