### PR TITLE
Fix stress normalization for partially periodic systems (#1509)

### DIFF
--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -20,25 +20,27 @@ def get_neighborhood(
     assert len(pbc) == 3 and all(isinstance(i, (bool, np.bool_)) for i in pbc)
     assert cell.shape == (3, 3)
 
-    pbc_x = pbc[0]
-    pbc_y = pbc[1]
-    pbc_z = pbc[2]
     identity = np.identity(3, dtype=float)
     max_positions = np.max(np.absolute(positions)) + 1
-    # Extend cell in non-periodic directions
-    # For models with more than 5 layers, the multiplicative constant needs to be increased.
-    # temp_cell = np.copy(cell)
-    if not pbc_x:
-        cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
-    if not pbc_y:
-        cell[1, :] = max_positions * 5 * cutoff * identity[1, :]
-    if not pbc_z:
-        cell[2, :] = max_positions * 5 * cutoff * identity[2, :]
+    # blow up the cell in non-periodic directions so matscipy can bin the atoms
+    # (constant may need bumping for models with more than 5 layers)
+    extended_cell = np.array(cell, dtype=float, copy=True)
+    for dim in range(3):
+        if not pbc[dim]:
+            extended_cell[dim, :] = max_positions * 5 * cutoff * identity[dim, :]
+
+    # only use the blown-up cell for the neighbour search, don't return it:
+    # stress divides by det(cell) later, so the fake volume shrinks it (#1509).
+    # keep it for fully aperiodic systems though (no stress there anyway)
+    if any(pbc):
+        cell = np.array(cell, dtype=float, copy=True)
+    else:
+        cell = extended_cell
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",
         pbc=pbc,
-        cell=cell,
+        cell=extended_cell,
         positions=positions,
         cutoff=cutoff,
         # self_interaction=True,  # we want edges from atom to itself in different periodic images

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -206,9 +206,11 @@ def test_half_periodic():
     atoms = ase.build.fcc111("Al", size=(3, 3, 1), vacuum=0.0)
     assert all(atoms.pbc == (True, True, False))
     config = config_from_atoms(atoms)  # first shell dist is 2.864A
-    edge_index, shifts, _, _ = get_neighborhood(
+    edge_index, shifts, _, cell = get_neighborhood(
         config.positions, cutoff=2.9, pbc=(True, True, False), cell=config.cell
     )
+    # should give back the real cell, not the blown-up one (#1509)
+    assert np.allclose(cell, config.cell)
     sender, receiver = edge_index
     vectors = (
         config.positions[receiver] - config.positions[sender] + shifts

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -450,3 +450,76 @@ def test_atomic_virials_stresses():
     assert torch.allclose(
         summed_atomic_stresses, total_stress.squeeze(0), atol=1e-6
     ), f"Sum of atomic stresses (normalized by volume) {summed_atomic_stresses} does not match total stress {total_stress.squeeze(0)}"
+
+
+def test_stress_partial_pbc():
+    """
+    Analytic stress must equal the finite-difference strain derivative of the
+    energy for partially periodic (slab) systems (regression test for #1509).
+    """
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(7)
+
+    slab_z_table = tools.AtomicNumberTable([14])
+    model = modules.MACE(
+        r_max=5.0,
+        num_bessel=8,
+        num_polynomial_cutoff=6,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=1,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o"),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([0.0]),
+        avg_num_neighbors=8,
+        atomic_numbers=slab_z_table.zs,
+        correlation=3,
+        radial_type="bessel",
+    )
+
+    def compute(atoms):
+        atomic_data = data.AtomicData.from_config(
+            data.config_from_atoms(atoms), z_table=slab_z_table, cutoff=5.0
+        )
+        loader = torch_geometric.dataloader.DataLoader(
+            dataset=[atomic_data], batch_size=1, shuffle=False, drop_last=False
+        )
+        batch = next(iter(loader)).to_dict()
+        output = model(batch, training=False, compute_stress=True)
+        return output["energy"].item(), output["stress"].detach().numpy()[0]
+
+    # Si slab: periodic in x/y, vacuum along z
+    slab = build.bulk("Si", "diamond", a=5.43).repeat((2, 2, 2))
+    slab.set_pbc([True, True, False])
+    cell = slab.get_cell().array.copy()
+    cell[2] = [0.0, 0.0, slab.positions[:, 2].max() + 20.0]
+    slab.set_cell(cell, scale_atoms=False)
+    slab.positions[:, 2] += 10.0
+
+    cell0 = slab.get_cell().array.copy()
+    volume = abs(np.linalg.det(cell0))
+    eps, delta = 0.010, 0.001
+
+    def strained(strain_yy):
+        atoms = slab.copy()
+        strain = np.eye(3)
+        strain[1, 1] += strain_yy
+        atoms.set_cell(cell0 @ strain, scale_atoms=True)
+        return atoms
+
+    energy_plus, _ = compute(strained(eps + delta))
+    energy_minus, _ = compute(strained(eps - delta))
+    _, stress = compute(strained(eps))
+
+    finite_diff = (energy_plus - energy_minus) / (2 * delta) / volume
+    assert np.isclose(finite_diff, stress[1, 1], rtol=1e-4), (
+        f"sigma_yy finite difference {finite_diff} does not match "
+        f"analytic stress {stress[1, 1]}"
+    )


### PR DESCRIPTION
### Summary

Fixes #1509. The analytic stress returned for partially periodic (slab) systems was silently scaled down by a large factor (~18x in the reported case), while energies and forces were unaffected.

### Root cause

`get_neighborhood` extends the cell along non-periodic directions so that `matscipy` can bin the atoms:

```python
if not pbc_x:
    cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
```

This inflated cell was then **returned** from the function and stored in `AtomicData`. Stress is normalized by `det(cell)` in `compute_forces_virials`, so the artificial volume along the vacuum direction shrinks the stress by exactly the ratio of the inflated extent to the true extent. For the phosphorene example in the issue this ratio is `max_positions * 5 * cutoff / z_true ≈ 17.8`, matching the reported `17.81`. Energies and forces don't touch `det(cell)`, which is why only stress was affected and the bug went unnoticed.

### Fix

Use the extended cell only for the neighbour-list call, and return the physical cell whenever at least one direction is periodic. `unit_shifts` are zero along non-periodic directions, so the shifts (and therefore the energy/forces) are identical. Fully non-periodic systems keep the extended cell, since stress is meaningless there and long-range models rely on a non-degenerate cell — so their behaviour is unchanged.

### Verification

Finite-difference check (analytic stress vs. strain derivative of the energy), model-independent:

| system | before | after |
|---|---|---|
| bulk Si (pbc TTT, control) | ratio 1.0000 | ratio 1.0000 |
| Si slab (pbc TTF) | ratio ~16.6 | ratio 1.0000 |

Added a regression test (`test_stress_partial_pbc`) that fails on the current code and passes with the fix, plus an assertion in `test_half_periodic` that the physical cell is returned. Full existing test suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core neighbourhood/cell plumbing used by all models; behaviour change is scoped to partial PBC (fully periodic and fully aperiodic paths are preserved) but stress and any volume-derived quantities now differ for slabs.
> 
> **Overview**
> Fixes **incorrect analytic stress** for slabs and other partially periodic systems, where stress was scaled down by the ratio of the artificially inflated vacuum cell to the true cell.
> 
> **`get_neighborhood`** still builds an **extended cell** along non-periodic axes for `matscipy` neighbour binning, but passes that cell only into `neighbour_list`. When **any** direction is periodic, it now **returns a copy of the physical cell** (not the blown-up one) so downstream stress normalization via `det(cell)` uses the real volume. Fully aperiodic systems still return the extended cell, unchanged.
> 
> Tests add a **physical-cell assertion** in `test_half_periodic` and a **`test_stress_partial_pbc`** regression that compares finite-difference strain energy to analytic `sigma_yy` on a Si TTF slab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c210e76134fc74faf8f9a6d61577b1259556fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->