### PR TITLE
Fix non-periodic cell in get_neighborhood: extent-based padding + physical cell on partial PBC

### DIFF
--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -88,4 +88,3 @@ def get_neighborhood(
     shifts = np.dot(unit_shifts, cell)  # [n_edges, 3]
 
     return edge_index, shifts, unit_shifts, cell
-

--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -24,16 +24,23 @@ def get_neighborhood(
     pbc_y = pbc[1]
     pbc_z = pbc[2]
     identity = np.identity(3, dtype=float)
-    max_positions = np.max(np.absolute(positions)) + 1
-    # Extend cell in non-periodic directions
-    # For models with more than 5 layers, the multiplicative constant needs to be increased.
-    # temp_cell = np.copy(cell)
+    # Extend cell in non-periodic directions using the actual extent of
+    # the atoms plus cutoff padding.  The previous formula used
+    # ``max(abs(positions)) * 5 * cutoff`` which (a) depended on the
+    # absolute coordinate origin rather than the molecular extent, and
+    # (b) created unnecessarily large cells that caused PolarMACE's
+    # k-space electrostatics to OOM on GPUs.  The extent-based cell
+    # gives identical neighbour lists and identical PolarMACE energies /
+    # forces (verified to float32 precision).
     if not pbc_x:
-        cell[0, :] = max_positions * 5 * cutoff * identity[0, :]
+        extent_x = positions[:, 0].max() - positions[:, 0].min()
+        cell[0, :] = (extent_x + 2 * cutoff + 1) * identity[0, :]
     if not pbc_y:
-        cell[1, :] = max_positions * 5 * cutoff * identity[1, :]
+        extent_y = positions[:, 1].max() - positions[:, 1].min()
+        cell[1, :] = (extent_y + 2 * cutoff + 1) * identity[1, :]
     if not pbc_z:
-        cell[2, :] = max_positions * 5 * cutoff * identity[2, :]
+        extent_z = positions[:, 2].max() - positions[:, 2].min()
+        cell[2, :] = (extent_z + 2 * cutoff + 1) * identity[2, :]
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",
@@ -64,3 +71,4 @@ def get_neighborhood(
     shifts = np.dot(unit_shifts, cell)  # [n_edges, 3]
 
     return edge_index, shifts, unit_shifts, cell
+

--- a/mace/data/neighborhood.py
+++ b/mace/data/neighborhood.py
@@ -20,32 +20,49 @@ def get_neighborhood(
     assert len(pbc) == 3 and all(isinstance(i, (bool, np.bool_)) for i in pbc)
     assert cell.shape == (3, 3)
 
-    pbc_x = pbc[0]
-    pbc_y = pbc[1]
-    pbc_z = pbc[2]
     identity = np.identity(3, dtype=float)
-    # Extend cell in non-periodic directions using the actual extent of
-    # the atoms plus cutoff padding.  The previous formula used
-    # ``max(abs(positions)) * 5 * cutoff`` which (a) depended on the
-    # absolute coordinate origin rather than the molecular extent, and
-    # (b) created unnecessarily large cells that caused PolarMACE's
-    # k-space electrostatics to OOM on GPUs.  The extent-based cell
-    # gives identical neighbour lists and identical PolarMACE energies /
-    # forces (verified to float32 precision).
-    if not pbc_x:
-        extent_x = positions[:, 0].max() - positions[:, 0].min()
-        cell[0, :] = (extent_x + 2 * cutoff + 1) * identity[0, :]
-    if not pbc_y:
-        extent_y = positions[:, 1].max() - positions[:, 1].min()
-        cell[1, :] = (extent_y + 2 * cutoff + 1) * identity[1, :]
-    if not pbc_z:
-        extent_z = positions[:, 2].max() - positions[:, 2].min()
-        cell[2, :] = (extent_z + 2 * cutoff + 1) * identity[2, :]
+
+    # matscipy cannot bin atoms along a non-periodic axis, so we blow up the
+    # cell there just for the neighbour search. Size it from the actual atom
+    # extent (+ cutoff padding) rather than from max(abs(positions)): the old
+    # `max(abs(positions)) * 5 * cutoff` depended on the absolute coordinate
+    # origin and produced huge cells, which blow up PolarMACE's k-space
+    # electrostatics into GPU OOM. Extent-based padding gives identical
+    # neighbour lists at a fraction of the volume.
+    extended_cell = np.array(cell, dtype=float, copy=True)
+    for dim in range(3):
+        if not pbc[dim]:
+            extent = positions[:, dim].max() - positions[:, dim].min()
+            extended_cell[dim, :] = (extent + 2 * cutoff + 1) * identity[dim, :]
+
+    # The neighbour search uses the blown-up cell, but we must not *return* it
+    # when any axis is periodic: stress later normalizes by det(cell), so a
+    # fake volume along the vacuum axis silently rescales the stress of slabs
+    # and other partially periodic systems. Return the physical cell there.
+    # Fully aperiodic systems keep the extended cell (stress is meaningless
+    # and long-range models need a non-degenerate cell).
+    #
+    # NOTE: electrostatic models (e.g. PolarMACE) also read this cell as their
+    # k-space box and, crucially, its det() as the volume their slab / molecule
+    # dipole corrections divide by. Returning the physical cell is what gives
+    # those corrections the right volume; the inflated cell would silently scale
+    # them away. (Adequate vacuum is still the caller's job, as in any 3D-Ewald
+    # slab calculation.)
+    if any(pbc):
+        cell = np.array(cell, dtype=float, copy=True)
+        # A non-periodic axis whose physical row is all zeros (e.g. a slab built
+        # with zero vacuum) would leave det(cell)=0, which NaNs the stress
+        # (division by volume) and blows up rcell. Keep the extended row there.
+        for dim in range(3):
+            if not pbc[dim] and not cell[dim].any():
+                cell[dim] = extended_cell[dim]
+    else:
+        cell = extended_cell
 
     sender, receiver, unit_shifts = neighbour_list(
         quantities="ijS",
         pbc=pbc,
-        cell=cell,
+        cell=extended_cell,
         positions=positions,
         cutoff=cutoff,
         # self_interaction=True,  # we want edges from atom to itself in different periodic images

--- a/tests/extensions/polar/test_polar_cueq.py
+++ b/tests/extensions/polar/test_polar_cueq.py
@@ -152,7 +152,11 @@ def test_polar_true_cueq_matches_e3nn(model_name, _):
 
     assert energy_max_abs <= 3.0e-4
     assert forces_max_abs <= 2.5e-4
-    assert stress_max_abs <= 1.0e-8
+    # stress = virial / det(cell); the non-periodic cell is now sized from the
+    # atom extent instead of max(|pos|)*5*cutoff, so its volume is ~2 orders
+    # smaller and stress magnitudes (and thus the e3nn/cueq abs difference)
+    # scale up proportionally. Parity is unchanged; the absolute bound isn't.
+    assert stress_max_abs <= 1.0e-6
 
 
 @pytest.mark.cueq
@@ -193,7 +197,9 @@ def test_polar_2l_true_cueq_matches_e3nn_float64():
 
     assert energy_max_abs <= 1.0e-7
     assert forces_max_abs <= 1.0e-7
-    assert stress_max_abs <= 1.0e-11
+    # see note above: the smaller (physical-extent) non-periodic cell scales
+    # stress magnitudes up, so the absolute e3nn/cueq bound is loosened here too.
+    assert stress_max_abs <= 1.0e-9
 
 
 try:

--- a/tests/extensions/polar/test_polar_models.py
+++ b/tests/extensions/polar/test_polar_models.py
@@ -536,24 +536,19 @@ def test_polar_slab_partial_pbc_cell_contract(dtype):
 @pytest.mark.parametrize("dtype", [torch.float64])
 def test_polar_slab_electrostatics_converge_with_vacuum(dtype):
     """
-    Physics check for the coupling flagged in review ("the vacuum affects the
-    electrostatic part").
+    Smoke check for the coupling flagged in review ("the vacuum affects the
+    electrostatic part"): the returned physical cell becomes the k-space box
+    (and its det() the volume), so the vacuum gap enters the electrostatics.
+    The short-range part is identical across vacuum sizes (same edges/shifts),
+    so any energy change is purely the electrostatic response to the cell, and
+    on a benign slab it must *converge* (not diverge) as the vacuum grows.
 
-    The returned physical cell becomes the k-space box (and its det() the
-    volume), so the vacuum gap enters the electrostatics. graph_longrange
-    already applies a Yeh-Berkowitz slab dipole correction for pbc=(T, T, F)
-    (on by default), which removes the leading vacuum-dependent term, so the
-    slab energy must *converge* as the vacuum grows -- successive differences
-    shrink. The short-range part is identical across vacuum sizes (same
-    edges/shifts), so any change is purely the electrostatic response to the
-    returned cell.
-
-    _polar_slab_atoms is dipole-free, which makes convergence robust without
-    even leaning on the correction; with the correction active a dipolar slab
-    should converge too.
-
-    NOTE: the tolerance below is a scale-free convergence criterion; confirm the
-    absolute energy scale once in an environment with graph_longrange installed.
+    SCOPE: this guards "finite and non-diverging", not the Yeh-Berkowitz slab
+    correction itself. _polar_slab_atoms is dipole-free, and a dipole-free slab
+    converges whether or not that correction is active (verified by toggling
+    include_pbc_corrections), so this test does NOT exercise it. Testing the
+    correction would need a dipolar slab, which is not stable on an untrained
+    model here.
     """
     device = torch.device("cpu")
     torch.manual_seed(0)

--- a/tests/extensions/polar/test_polar_models.py
+++ b/tests/extensions/polar/test_polar_models.py
@@ -445,6 +445,140 @@ def test_energy_invariance_under_rotation_and_translation(dtype):
 
 
 # ---------------------------------------------------------------------------
+# Partial-PBC (slab) regression: get_neighborhood cell fix vs electrostatics
+# ---------------------------------------------------------------------------
+
+
+def _polar_slab_atoms(vacuum: float) -> Atoms:
+    """
+    z-mirror-symmetric OH2 slab, periodic in x and y with vacuum along z
+    (pbc = (T, T, F)).
+
+    The two H are stacked at +/- z with identical xy, so the slab is invariant
+    under z -> -z and carries no net dipole perpendicular to the surface. That
+    matters for the electrostatics check below: a 3D-periodic k-space (Ewald)
+    sum applied to a slab converges quickly with the vacuum gap only when there
+    is no perpendicular dipole (otherwise it has a conditionally convergent
+    term that needs a slab / Yeh-Berkowitz correction).
+    """
+    a = 3.2
+    symbols = ["O", "H", "H"]
+    positions = [[0.0, 0.0, 0.0], [0.8, 0.8, 0.6], [0.8, 0.8, -0.6]]
+    cell = [[a, 0.0, 0.0], [0.0, a, 0.0], [0.0, 0.0, vacuum]]
+    return Atoms(symbols=symbols, positions=positions, cell=cell, pbc=(True, True, False))
+
+
+def _run_polar_slab(model, dtype, vacuum: float) -> dict:
+    """Build a slab config through get_neighborhood -> AtomicData and run PolarMACE."""
+    z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
+    config = data.config_from_atoms(_polar_slab_atoms(vacuum), head_name="Default")
+    atomic_data = data.AtomicData.from_config(
+        config, z_table=z_table, cutoff=float(model.r_max), heads=model.heads
+    )
+    loader = torch_geometric.dataloader.DataLoader(
+        dataset=[atomic_data], batch_size=1, shuffle=False, drop_last=False
+    )
+    batch = next(iter(loader)).to("cpu").to_dict()
+    for key, value in batch.items():
+        if torch.is_tensor(value) and value.dtype.is_floating_point:
+            batch[key] = value.to(dtype)
+    out = model(batch, training=False, compute_force=True, compute_stress=True)
+    return {
+        "energy": out["energy"].detach(),
+        "forces": out["forces"].detach(),
+        "stress": None if out.get("stress") is None else out["stress"].detach(),
+        "cell": batch["cell"].view(3, 3).detach().cpu().numpy(),
+        "volume": float(batch["volume"].reshape(-1)[0]),
+        "rcell": batch["rcell"].view(3, 3).detach().cpu().numpy(),
+        "edges": batch["edge_index"].detach().cpu().numpy(),
+    }
+
+
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_polar_slab_partial_pbc_cell_contract(dtype):
+    """
+    get_neighborhood must return the *physical* cell for a partially periodic
+    (slab) system, and that cell must feed AtomicData.volume / rcell (which drive
+    PolarMACE's k-space electrostatics). Deterministic contract for the combined
+    fix: extent-based padding for the neighbour search, physical cell returned
+    on partial PBC.
+    """
+    device = torch.device("cpu")
+    torch.manual_seed(0)
+    model = _build_minimal_model(device, dtype)
+
+    thin = _run_polar_slab(model, dtype, vacuum=18.0)
+    thick = _run_polar_slab(model, dtype, vacuum=42.0)
+
+    # physical cell returned, not the matscipy blow-up nor max(|pos|)*5*cutoff.
+    assert np.isclose(thin["cell"][2, 2], 18.0), thin["cell"]
+    assert np.isclose(thick["cell"][2, 2], 42.0), thick["cell"]
+    # the periodic x/y rows are the true lattice, identical across vacuum sizes.
+    assert np.allclose(thin["cell"][:2, :2], thick["cell"][:2, :2])
+    # volume / rcell derive from the physical cell -> they feed the k-space sum.
+    assert np.isclose(thin["volume"], np.linalg.det(thin["cell"]))
+    assert np.isclose(thick["volume"], np.linalg.det(thick["cell"]))
+    assert np.allclose(thin["rcell"], 2 * np.pi * np.linalg.inv(thin["cell"].T))
+
+    # short-range graph is invariant to the vacuum: the padding only ever lived
+    # in the internal extended cell used for neighbour binning, never in shifts.
+    assert thin["edges"].shape == thick["edges"].shape
+    assert np.array_equal(thin["edges"], thick["edges"])
+
+    # forward is finite on a partial-PBC electrostatic model (a path that the
+    # aperiodic-only and non-electrostatic fixes each left untested).
+    for res in (thin, thick):
+        assert torch.isfinite(res["energy"]).all()
+        assert torch.isfinite(res["forces"]).all()
+        assert res["stress"] is not None and torch.isfinite(res["stress"]).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_polar_slab_electrostatics_converge_with_vacuum(dtype):
+    """
+    Physics check for the coupling flagged in review ("the vacuum affects the
+    electrostatic part").
+
+    The returned physical cell becomes the k-space box (and its det() the
+    volume), so the vacuum gap enters the electrostatics. graph_longrange
+    already applies a Yeh-Berkowitz slab dipole correction for pbc=(T, T, F)
+    (on by default), which removes the leading vacuum-dependent term, so the
+    slab energy must *converge* as the vacuum grows -- successive differences
+    shrink. The short-range part is identical across vacuum sizes (same
+    edges/shifts), so any change is purely the electrostatic response to the
+    returned cell.
+
+    _polar_slab_atoms is dipole-free, which makes convergence robust without
+    even leaning on the correction; with the correction active a dipolar slab
+    should converge too.
+
+    NOTE: the tolerance below is a scale-free convergence criterion; confirm the
+    absolute energy scale once in an environment with graph_longrange installed.
+    """
+    device = torch.device("cpu")
+    torch.manual_seed(0)
+    model = _build_minimal_model(device, dtype)
+
+    energies = {
+        vac: _run_polar_slab(model, dtype, vacuum=vac)["energy"].item()
+        for vac in (30.0, 45.0, 60.0)
+    }
+    for vac, e in energies.items():
+        assert np.isfinite(e), (vac, e)
+
+    d1 = abs(energies[45.0] - energies[30.0])
+    d2 = abs(energies[60.0] - energies[45.0])
+    # Converging: the far-field increment is no larger than the near one. Guard
+    # the case where it is already converged at 30 A (both increments ~ noise).
+    tol = 1e-9 + 1e-6 * abs(energies[60.0])
+    assert d2 <= d1 + tol, (
+        "slab electrostatics is not converging with vacuum "
+        f"(d(30->45)={d1!r}, d(45->60)={d2!r}); with the Yeh-Berkowitz slab "
+        "correction active a dipole-free slab must converge"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Checkpoint evaluation
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -252,3 +252,81 @@ def test_nonperiodic_cell_is_extent_based():
     # and the cell tracks the extent + cutoff padding (not |positions|)
     extent = positions.max(axis=0) - positions.min(axis=0)
     assert np.allclose(np.diag(cell_near), extent + 2 * cutoff + 1)
+
+
+def _edge_multiset(idx_pairs, shift_vecs):
+    return sorted(
+        (
+            int(i),
+            int(j),
+            round(float(s[0]), 4),
+            round(float(s[1]), 4),
+            round(float(s[2]), 4),
+        )
+        for (i, j), s in zip(idx_pairs, shift_vecs)
+    )
+
+
+def _bruteforce_neighbours(positions, cell, pbc, cutoff):
+    # Reference neighbour list: enumerate periodic images along the periodic axes
+    # (none along non-periodic ones) and keep pairs within cutoff. The image range
+    # is grown until the edge set stops changing, so the reference is complete no
+    # matter how skewed the cell is (a fixed range could miss images for a very
+    # non-orthogonal cell).
+    prev, radius = None, 2
+    while True:
+        ranges = [range(-radius, radius + 1) if pbc[d] else range(1) for d in range(3)]
+        pairs, shift_vecs = [], []
+        for i in range(len(positions)):
+            for j in range(len(positions)):
+                for n0 in ranges[0]:
+                    for n1 in ranges[1]:
+                        for n2 in ranges[2]:
+                            if i == j and n0 == 0 and n1 == 0 and n2 == 0:
+                                continue
+                            shift = n0 * cell[0] + n1 * cell[1] + n2 * cell[2]
+                            if (
+                                np.linalg.norm(positions[j] + shift - positions[i])
+                                < cutoff
+                            ):
+                                pairs.append((i, j))
+                                shift_vecs.append(shift)
+        edges = _edge_multiset(pairs, shift_vecs)
+        if edges == prev:
+            return edges
+        prev, radius = edges, radius + 1
+
+
+_NONORTHO_CELLS = {
+    # in-plane periodic vectors are non-orthogonal; vacuum along the 3rd axis
+    "hexagonal": np.array([[3.0, 0.0, 0.0], [1.5, 2.598, 0.0], [0.0, 0.0, 0.0]]),
+    "monoclinic": np.array([[3.2, 0.0, 0.0], [0.8, 2.9, 0.0], [0.0, 0.0, 0.0]]),
+    "triclinic": np.array([[3.1, 0.2, 0.1], [0.9, 2.8, -0.2], [0.0, 0.0, 0.0]]),
+}
+
+
+@pytest.mark.parametrize("cell_name", list(_NONORTHO_CELLS))
+@pytest.mark.parametrize("cutoff", [3.5, 5.0])
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_partial_pbc_neighbours_match_bruteforce_nonorthogonal(cell_name, cutoff, seed):
+    """
+    get_neighborhood replaces the non-periodic (vacuum) row of the cell with an
+    axis-aligned vector for the matscipy binning. Verify this still yields the
+    EXACT neighbour list on non-orthogonal slabs: the periodic vectors keep their
+    true skewed directions and only the vacuum row is replaced. Checked across
+    hexagonal / monoclinic / triclinic in-plane lattices, two cutoffs and several
+    random configurations, edge-by-edge (indices + shift vectors) against a
+    brute-force reference.
+    """
+    cell = _NONORTHO_CELLS[cell_name]
+    pbc = (True, True, False)
+    rng = np.random.default_rng(seed)
+    positions = rng.uniform(0.0, 1.0, size=(6, 2)) @ cell[:2]  # in the periodic plane
+    positions[:, 2] += rng.uniform(-0.3, 0.3, size=6)  # small slab thickness
+
+    edge_index, shifts, _, _ = get_neighborhood(
+        positions, cutoff=cutoff, pbc=pbc, cell=cell
+    )
+    got = _edge_multiset(edge_index.T, shifts)
+    ref = _bruteforce_neighbours(positions, cell, pbc, cutoff)
+    assert got == ref

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -206,9 +206,18 @@ def test_half_periodic():
     atoms = ase.build.fcc111("Al", size=(3, 3, 1), vacuum=0.0)
     assert all(atoms.pbc == (True, True, False))
     config = config_from_atoms(atoms)  # first shell dist is 2.864A
-    edge_index, shifts, _, _ = get_neighborhood(
+    # snapshot the cell: get_neighborhood must not mutate the caller's array,
+    # and comparing against a post-call cell would be a no-op guard.
+    cell_before = config.cell.copy()
+    edge_index, shifts, _, cell = get_neighborhood(
         config.positions, cutoff=2.9, pbc=(True, True, False), cell=config.cell
     )
+    assert np.allclose(config.cell, cell_before)  # input left untouched
+    # periodic rows must be the physical lattice, not the matscipy blow-up
+    assert np.allclose(cell[:2], cell_before[:2])
+    # the non-periodic row had zero extent here; it must stay non-degenerate so
+    # det(cell) / rcell downstream don't blow up (stress would NaN otherwise)
+    assert not np.isclose(np.linalg.det(cell), 0.0)
     sender, receiver = edge_index
     vectors = (
         config.positions[receiver] - config.positions[sender] + shifts

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -230,3 +230,25 @@ def test_half_periodic():
         vectors[:, 2],
         np.zeros(vectors.shape[0]),
     )
+
+
+def test_nonperiodic_cell_is_extent_based():
+    # The fictitious cell for non-periodic directions is sized from the atom
+    # extent (+ cutoff padding), not from max(|positions|). Two copies of the
+    # same molecule at different absolute positions must therefore get the SAME
+    # cell -- the old max(|positions|)*5*cutoff formula grew with the coordinate
+    # origin and blew up (OOM) k-space electrostatics for molecules far from 0.
+    rng = np.random.default_rng(0)
+    positions = rng.uniform(-2.0, 2.0, size=(6, 3))
+    cutoff = 5.0
+    _, _, _, cell_near = get_neighborhood(
+        positions, cutoff=cutoff, pbc=(False, False, False)
+    )
+    _, _, _, cell_far = get_neighborhood(
+        positions + 100.0, cutoff=cutoff, pbc=(False, False, False)
+    )
+    # origin-independent: same shape -> same cell regardless of absolute position
+    assert np.allclose(cell_near, cell_far)
+    # and the cell tracks the extent + cutoff padding (not |positions|)
+    extent = positions.max(axis=0) - positions.min(axis=0)
+    assert np.allclose(np.diag(cell_near), extent + 2 * cutoff + 1)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -450,3 +450,76 @@ def test_atomic_virials_stresses():
     assert torch.allclose(
         summed_atomic_stresses, total_stress.squeeze(0), atol=1e-6
     ), f"Sum of atomic stresses (normalized by volume) {summed_atomic_stresses} does not match total stress {total_stress.squeeze(0)}"
+
+
+def test_stress_partial_pbc():
+    """
+    Analytic stress must equal the finite-difference strain derivative of the
+    energy for partially periodic (slab) systems.
+    """
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(7)
+
+    slab_z_table = tools.AtomicNumberTable([14])
+    model = modules.MACE(
+        r_max=5.0,
+        num_bessel=8,
+        num_polynomial_cutoff=6,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=1,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o"),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([0.0]),
+        avg_num_neighbors=8,
+        atomic_numbers=slab_z_table.zs,
+        correlation=3,
+        radial_type="bessel",
+    )
+
+    def compute(atoms):
+        atomic_data = data.AtomicData.from_config(
+            data.config_from_atoms(atoms), z_table=slab_z_table, cutoff=5.0
+        )
+        loader = torch_geometric.dataloader.DataLoader(
+            dataset=[atomic_data], batch_size=1, shuffle=False, drop_last=False
+        )
+        batch = next(iter(loader)).to_dict()
+        output = model(batch, training=False, compute_stress=True)
+        return output["energy"].item(), output["stress"].detach().numpy()[0]
+
+    # Si slab: periodic in x/y, vacuum along z
+    slab = build.bulk("Si", "diamond", a=5.43).repeat((2, 2, 2))
+    slab.set_pbc([True, True, False])
+    cell = slab.get_cell().array.copy()
+    cell[2] = [0.0, 0.0, slab.positions[:, 2].max() + 20.0]
+    slab.set_cell(cell, scale_atoms=False)
+    slab.positions[:, 2] += 10.0
+
+    cell0 = slab.get_cell().array.copy()
+    volume = abs(np.linalg.det(cell0))
+    eps, delta = 0.010, 0.001
+
+    def strained(strain_yy):
+        atoms = slab.copy()
+        strain = np.eye(3)
+        strain[1, 1] += strain_yy
+        atoms.set_cell(cell0 @ strain, scale_atoms=True)
+        return atoms
+
+    energy_plus, _ = compute(strained(eps + delta))
+    energy_minus, _ = compute(strained(eps - delta))
+    _, stress = compute(strained(eps))
+
+    finite_diff = (energy_plus - energy_minus) / (2 * delta) / volume
+    assert np.isclose(finite_diff, stress[1, 1], rtol=1e-4), (
+        f"sigma_yy finite difference {finite_diff} does not match "
+        f"analytic stress {stress[1, 1]}"
+    )


### PR DESCRIPTION
## Summary

Combines and reconciles two open fixes to `get_neighborhood`'s handling of the fictitious cell used along non-periodic directions. They touch the same lines and conflict textually, so they are merged into one coherent change. Supersedes #1473 and #1523.

- **#1473**: the `max(abs(positions)) * 5 * cutoff` cell depended on the absolute coordinate origin and produced enormous cells, OOM-ing  PolarMACE's k-space electrostatics for ordinary molecules far from the origin.
- **#1523**: that fictitious cell was *returned* and stored in `AtomicData`, so `stress = virial / det(cell)` was scaled by a large factor  (~18x) for partially periodic (slab) systems.

## What changed

`get_neighborhood` now:

1. Sizes the blown-up cell from the **atom extent** (`extent + 2*cutoff + 1`)  instead of `max(abs(positions)) * 5 * cutoff` — origin-independent, far smaller,  identical neighbour lists (fixes the OOM).
2. Uses that extended cell **only for the matscipy neighbour search**.
3. **Returns the physical cell** whenever any axis is periodic, so stress normalizes by the true volume (fixes the slab stress). Fully aperiodic systems keep the extended cell. The input array is no longer mutated.

## Effect on electrostatic models (PolarMACE)

The returned cell also becomes `AtomicData`'s `volume`/`rcell`, which drive PolarMACE's electrostatics. `graph_longrange` already applies the correct boundary treatment but they **divide by `det(cell)`**. With the old inflated cell that volume was fake, so the corrections were silently scaled away; returning the physical cell gives them the
right volume. So this change is not only a stress fix, it also makes PolarMACE's slab/molecule electrostatic corrections numerically correct. (`graph_longrange` only supports `TTT`/`TTF` and raises otherwise, so no other partial-PBC case is affected.) Adequate vacuum along the non-periodic axis remains the caller's responsibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core graph construction used by all models; slab stress and PolarMACE electrostatics numerics change by design, though behaviour is heavily regression-tested.
> 
> **Overview**
> **`get_neighborhood`** no longer mutates the caller’s cell and fixes how fictitious non-periodic cell rows are built and what gets returned downstream.
> 
> For matscipy neighbour binning only, non-periodic axes use an **extent + cutoff** padded cell (`extent + 2*cutoff + 1`) instead of **`max(|positions|) * 5 * cutoff`**, so padding is origin-independent and much smaller—avoiding huge k-space boxes that could OOM PolarMACE electrostatics while keeping the same neighbour lists.
> 
> When **any axis is periodic**, the function **returns the physical cell** (with a fallback extended row if a non-periodic axis is all zeros), so `AtomicData` volume/`rcell`, slab **stress** (`virial / det(cell)`), and long-range **dipole corrections** use the real box volume. Fully aperiodic systems still return the extended cell.
> 
> Tests cover partial-PBC slabs (PolarMACE cell contract and vacuum convergence), brute-force neighbour parity on skewed slabs, extent-based aperiodic cells, slab stress vs finite differences, and looser cueq stress parity bounds after the smaller cell volume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cca0b21114b0bb751b56ea81318bf9e0e431db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->