### PR TITLE
Per-element (per-atom) force loss weighting

### DIFF
--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -44,6 +44,7 @@ class AtomicData(torch_geometric.data.Data):
     weight: torch.Tensor
     energy_weight: torch.Tensor
     forces_weight: torch.Tensor
+    forces_atomic_weights: torch.Tensor
     stress_weight: torch.Tensor
     virials_weight: torch.Tensor
     dipole_weight: torch.Tensor
@@ -82,6 +83,7 @@ class AtomicData(torch_geometric.data.Data):
         elec_temp: Optional[torch.Tensor],  # [,]
         total_charge: Optional[torch.Tensor] = None,  # [,]
         total_spin: Optional[torch.Tensor] = None,  # [,]
+        forces_atomic_weights: Optional[torch.Tensor] = None,  # [n_nodes, 1]
         pbc: Optional[torch.Tensor] = None,  # [, 3]
         density_coefficients: Optional[torch.Tensor] = None,  # [n_nodes, k]
         rcell: Optional[torch.Tensor] = None,  # [3,3]
@@ -102,6 +104,7 @@ class AtomicData(torch_geometric.data.Data):
         assert head is None or len(head.shape) == 0
         assert energy_weight is None or len(energy_weight.shape) == 0
         assert forces_weight is None or len(forces_weight.shape) == 0
+        assert forces_atomic_weights is None or forces_atomic_weights.shape == (num_nodes, 1)
         assert stress_weight is None or len(stress_weight.shape) == 0
         assert virials_weight is None or len(virials_weight.shape) == 0
         assert dipole_weight is None or dipole_weight.shape == (1, 3), dipole_weight
@@ -139,6 +142,7 @@ class AtomicData(torch_geometric.data.Data):
             "head": head,
             "energy_weight": energy_weight,
             "forces_weight": forces_weight,
+            "forces_atomic_weights": forces_atomic_weights,
             "stress_weight": stress_weight,
             "virials_weight": virials_weight,
             "dipole_weight": dipole_weight,
@@ -221,6 +225,15 @@ class AtomicData(torch_geometric.data.Data):
             )
             if config.property_weights.get("forces") is not None
             else torch.tensor(1.0, dtype=torch.get_default_dtype())
