### PR TITLE
Allow imports to work if openequivariance is installed but not running on supported GPU

### DIFF
--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -22,6 +22,12 @@ try:
     OEQ_AVAILABLE = True
 except ImportError:
     OEQ_AVAILABLE = False
+except AssertionError as exc:
+    if "Only CUDA and HIP backends are supported" in str(exc):
+        # continue w/o if using CPU torch
+        OEQ_AVAILABLE = False
+    else:
+        raise
 
 
 def run(

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -27,6 +27,12 @@ try:
     OEQ_AVAILABLE = True
 except ImportError:
     OEQ_AVAILABLE = False
+except AssertionError as exc:
+    if "Only CUDA and HIP backends are supported" in str(exc):
+        # continue w/o if using CPU torch
+        OEQ_AVAILABLE = False
+    else:
+        raise
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Check for `AssertionError` that contains a specific string when importing `openequivariance`, and allow it to continue without OEQ if it's caused by running on a non-supported GPU (e.g. torch _CPU_)

closes #1532 