### PR TITLE
Checkpoint interaction neighbor normalization

### DIFF
--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -220,9 +220,9 @@ def transfer_weights(
 
     # Transfer avg_num_neighbors
     for i in range(num_layers):
-        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
-            i
-        ].avg_num_neighbors
+        target_model.interactions[i].set_avg_num_neighbors(
+            source_model.interactions[i].avg_num_neighbors
+        )
 
     # Load state dict into target model
     target_model.load_state_dict(target_dict)

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -204,9 +204,9 @@ def transfer_weights(
                 )
     # Transfer avg_num_neighbors
     for i in range(num_layers):
-        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
-            i
-        ].avg_num_neighbors
+        target_model.interactions[i].set_avg_num_neighbors(
+            source_model.interactions[i].avg_num_neighbors
+        )
 
     # Load state dict into target model
     target_model.load_state_dict(target_dict)

--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -114,9 +114,9 @@ def run(
     target_model.load_state_dict(target_dict)
 
     for i in range(num_layers):
-        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
-            i
-        ].avg_num_neighbors
+        target_model.interactions[i].set_avg_num_neighbors(
+            source_model.interactions[i].avg_num_neighbors
+        )
 
     if return_model:
         return target_model

--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -47,9 +47,9 @@ def run(
     target_model.load_state_dict(target_dict)
 
     for i in range(2):
-        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
-            i
-        ].avg_num_neighbors
+        target_model.interactions[i].set_avg_num_neighbors(
+            source_model.interactions[i].avg_num_neighbors
+        )
 
     if return_model:
         return target_model

--- a/mace/cli/convert_oeq_e3nn.py
+++ b/mace/cli/convert_oeq_e3nn.py
@@ -33,10 +33,9 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
             target_dict[key] = source_dict[key]
 
     for i in range(2):
-
-        target_model.interactions[i].avg_num_neighbors = source_model.interactions[
-            i
-        ].avg_num_neighbors
+        target_model.interactions[i].set_avg_num_neighbors(
+            source_model.interactions[i].avg_num_neighbors
+        )
 
     target_model.load_state_dict(target_dict)
 

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -636,6 +636,8 @@ class EquivariantProductBasisWithSelfMagmomBlock(torch.nn.Module):
 
 @compile_mode("script")
 class InteractionBlock(torch.nn.Module):