+        )
+
+        forces_atomic_weights = (
+            torch.tensor(
+                config.properties.get("forces_atomic_weights"),
+                dtype=torch.get_default_dtype(),
+            ).view(num_atoms, 1)
+            if config.properties.get("forces_atomic_weights") is not None
+            else torch.ones(num_atoms, 1, dtype=torch.get_default_dtype())
         )
 
         stress_weight = (
@@ -408,6 +421,7 @@ class AtomicData(torch_geometric.data.Data):
             head=head,
             energy_weight=energy_weight,
             forces_weight=forces_weight,
+            forces_atomic_weights=forces_atomic_weights,
             stress_weight=stress_weight,
             virials_weight=virials_weight,
             dipole_weight=dipole_weight,

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -61,7 +61,7 @@ def update_keyspec_from_kwargs(
         "polarizability_key",
         "total_spin_key",
     ]
-    arrays = ["forces_key", "charges_key"]
+    arrays = ["forces_key", "charges_key", "forces_atomic_weights_key"]
     info_keys = {}
     arrays_keys = {}
     for key in infos:

--- a/mace/modules/loss.py
+++ b/mace/modules/loss.py
@@ -43,6 +43,17 @@ def reduce_loss(raw_loss: torch.Tensor, ddp: Optional[bool] = None) -> torch.Ten
     return raw_loss.mean()
 
 
+def get_forces_atomic_weights(ref: Batch) -> Optional[torch.Tensor]:
+    """
+    Returns per-atom force loss weights with shape [n_atoms, 1], or None if the
+    batch does not carry them (e.g. datasets created before this feature).
+    """
+    weights = getattr(ref, "forces_atomic_weights", None)
+    if weights is None:
+        return None
+    return weights.view(-1, 1)
+
+
 # ------------------------------------------------------------------------------
 # Energy Loss Functions
 # ------------------------------------------------------------------------------
@@ -132,6 +143,9 @@ def mean_squared_error_forces(
         * configs_forces_weight
         * torch.square(ref["forces"] - pred["forces"])
     )
+    atomic_weights = get_forces_atomic_weights(ref)
+    if atomic_weights is not None:
+        raw_loss = atomic_weights * raw_loss
     return reduce_loss(raw_loss, ddp)
 
 
@@ -139,6 +153,9 @@ def mean_normed_error_forces(
     ref: Batch, pred: TensorDict, ddp: Optional[bool] = None
 ) -> torch.Tensor:
     raw_loss = torch.linalg.vector_norm(ref["forces"] - pred["forces"], ord=2, dim=-1)
+    atomic_weights = get_forces_atomic_weights(ref)
+    if atomic_weights is not None:
+        raw_loss = atomic_weights.view(-1) * raw_loss
     return reduce_loss(raw_loss, ddp)
 
 
@@ -205,6 +222,9 @@ def conditional_mse_forces(
     se[c3] = torch.square(err[c3]) * factors[2]
     se[~(c1 | c2 | c3)] = torch.square(err[~(c1 | c2 | c3)]) * factors[3]
     raw_loss = configs_weight * configs_forces_weight * se
+    atomic_weights = get_forces_atomic_weights(ref)
+    if atomic_weights is not None:
+        raw_loss = atomic_weights * raw_loss
     return reduce_loss(raw_loss, ddp)
 
 
@@ -213,6 +233,7 @@ def conditional_huber_forces(
     pred_forces: torch.Tensor,
     huber_delta: float,
     ddp: Optional[bool] = None,
+    atomic_weights: Optional[torch.Tensor] = None,  # [n_atoms, 1]
 ) -> torch.Tensor:
     factors = huber_delta * torch.tensor(
         [1.0, 0.7, 0.4, 0.1], device=ref_forces.device, dtype=ref_forces.dtype
@@ -235,6 +256,8 @@ def conditional_huber_forces(
     se[c4] = torch.nn.functional.huber_loss(
         ref_forces[c4], pred_forces[c4], reduction="none", delta=factors[3]
     )
+    if atomic_weights is not None:
+        se = atomic_weights * se
     return reduce_loss(se, ddp)
 
 
@@ -357,6 +380,9 @@ class WeightedHuberEnergyForcesStressLoss(torch.nn.Module):
             loss_forces = torch.nn.functional.huber_loss(
                 ref["forces"], pred["forces"], reduction="none", delta=self.huber_delta
             )
+            atomic_weights = get_forces_atomic_weights(ref)
+            if atomic_weights is not None:
+                loss_forces = atomic_weights * loss_forces
             loss_forces = reduce_loss(loss_forces, ddp)
             loss_stress = torch.nn.functional.huber_loss(
                 ref["stress"], pred["stress"], reduction="none", delta=self.huber_delta
@@ -370,8 +396,12 @@ class WeightedHuberEnergyForcesStressLoss(torch.nn.Module):
                 delta=self.huber_delta,
             )
             loss_forces = torch.nn.functional.huber_loss(
-                ref["forces"], pred["forces"], reduction="mean", delta=self.huber_delta
+                ref["forces"], pred["forces"], reduction="none", delta=self.huber_delta
             )
+            atomic_weights = get_forces_atomic_weights(ref)
+            if atomic_weights is not None:
+                loss_forces = atomic_weights * loss_forces
+            loss_forces = loss_forces.mean()
             loss_stress = torch.nn.functional.huber_loss(
                 ref["stress"], pred["stress"], reduction="mean", delta=self.huber_delta
             )
@@ -429,6 +459,7 @@ class UniversalLoss(torch.nn.Module):
                 configs_forces_weight * pred["forces"],
                 huber_delta=self.huber_delta,
                 ddp=ddp,
+                atomic_weights=get_forces_atomic_weights(ref),
             )
             loss_stress = torch.nn.functional.huber_loss(
                 configs_stress_weight * ref["stress"],
@@ -449,6 +480,7 @@ class UniversalLoss(torch.nn.Module):
                 configs_forces_weight * pred["forces"],
                 huber_delta=self.huber_delta,
                 ddp=ddp,
+                atomic_weights=get_forces_atomic_weights(ref),
             )
             loss_stress = torch.nn.functional.huber_loss(
                 configs_stress_weight * ref["stress"],

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -706,6 +706,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         default=DefaultKeys.CHARGES.value,
     )
     parser.add_argument(
+        "--forces_atomic_weights_key",
+        help="Key of per-atom force loss weights in training xyz (arrays entry, one scalar per atom)",
+        type=str,
+        default=DefaultKeys.FORCES_ATOMIC_WEIGHTS.value,
+    )
+    parser.add_argument(
         "--elec_temp_key",
         help="Key of electronic temperature in training xyz",
         type=str,
@@ -1216,6 +1222,12 @@ def build_preprocess_arg_parser() -> argparse.ArgumentParser:
         help="Key of atomic charges in training xyz",
         type=str,
         default=DefaultKeys.CHARGES.value,
+    )
+    parser.add_argument(
+        "--forces_atomic_weights_key",
+        help="Key of per-atom force loss weights in training xyz (arrays entry, one scalar per atom)",
+        type=str,
+        default=DefaultKeys.FORCES_ATOMIC_WEIGHTS.value,
     )
     parser.add_argument(
         "--atomic_numbers",

--- a/mace/tools/default_keys.py
+++ b/mace/tools/default_keys.py
@@ -12,6 +12,7 @@ class DefaultKeys(Enum):
     POLARIZABILITY = "polarizability"
     HEAD = "head"
     CHARGES = "REF_charges"
+    FORCES_ATOMIC_WEIGHTS = "REF_forces_atomic_weights"
     TOTAL_CHARGE = "total_charge"
     TOTAL_SPIN = "total_spin"
     ELEC_TEMP = "elec_temp"

--- a/tests/test_forces_atomic_weights.py
+++ b/tests/test_forces_atomic_weights.py
@@ -1,0 +1,189 @@
+"""Tests for per-atom (e.g. per-element) force loss weighting."""
+
+import numpy as np
+import pytest
+import torch
+from ase.atoms import Atoms
+
+from mace import data
+from mace.data import AtomicData, KeySpecification, config_from_atoms
+from mace.modules import (
+    UniversalLoss,
+    WeightedEnergyForcesLoss,
+    WeightedForcesLoss,
+    WeightedHuberEnergyForcesStressLoss,
+)
+from mace.tools import AtomicNumberTable, torch_geometric
+
+torch.set_default_dtype(torch.float64)
+
+TABLE = AtomicNumberTable([1, 8])
+CUTOFF = 3.0
+
+
+def make_config(atomic_weights=None):
+    config = data.Configuration(
+        atomic_numbers=np.array([8, 1, 1]),
+        positions=np.array(
+            [
+                [0.0, -2.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        ),
+        properties={
+            "energy": -1.5,
+            "forces": np.array(
+                [
+                    [0.0, -1.3, 0.0],
+                    [1.0, 0.2, 0.0],
+                    [0.0, 1.1, 0.3],
+                ]
+            ),
+            "stress": np.zeros(6),
+        },
+        property_weights={"energy": 1.0, "forces": 1.0, "stress": 1.0},
+    )
+    if atomic_weights is not None:
+        config.properties["forces_atomic_weights"] = np.asarray(atomic_weights)
+    return config
+
+
+def make_batch(configs):
+    dataset = [AtomicData.from_config(c, z_table=TABLE, cutoff=CUTOFF) for c in configs]
+    loader = torch_geometric.dataloader.DataLoader(
+        dataset=dataset, batch_size=len(dataset), shuffle=False, drop_last=False
+    )
+    return next(iter(loader))
+
+
+def make_pred(batch, forces_offset):
+    return {
+        "energy": batch.energy.clone(),
+        "forces": batch.forces + forces_offset,
+        "stress": batch.stress.clone(),
+    }
+
+
+@pytest.mark.parametrize(
+    "loss_cls",
+    [
+        WeightedEnergyForcesLoss,
+        WeightedForcesLoss,
+        WeightedHuberEnergyForcesStressLoss,
+        UniversalLoss,
+    ],
+)
+def test_uniform_weights_match_default(loss_cls):
+    """weights == 1 must reproduce the unweighted loss exactly."""
+    loss_fn = loss_cls(forces_weight=1.0)
+    batch_default = make_batch([make_config(), make_config()])
+    batch_ones = make_batch(
+        [make_config([1.0, 1.0, 1.0]), make_config([1.0, 1.0, 1.0])]
+    )
+    offset = 0.1 * torch.ones_like(batch_default.forces)
+    out_default = loss_fn(batch_default, make_pred(batch_default, offset))
+    out_ones = loss_fn(batch_ones, make_pred(batch_ones, offset))
+    assert torch.allclose(out_default, out_ones)
+
+
+def test_weights_scale_mse_loss():
+    """Uniform weight w scales the (linear-in-weight) MSE force loss by w."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    batch_1 = make_batch([make_config([1.0, 1.0, 1.0])])
+    batch_2 = make_batch([make_config([2.0, 2.0, 2.0])])
+    offset = 0.1 * torch.ones_like(batch_1.forces)
+    out_1 = loss_fn(batch_1, make_pred(batch_1, offset))
+    out_2 = loss_fn(batch_2, make_pred(batch_2, offset))
+    assert torch.allclose(out_2, 2.0 * out_1)
+
+
+def test_zero_weight_masks_atom():
+    """An atom with weight 0 must not contribute to the force loss."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    batch = make_batch([make_config([0.0, 1.0, 1.0])])
+    # error only on the zero-weighted atom
+    offset = torch.zeros_like(batch.forces)
+    offset[0] = 100.0
+    out = loss_fn(batch, make_pred(batch, offset))
+    assert out.item() == pytest.approx(0.0)
+    # sanity: same error on a weighted atom is nonzero
+    offset2 = torch.zeros_like(batch.forces)
+    offset2[1] = 100.0
+    out2 = loss_fn(batch, make_pred(batch, offset2))
+    assert out2.item() > 0.0
+
+
+def test_per_element_weighting_ratio():
+    """Element-keyed weights: minority-atom error is up-weighted as expected."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    element_weights = {8: 5.0, 1: 1.0}
+    config = make_config()
+    config.properties["forces_atomic_weights"] = np.array(
+        [element_weights[z] for z in config.atomic_numbers]
+    )
+    batch = make_batch([config])
+    err_on_O = torch.zeros_like(batch.forces)
+    err_on_O[0] = 1.0
+    err_on_H = torch.zeros_like(batch.forces)
+    err_on_H[1] = 1.0
+    out_O = loss_fn(batch, make_pred(batch, err_on_O))
+    out_H = loss_fn(batch, make_pred(batch, err_on_H))
+    assert torch.allclose(out_O, 5.0 * out_H)
+
+
+def test_mixed_batch_with_and_without_weights():
+    """Configs lacking the column default to 1 and collate with weighted ones."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    batch = make_batch([make_config([3.0, 3.0, 3.0]), make_config()])
+    assert batch.forces_atomic_weights.shape == (6, 1)
+    assert torch.allclose(
+        batch.forces_atomic_weights.view(-1),
+        torch.tensor([3.0, 3.0, 3.0, 1.0, 1.0, 1.0]),
+    )
+    offset = 0.1 * torch.ones_like(batch.forces)
+    out = loss_fn(batch, make_pred(batch, offset))
+    batch_ref = make_batch([make_config(), make_config()])
+    out_ref = loss_fn(batch_ref, make_pred(batch_ref, offset))
+    assert torch.allclose(out, 2.0 * out_ref)  # mean weight = 2
+
+
+def test_legacy_batch_without_attribute():
+    """Batches built without the field (legacy caches) must still work."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    batch = make_batch([make_config()])
+    del batch.forces_atomic_weights
+    offset = 0.1 * torch.ones_like(batch.forces)
+    out = loss_fn(batch, make_pred(batch, offset))
+    assert torch.isfinite(out)
+
+
+def test_xyz_column_roundtrip():
+    """The default arrays column is picked up via KeySpecification."""
+    atoms = Atoms("OH2", positions=[[0, -2, 0], [1, 0, 0], [0, 1, 0]])
+    atoms.info["REF_energy"] = -1.5
+    atoms.arrays["REF_forces"] = np.zeros((3, 3))
+    atoms.arrays["REF_forces_atomic_weights"] = np.array([5.0, 1.0, 1.0])
+    keyspec = KeySpecification.from_defaults()
+    config = config_from_atoms(atoms, key_specification=keyspec)
+    assert np.allclose(
+        config.properties["forces_atomic_weights"], np.array([5.0, 1.0, 1.0])
+    )
+    atomic_data = AtomicData.from_config(config, z_table=TABLE, cutoff=CUTOFF)
+    assert atomic_data.forces_atomic_weights.shape == (3, 1)
+    assert torch.allclose(
+        atomic_data.forces_atomic_weights.view(-1), torch.tensor([5.0, 1.0, 1.0])
+    )
+
+
+def test_ddp_reduction_consistency():
+    """reduce path: ddp=False and explicit mean agree for weighted loss."""
+    loss_fn = WeightedForcesLoss(forces_weight=1.0)
+    batch = make_batch([make_config([2.0, 0.5, 1.0])])
+    offset = 0.3 * torch.ones_like(batch.forces)
+    pred = make_pred(batch, offset)
+    out = loss_fn(batch, pred, ddp=False)
+    expected = (
+        batch.forces_atomic_weights * torch.square(batch.forces - pred["forces"])
+    ).mean()
+    assert torch.allclose(out, expected)


### PR DESCRIPTION
### Closes #1539.

Adds opt-in per-atom force loss weighting via a new xyz arrays column, REF_forces_atomic_weights (one scalar per atom). Per-element weighting is achieved by expanding an element→weight map into this column during preprocessing. Defaults to uniform, so existing training runs are unchanged.

### Changes
As noted in the issue thread, loading already supports arbitrary per-atom arrays — the work is loss-side plus registering the key.

- ` default_keys.py / arg_parser.py / data/utils.py`: register `forces_atomic_weights` as an arrays key, add `--forces_atomic_weights_key` to the train and preprocess parsers.
- `data/atomic_data.py`: `forces_atomic_weights` as a first-class node field, shape `(n_atoms, 1)`, defaulting to ones in `from_config` (keeps batches homogeneous when only some configs carry the column, and keeps the feature strictly opt-in).
- `modules/loss.py`: a getattr-based helper multiplies the weights into every force path — `mean_squared_error_forces`, `mean_normed_error_forces`, `conditional_mse_forces`, `conditional_huber_forces` (via a new optional arg), and both branches of `WeightedHuberEnergyForcesStressLoss`. Covers the weighted, forces_only, stress, huber, universal, and l1l2energyforces losses.

### Out of Scope

- Validation RMSE_F stays unweighted (`filter_nonzero_weight` still masks by config, not atom).
- Per-component `(n, 3)` weights — scalar-per-atom is the clean v1; `mean_normed_error_forces` can't use per-component weights anyway.

### Usage
```
wmap = {29: 10.0, 6: 1.0}  # up-weight Cu vs C
atoms.arrays["REF_forces_atomic_weights"] = np.array(
    [wmap[z] for z in atoms.get_atomic_numbers()]
)
```

### Tests
New `tests/test_forces_atomic_weights.py` (uniform-weights-match-default, linear scaling, zero-weight masking, per-element ratio, mixed/legacy batches, xyz round-trip, DDP-reduction consistency). Existing `test_modules`, `test_data`, `test_run_train` pass.