### PR TITLE
Add a GPU test for the polar extension

### DIFF
--- a/.github/gitlab/ci.yml
+++ b/.github/gitlab/ci.yml
@@ -138,11 +138,11 @@ gpu-nvidia:
     TORCH_INDEX: ""
     EXTRAS: "dev,cueq,cueq-cuda-13,oeq,schedulefree"
     PIP_REQUIREMENTS: "requirements/polar.txt requirements/les.txt"
-    # `polar` is installed but deliberately NOT required: no polar test carries
-    # the `gpu` marker, so the marker expression can never select one and the
-    # guarantee would be empty. The install stays, so adding such a test needs
-    # no change here. Everything else listed IS reachable under `-m gpu`.
-    REQUIRE_CAPS: "gpu,cueq,oeq,les,schedulefree,network"
+    # Everything listed IS reachable under `-m gpu`, which is the whole point:
+    # a capability whose tests are all deselected passes the guard in
+    # tests/conftest.py silently, because that guard counts collected tests
+    # rather than selected ones.
+    REQUIRE_CAPS: "gpu,cueq,oeq,polar,les,schedulefree,network"
     MARKER_EXPR: "gpu"
 
 # cuEquivariance is NVIDIA-only, hence the narrower marker expression. This
@@ -176,10 +176,11 @@ gpu-amd:
     EXTRAS: "dev,oeq,schedulefree"
     PIP_REQUIREMENTS: "requirements/polar.txt requirements/les.txt"
     # Narrower than the Nvidia list, because `not cueq` removes the only test
-    # that could exercise each of the missing three: the one `gpu` `les` test is
-    # also `cueq`-marked, as is the one `gpu` `network` test, and no polar test
-    # is `gpu`-marked at all. Requiring them here would read as coverage this
-    # job does not have — the zero-collection guard in tests/conftest.py counts
-    # collected tests, not selected ones, so it cannot catch that for us.
-    REQUIRE_CAPS: "gpu,oeq,schedulefree"
+    # that could exercise `les` or `network`: both of those `gpu` tests are also
+    # `cueq`-marked. Requiring them here would read as coverage this job does
+    # not have, and the zero-collection guard in tests/conftest.py cannot catch
+    # that for us, since it counts collected tests rather than selected ones.
+    # `polar` is required: its `gpu` test carries no `cueq` mark, so it runs
+    # here too — verified on an MI210, 39 passed.
+    REQUIRE_CAPS: "gpu,oeq,polar,schedulefree"
     MARKER_EXPR: "gpu and not cueq"

--- a/tests/extensions/polar/test_polar_models.py
+++ b/tests/extensions/polar/test_polar_models.py
@@ -447,6 +447,38 @@ def test_energy_invariance_under_rotation_and_translation(dtype):
 
 
 # ---------------------------------------------------------------------------
+# CPU/CUDA parity of the electrostatics path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda is not available")
+@pytest.mark.parametrize("dtype", [torch.float64])
+def test_polar_cpu_cuda_parity(dtype):
+    """The same model is moved to CUDA rather than rebuilt, so the weights are
+    identical by construction and any difference is the device's. float64 keeps
+    the tolerance from depending on thread count and hardware.
+    """
+    torch.manual_seed(0)
+    model = _build_minimal_model(torch.device("cpu"), dtype)
+    batch_cpu = _build_minimal_batch(torch.device("cpu"), dtype)
+
+    out_cpu = model(batch_cpu, training=False, compute_force=False)
+    E_cpu = out_cpu["energy"].detach()
+
+    # _build_minimal_batch is deterministic (no RNG), so this is the same input.
+    model.to(device="cuda")
+    batch_cuda = _build_minimal_batch(torch.device("cuda"), dtype)
+
+    out_cuda = model(batch_cuda, training=False, compute_force=False)
+    E_cuda = out_cuda["energy"].detach()
+
+    assert torch.isfinite(E_cuda).all()
+    assert E_cuda.shape == E_cpu.shape
+    assert torch.allclose(E_cpu, E_cuda.cpu(), atol=1e-8, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
 # Partial-PBC (slab) regression: get_neighborhood cell fix vs electrostatics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The polar extension is installed in both GPU CI jobs but no test was running it, because no polar test carried the `gpu` marker. That is also why `polar` is not listed in `REQUIRE_CAPS` in the GPU pipeline: the guarantee would have been empty.

This adds one test. It builds the model on CPU, runs it, then moves the same model to CUDA and runs the same input again, so the weights are identical and any difference comes from the device. It uses float64 and no reference values, so the
tolerance does not depend on thread count or hardware. There is no `cueq` mark, so it runs on both vendors and covers the electrostatics path on ROCm too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI configuration only; no production polar or electrostatics logic changes.
> 
> **Overview**
> Adds **`test_polar_cpu_cuda_parity`**, a `@pytest.mark.gpu` check that runs a minimal **PolarMACE** model on CPU, moves the **same weights** to CUDA, and asserts energies match in **float64**—exercising the polar electrostatics path on GPU without a `cueq` mark (so it runs on **NVIDIA and ROCm**).
> 
> GPU CI **`REQUIRE_CAPS`** now includes **`polar`** on both **`gpu-nvidia`** and **`gpu-amd`**, with comments updated to match: polar was installed before but had no `gpu`-marked test, so the capability guard could not enforce coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62592ebdb86785738d4240688259f367cf296688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->