+    avg_num_neighbors: torch.Tensor
+
     def __init__(
         self,
         node_attrs_irreps: o3.Irreps,
@@ -657,7 +659,10 @@ class InteractionBlock(torch.nn.Module):
         self.edge_feats_irreps = edge_feats_irreps
         self.target_irreps = target_irreps
         self.hidden_irreps = hidden_irreps
-        self.avg_num_neighbors = avg_num_neighbors
+        self.register_buffer(
+            "avg_num_neighbors",
+            torch.as_tensor(avg_num_neighbors, dtype=torch.get_default_dtype()),
+        )
         if radial_MLP is None:
             radial_MLP = [64, 64, 64]
         if edge_irreps is None:
@@ -671,6 +676,41 @@ class InteractionBlock(torch.nn.Module):
         if self.cueq_config and self.cueq_config.conv_fusion:
             self.conv_fusion = self.cueq_config.conv_fusion
         self._setup()
+
+    def set_avg_num_neighbors(self, value: Union[float, torch.Tensor]) -> None:
+        """Copy neighbor normalization from current or legacy models."""
+        self.avg_num_neighbors.copy_(
+            torch.as_tensor(
+                value,
+                dtype=self.avg_num_neighbors.dtype,
+                device=self.avg_num_neighbors.device,
+            )
+        )
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        key = prefix + "avg_num_neighbors"
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+        # Checkpoints created before this value became a buffer rely on the
+        # normalization supplied when reconstructing the model.
+        if key not in state_dict and key in missing_keys:
+            missing_keys.remove(key)
 
     @abstractmethod
     def _setup(self) -> None:

--- a/mace/tools/finetuning_utils.py
+++ b/mace/tools/finetuning_utils.py
@@ -111,9 +111,9 @@ def load_foundations_elements_default(
         model.interactions[i].linear_up.weight = torch.nn.Parameter(
             model_foundations.interactions[i].linear_up.weight.clone()
         )
-        model.interactions[i].avg_num_neighbors = model_foundations.interactions[
-            i
-        ].avg_num_neighbors
+        model.interactions[i].set_avg_num_neighbors(
+            model_foundations.interactions[i].avg_num_neighbors
+        )
 
         for (_, param_1), (_, param_2) in zip(
             model.interactions[i].conv_tp_weights.named_parameters(),
@@ -442,9 +442,9 @@ def load_foundations_elements_magnetic(
         model.interactions[i].linear_up.weight = torch.nn.Parameter(
             model_foundations.interactions[i].linear_up.weight.clone()
         )
-        model.interactions[i].avg_num_neighbors = model_foundations.interactions[
-            i
-        ].avg_num_neighbors
+        model.interactions[i].set_avg_num_neighbors(
+            model_foundations.interactions[i].avg_num_neighbors
+        )
         for j in range(4):  # Assuming 4 layers in conv_tp_weights,
             layer_name = f"layer{j}"
             if j == 0:
@@ -686,9 +686,9 @@ def load_foundations_mdp(
         model.interactions[i].linear_up.weight = torch.nn.Parameter(
             model_foundations.interactions[i].linear_up.weight.clone()
         )
-        model.interactions[i].avg_num_neighbors = model_foundations.interactions[
-            i
-        ].avg_num_neighbors
+        model.interactions[i].set_avg_num_neighbors(
+            model_foundations.interactions[i].avg_num_neighbors
+        )
 
         for (_, param_1), (_, param_2) in zip(
             model.interactions[i].conv_tp_weights.named_parameters(),

--- a/tests/unit/test_finetuning_utils.py
+++ b/tests/unit/test_finetuning_utils.py
@@ -158,9 +158,7 @@ def test_load_foundations_elements_r_max_mismatch_raises():
     foundation, _ = build_scale_shift_mace(FOUNDATION_ZS, seed=1)
     target, target_table = build_scale_shift_mace(TARGET_ZS, seed=2, r_max=4.0)
     with pytest.raises(AssertionError):
-        load_foundations_elements(
-            target, foundation, table=target_table, max_L=MAX_L
-        )
+        load_foundations_elements(target, foundation, table=target_table, max_L=MAX_L)
 
 
 def test_load_foundations_copies_matching_shapes_and_skips_readouts():
@@ -186,18 +184,57 @@ def test_load_foundations_copies_matching_shapes_and_skips_readouts():
 
 
 def test_load_foundations_include_readouts():
-    # same avg_num_neighbors: load_foundations only copies the state dict, so
-    # non-state attributes must already match for predictions to coincide
     foundation, _ = build_scale_shift_mace(TARGET_ZS, seed=5, avg_num_neighbors=3.0)
     target, target_table = build_scale_shift_mace(
-        TARGET_ZS, seed=6, avg_num_neighbors=3.0
+        TARGET_ZS, seed=6, avg_num_neighbors=9.0
     )
     target = load_foundations(target, foundation, include_readouts=True)
     assert torch.allclose(
         target.readouts[0].linear.weight, foundation.readouts[0].linear.weight
     )
+    for target_interaction, foundation_interaction in zip(
+        target.interactions, foundation.interactions
+    ):
+        assert torch.equal(
+            target_interaction.avg_num_neighbors,
+            foundation_interaction.avg_num_neighbors,
+        )
     # identical architecture + full copy => identical predictions
     batch = water_batch(target_table, cutoff=R_MAX)
     out_t = target(batch.to_dict(), training=False, compute_force=False)
     out_f = foundation(batch.to_dict(), training=False, compute_force=False)
     assert torch.allclose(out_t["energy"], out_f["energy"])
+
+
+def test_avg_num_neighbors_is_checkpointed_and_cast():
+    model, _ = build_scale_shift_mace(TARGET_ZS, seed=7, avg_num_neighbors=4.25)
+
+    # Conversion utilities may copy this value from legacy models as a float.
+    model.interactions[0].set_avg_num_neighbors(6.5)
+    state_dict = model.state_dict()
+    for index in range(int(model.num_interactions)):
+        key = f"interactions.{index}.avg_num_neighbors"
+        assert key in state_dict
+        expected = 6.5 if index == 0 else 4.25
+        assert state_dict[key].item() == pytest.approx(expected)
+
+    model.float()
+    for interaction in model.interactions:
+        assert interaction.avg_num_neighbors.dtype == torch.float32
+
+
+def test_legacy_state_dict_without_avg_num_neighbors_loads_strictly():
+    source, _ = build_scale_shift_mace(TARGET_ZS, seed=8, avg_num_neighbors=3.0)
+    legacy_state_dict = {
+        key: value
+        for key, value in source.state_dict().items()
+        if not key.endswith("avg_num_neighbors")
+    }
+    target, _ = build_scale_shift_mace(TARGET_ZS, seed=9, avg_num_neighbors=7.0)
+
+    incompatible = target.load_state_dict(legacy_state_dict, strict=True)
+
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+    for interaction in target.interactions:
+        assert interaction.avg_num_neighbors.item() == pytest.approx(7.0)


### PR DESCRIPTION
Fixes #1415.

## Summary
- register each interaction block avg_num_neighbors as a persistent buffer, so it follows checkpoints and dtype/device conversions
- keep strict loading compatible with legacy checkpoints that do not contain the new buffer
- update model conversion and fine-tuning transfers to copy legacy float values safely

## Validation
- pytest tests/unit/test_finetuning_utils.py tests/unit/test_models.py -q (15 passed)
- pytest tests/unit -q -k "not benchmark" (247 passed, 16 deselected)
- MACE_REQUIRE_CAPS=gpu,cueq,oeq pytest tests/backends -q (50 passed)
- converted the released legacy MH1 model and verified the float normalization becomes a checkpointed tensor
- black, isort, pylint, and git diff --check