### PR TITLE
Merge main into develop

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -237,9 +237,10 @@ def mace_mp(
     device: str = "",
     default_dtype: str = "float32",
     dispersion: bool = False,
-    damping: str = "bj",  # choices: ["zero", "bj", "zerom", "bjm"]
+    dispersion_damping: str = "bj",  # choices: ["zero", "bj", "zerom", "bjm"]
     dispersion_xc: str = "pbe",
     dispersion_cutoff: float = 40.0 * units.Bohr,
+    dispersion_coord_cutoff: float = 40.0 * units.Bohr,
     return_raw_model: bool = False,
     **kwargs,
 ) -> Union[MACECalculator, torch.nn.Module, SumCalculator]:
@@ -263,9 +264,10 @@ def mace_mp(
         device (str, optional): Device to use for the model. Defaults to "cuda" if available.
         default_dtype (str, optional): Default dtype for the model. Defaults to "float32".
         dispersion (bool, optional): Whether to use D3 dispersion corrections. Defaults to False.
-        damping (str): The damping function associated with the D3 correction. Defaults to "bj" for D3(BJ).
-        dispersion_xc (str, optional): Exchange-correlation functional for D3 dispersion corrections.
-        dispersion_cutoff (float, optional): Cutoff radius in Bohr for D3 dispersion corrections.
+        dispersion_damping (str): The damping function associated with the D3 correction. Defaults to "bj" for D3(BJ).
+        dispersion_xc (str, optional): Exchange-correlation functional for D3 dispersion corrections. Defaults to "pbe"
+        dispersion_cutoff (float, optional): Cutoff radius in D3 dispersion corrections. Defaults to 40 * Bohr
+        dispersion_coord_cutoff (float, optional): Cutoff radius for coordination number in D3 dispersion corrections. Defaults to 40 * Bohr
         return_raw_model (bool, optional): Whether to return the raw model or an ASE calculator. Defaults to False.
         **kwargs: Passed to MACECalculator and TorchDFTD3Calculator.
 
@@ -314,10 +316,11 @@ def mace_mp(
     dtype = torch.float32 if default_dtype == "float32" else torch.float64
     d3_calc = TorchDFTD3Calculator(
         device=device,
-        damping=damping,
+        damping=dispersion_damping,
         dtype=dtype,
         xc=dispersion_xc,
         cutoff=dispersion_cutoff,
+        cnthr=dispersion_coord_cutoff,
         **kwargs,
     )
 

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -129,7 +129,9 @@ class MACECalculator(Calculator):
         Calculator.__init__(self, **kwargs)
         self.compute_bec = compute_bec
         if external_field is not None:
-            external_field = np.asarray(external_field, dtype=np.float64).reshape(-1) # (3,) vector
+            external_field = np.asarray(external_field, dtype=np.float64).reshape(
+                -1
+            )  # (3,) vector
             if external_field.size != 3:
                 raise ValueError(
                     "external_field must be a 3-vector [Ex, Ey, Ez]; "
@@ -780,20 +782,26 @@ class MACECalculator(Calculator):
                 ]
             )
         if "latent_alphas" in ret_tensors:
-            self.results["LES_alphas"] = torch.mean(ret_tensors["latent_alphas"], dim=0).cpu().numpy()
-        if "latent_kappas" in ret_tensors:
-            self.results["LES_kappas"] = torch.mean(ret_tensors["latent_kappas"], dim=0).cpu().numpy()
-        if getattr(self, "compute_bec", False) and "BEC" in ret_tensors:
-            self.results["bec"] = (
-                torch.mean(ret_tensors["BEC"], dim=0).cpu().numpy()
+            self.results["LES_alphas"] = (
+                torch.mean(ret_tensors["latent_alphas"], dim=0).cpu().numpy()
             )
-        if self.external_field is not None and getattr(self, "compute_bec", False) and "bec" in self.results:
+        if "latent_kappas" in ret_tensors:
+            self.results["LES_kappas"] = (
+                torch.mean(ret_tensors["latent_kappas"], dim=0).cpu().numpy()
+            )
+        if getattr(self, "compute_bec", False) and "BEC" in ret_tensors:
+            self.results["bec"] = torch.mean(ret_tensors["BEC"], dim=0).cpu().numpy()
+        if (
+            self.external_field is not None
+            and getattr(self, "compute_bec", False)
+            and "bec" in self.results
+        ):
             bec_output = self.results["bec"]  # [N_atoms, 2, 3, 3] or [N_atoms, 3, 3]
             if bec_output.ndim == 4:
                 bec_output = np.sum(bec_output, axis=1)
             if getattr(self, "keep_neutral", False):
                 bec_output -= np.mean(bec_output, axis=0)
-            alphas = self.results.get('LES_alphas', None)
+            alphas = self.results.get("LES_alphas", None)
             if getattr(self, "eps_infty", None) is not None and alphas is not None:
                 epsilon_0 = 5.52635e-3
                 volume = atoms.get_volume()
@@ -801,19 +809,30 @@ class MACECalculator(Calculator):
                 if alpha_squeezed.ndim == 1:
                     chi = alpha_squeezed.sum() / volume / epsilon_0
                 elif alpha_squeezed.ndim == 3 and alpha_squeezed.shape[1:] == (3, 3):
-                    chi = np.einsum('icc->', alpha_squeezed) / 3.0 / volume / epsilon_0
+                    chi = np.einsum("icc->", alpha_squeezed) / 3.0 / volume / epsilon_0
                 elif alpha_squeezed.ndim == 2 and alpha_squeezed.shape[-1] == 9:
-                    chi = np.einsum('icc->', alpha_squeezed.reshape(-1, 3, 3)) / 3.0 / volume / epsilon_0
+                    chi = (
+                        np.einsum("icc->", alpha_squeezed.reshape(-1, 3, 3))
+                        / 3.0
+                        / volume
+                        / epsilon_0
+                    )
                 else:
                     chi = 0.0
                 epsilon_r = self.eps_infty / (1.0 + chi)
             else:
-                epsilon_r = getattr(self, "eps_infty", 1.0) if getattr(self, "eps_infty", None) is not None else 1.0
+                epsilon_r = (
+                    getattr(self, "eps_infty", 1.0)
+                    if getattr(self, "eps_infty", None) is not None
+                    else 1.0
+                )
             e_ext_arr = np.array(self.external_field, dtype=np.float64)
-            scaled_e_field = e_ext_arr * (epsilon_r ** 0.5)
+            scaled_e_field = e_ext_arr * (epsilon_r**0.5)
             electric_field_unit = getattr(self, "electric_field_unit", 1.0)
-            forces_bec = (                                         # bec_output: [N, i, j] = dP_i/dr_j
-                np.einsum("nij,i->nj", bec_output, scaled_e_field) # F_nj = sum_i Z*_nij E_i
+            forces_bec = (  # bec_output: [N, i, j] = dP_i/dr_j
+                np.einsum(
+                    "nij,i->nj", bec_output, scaled_e_field
+                )  # F_nj = sum_i Z*_nij E_i
                 * electric_field_unit
             )
             self.results["forces"] += forces_bec

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -10,7 +10,7 @@ import logging
 import os
 from glob import glob
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
 
@@ -115,9 +115,26 @@ class MACECalculator(Calculator):
         pad_num_atoms: int = 0,
         pad_num_edges: int = 0,
         warmup: bool = False,
+        compute_bec: bool = False,
+        external_field: Union[list, None] = None,
+        eps_infty: float = None,
+        electric_field_unit: float = 1.0,
+        keep_neutral: bool = True,
         **kwargs,
     ):
         Calculator.__init__(self, **kwargs)
+        self.compute_bec = compute_bec
+        if external_field is not None:
+            external_field = np.asarray(external_field, dtype=np.float64).reshape(-1) # (3,) vector
+            if external_field.size != 3:
+                raise ValueError(
+                    "external_field must be a 3-vector [Ex, Ey, Ez]; "
+                    f"got {external_field.size} component(s)"
+                )
+        self.external_field = external_field
+        self.eps_infty = eps_infty
+        self.electric_field_unit = electric_field_unit
+        self.keep_neutral = keep_neutral
 
         self._enable_cueq = enable_cueq
         self._enable_oeq = enable_oeq
@@ -209,6 +226,8 @@ class MACECalculator(Calculator):
                     "polarizability_sh",
                 ]
             )
+        if getattr(self, "compute_bec", False):
+            self.implemented_properties.append("bec")
 
         if model_paths is not None:
             if isinstance(model_paths, str):
@@ -491,6 +510,15 @@ class MACECalculator(Calculator):
                 dtype=out[key].dtype,
             )
 
+        for key in ("latent_alphas", "latent_kappas", "BEC"):
+            if out.get(key) is not None:
+                dict_of_tensors[key] = torch.zeros(
+                    num_models,
+                    *out[key].shape,
+                    device=self.device,
+                    dtype=out[key].dtype,
+                )
+
         node_e0 = None
         if "node_energy" in out:
             node_heads = batch["head"][batch["batch"]][:num_atoms]
@@ -632,13 +660,23 @@ class MACECalculator(Calculator):
                 displacement = displacement + positions.sum() * 0.0
                 batch_dict["displacement"] = displacement
 
-            out = model(
-                batch_dict,
-                compute_stress=compute_stress,
-                training=self.use_compile and not oeq_compile,
-                compute_edge_forces=self.compute_atomic_stresses,
-                compute_atomic_stresses=self.compute_atomic_stresses,
-            )
+            if getattr(self, "external_field", None) is not None:
+                batch_dict["external_field"] = torch.tensor(
+                    self.external_field,
+                    device=batch_dict["positions"].device,
+                    dtype=batch_dict["positions"].dtype,
+                )
+
+            forward_kwargs: Dict[str, Any] = {
+                "compute_stress": compute_stress,
+                "training": self.use_compile and not oeq_compile,
+                "compute_edge_forces": self.compute_atomic_stresses,
+                "compute_atomic_stresses": self.compute_atomic_stresses,
+            }
+            if getattr(self, "compute_bec", False):
+                forward_kwargs["compute_bec"] = True
+
+            out = model(batch_dict, **forward_kwargs)
             if is_padded:
                 out = self._slice_real_outputs(out, num_real_atoms)
             if i == 0:
@@ -731,6 +769,44 @@ class MACECalculator(Calculator):
                     for stress in self.results["stresses"]
                 ]
             )
+        if "latent_alphas" in ret_tensors:
+            self.results["LES_alphas"] = torch.mean(ret_tensors["latent_alphas"], dim=0).cpu().numpy()
+        if "latent_kappas" in ret_tensors:
+            self.results["LES_kappas"] = torch.mean(ret_tensors["latent_kappas"], dim=0).cpu().numpy()
+        if getattr(self, "compute_bec", False) and "BEC" in ret_tensors:
+            self.results["bec"] = (
+                torch.mean(ret_tensors["BEC"], dim=0).cpu().numpy()
+            )
+        if self.external_field is not None and getattr(self, "compute_bec", False) and "bec" in self.results:
+            bec_output = self.results["bec"]  # [N_atoms, 2, 3, 3] or [N_atoms, 3, 3]
+            if bec_output.ndim == 4:
+                bec_output = np.sum(bec_output, axis=1)
+            if getattr(self, "keep_neutral", False):
+                bec_output -= np.mean(bec_output, axis=0)
+            alphas = self.results.get('LES_alphas', None)
+            if getattr(self, "eps_infty", None) is not None and alphas is not None:
+                epsilon_0 = 5.52635e-3
+                volume = atoms.get_volume()
+                alpha_squeezed = np.squeeze(alphas)
+                if alpha_squeezed.ndim == 1:
+                    chi = alpha_squeezed.sum() / volume / epsilon_0
+                elif alpha_squeezed.ndim == 3 and alpha_squeezed.shape[1:] == (3, 3):
+                    chi = np.einsum('icc->', alpha_squeezed) / 3.0 / volume / epsilon_0
+                elif alpha_squeezed.ndim == 2 and alpha_squeezed.shape[-1] == 9:
+                    chi = np.einsum('icc->', alpha_squeezed.reshape(-1, 3, 3)) / 3.0 / volume / epsilon_0
+                else:
+                    chi = 0.0
+                epsilon_r = self.eps_infty / (1.0 + chi)
+            else:
+                epsilon_r = getattr(self, "eps_infty", 1.0) if getattr(self, "eps_infty", None) is not None else 1.0
+            e_ext_arr = np.array(self.external_field, dtype=np.float64)
+            scaled_e_field = e_ext_arr * (epsilon_r ** 0.5)
+            electric_field_unit = getattr(self, "electric_field_unit", 1.0)
+            forces_bec = (                                         # bec_output: [N, i, j] = dP_i/dr_j
+                np.einsum("nij,i->nj", bec_output, scaled_e_field) # F_nj = sum_i Z*_nij E_i
+                * electric_field_unit
+            )
+            self.results["forces"] += forces_bec
 
     def get_dielectric_derivatives(self, atoms=None):
         if atoms is None and self.atoms is None:

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -394,7 +394,9 @@ def run(args: argparse.Namespace) -> None:
             atoms.info[args.info_prefix + "stress"] = stresses[i]
 
         if args.compute_bec:
-            atoms.arrays[args.info_prefix + "BEC"] = bec_list[i].reshape(bec_list[i].shape[0], -1)
+            atoms.arrays[args.info_prefix + "BEC"] = bec_list[i].reshape(
+                bec_list[i].shape[0], -1
+            )
         if len(qs_list) > 0:
             atoms.arrays[args.info_prefix + "latent_charges"] = qs_list[i]
         if len(us_list) > 0:
@@ -402,9 +404,13 @@ def run(args: argparse.Namespace) -> None:
         if len(kappas_list) > 0:
             atoms.arrays[args.info_prefix + "latent_kappas"] = kappas_list[i]
         if len(alphas_list) > 0:
-            atoms.arrays[args.info_prefix + "latent_alphas"] = alphas_list[i].reshape(alphas_list[i].shape[0], -1)
+            atoms.arrays[args.info_prefix + "latent_alphas"] = alphas_list[i].reshape(
+                alphas_list[i].shape[0], -1
+            )
         if len(quads_list) > 0:
-            atoms.arrays[args.info_prefix + "latent_quads"] = quads_list[i].reshape(quads_list[i].shape[0], -1)
+            atoms.arrays[args.info_prefix + "latent_quads"] = quads_list[i].reshape(
+                quads_list[i].shape[0], -1
+            )
 
         if args.return_contributions:
             atoms.info[args.info_prefix + "BO_contributions"] = contributions[i]

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -188,6 +188,10 @@ def run(args: argparse.Namespace) -> None:
     stresses_list = []
     bec_list = []
     qs_list = []
+    us_list = []
+    kappas_list = []
+    alphas_list = []
+    quads_list = []
     forces_collection = []
 
     for batch in data_loader:
@@ -206,12 +210,45 @@ def run(args: argparse.Namespace) -> None:
             )
             bec_list.append(becs[:-1])  # drop last as its empty
 
+        if "latent_charges" in output and output["latent_charges"] is not None:
             qs = np.split(
                 torch_tools.to_numpy(output["latent_charges"]),
                 indices_or_sections=batch.ptr[1:],
                 axis=0,
             )
             qs_list.append(qs[:-1])  # drop last as its empty
+
+        if "latent_dipoles" in output and output["latent_dipoles"] is not None:
+            us = np.split(
+                torch_tools.to_numpy(output["latent_dipoles"]),
+                indices_or_sections=batch.ptr[1:],
+                axis=0,
+            )
+            us_list.append(us[:-1])
+
+        if "latent_kappas" in output and output["latent_kappas"] is not None:
+            kappas = np.split(
+                torch_tools.to_numpy(output["latent_kappas"]),
+                indices_or_sections=batch.ptr[1:],
+                axis=0,
+            )
+            kappas_list.append(kappas[:-1])
+
+        if "latent_alphas" in output and output["latent_alphas"] is not None:
+            alphas = np.split(
+                torch_tools.to_numpy(output["latent_alphas"]),
+                indices_or_sections=batch.ptr[1:],
+                axis=0,
+            )
+            alphas_list.append(alphas[:-1])
+
+        if "latent_quads" in output and output["latent_quads"] is not None:
+            quads = np.split(
+                torch_tools.to_numpy(output["latent_quads"]),
+                indices_or_sections=batch.ptr[1:],
+                axis=0,
+            )
+            quads_list.append(quads[:-1])
 
         if args.return_contributions:
             contributions_list.append(torch_tools.to_numpy(output["contributions"]))
@@ -279,7 +316,16 @@ def run(args: argparse.Namespace) -> None:
 
     if args.compute_bec:
         bec_list = [becs for sublist in bec_list for becs in sublist]
+    if len(qs_list) > 0:
         qs_list = [qs for sublist in qs_list for qs in sublist]
+    if len(us_list) > 0:
+        us_list = [us for sublist in us_list for us in sublist]
+    if len(kappas_list) > 0:
+        kappas_list = [kappas for sublist in kappas_list for kappas in sublist]
+    if len(alphas_list) > 0:
+        alphas_list = [alphas for sublist in alphas_list for alphas in sublist]
+    if len(quads_list) > 0:
+        quads_list = [quads for sublist in quads_list for quads in sublist]
 
     if args.return_contributions:
         contributions = np.concatenate(contributions_list, axis=0)
@@ -303,8 +349,17 @@ def run(args: argparse.Namespace) -> None:
             atoms.info[args.info_prefix + "stress"] = stresses[i]
 
         if args.compute_bec:
-            atoms.arrays[args.info_prefix + "BEC"] = bec_list[i].reshape(-1, 9)
+            atoms.arrays[args.info_prefix + "BEC"] = bec_list[i].reshape(bec_list[i].shape[0], -1)
+        if len(qs_list) > 0:
             atoms.arrays[args.info_prefix + "latent_charges"] = qs_list[i]
+        if len(us_list) > 0:
+            atoms.arrays[args.info_prefix + "latent_dipoles"] = us_list[i]
+        if len(kappas_list) > 0:
+            atoms.arrays[args.info_prefix + "latent_kappas"] = kappas_list[i]
+        if len(alphas_list) > 0:
+            atoms.arrays[args.info_prefix + "latent_alphas"] = alphas_list[i].reshape(alphas_list[i].shape[0], -1)
+        if len(quads_list) > 0:
+            atoms.arrays[args.info_prefix + "latent_quads"] = quads_list[i].reshape(quads_list[i].shape[0], -1)
 
         if args.return_contributions:
             atoms.info[args.info_prefix + "BO_contributions"] = contributions[i]

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -399,6 +399,7 @@ class AtomicData(torch_geometric.data.Data):
         cls_kwargs = dict(
             edge_index=torch.tensor(edge_index, dtype=torch.long),
             positions=positions,
+            atomic_numbers=torch.tensor(config.atomic_numbers, dtype=torch.long),
             shifts=torch.tensor(shifts, dtype=torch.get_default_dtype()),
             unit_shifts=torch.tensor(unit_shifts, dtype=torch.get_default_dtype()),
             cell=cell,

--- a/mace/modules/__init__.py
+++ b/mace/modules/__init__.py
@@ -9,11 +9,13 @@ from .blocks import (
     InteractionBlock,
     LinearDipolePolarReadoutBlock,
     LinearDipoleReadoutBlock,
+    LinearLesReadoutBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
     NonLinearBiasReadoutBlock,
     NonLinearDipolePolarReadoutBlock,
     NonLinearDipoleReadoutBlock,
+    NonLinearLesReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
     RealAgnosticAttResidualInteractionBlock,
@@ -24,7 +26,7 @@ from .blocks import (
     RealAgnosticResidualNonLinearInteractionBlock,
     ScaleShiftBlock,
 )
-from .extensions import PolarMACE
+from .extensions import MACELES, PolarMACE
 from .gate import GatedEquivariantBlock
 from .loss import (
     DipolePolarLoss,
@@ -108,10 +110,13 @@ __all__ = [
     "GaussianBasis",
     "MACE",
     "ScaleShiftMACE",
+    "MACELES",
     "AtomicDipolesMACE",
     "AtomicDielectricMACE",
     "EnergyDipolesMACE",
     "PolarMACE",
+    "LinearLesReadoutBlock",
+    "NonLinearLesReadoutBlock",
     "WeightedEnergyForcesLoss",
     "WeightedForcesLoss",
     "WeightedEnergyForcesVirialsLoss",

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -1862,6 +1862,7 @@ class ScaleShiftBlock(torch.nn.Module):
         )
         return f"{self.__class__.__name__}(scale={formatted_scale}, shift={formatted_shift})"
 
+
 # LES-specific readout blocks
 class LinearLesReadoutBlock(torch.nn.Module):
     """Predicts a 3x3 polarizability tensor from equivariant features.

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -3,6 +3,7 @@
 # Authors: Ilyes Batatia, Gregor Simm
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
+# pylint: disable=too-many-lines
 
 from abc import abstractmethod
 from typing import Any, Callable, List, Optional, Tuple, Union
@@ -1395,3 +1396,200 @@ class ScaleShiftBlock(torch.nn.Module):
             else f"{self.shift.item():.4f}"
         )
         return f"{self.__class__.__name__}(scale={formatted_scale}, shift={formatted_shift})"
+
+# LES-specific readout blocks
+class LinearLesReadoutBlock(torch.nn.Module):
+    """Predicts a 3x3 polarizability tensor from equivariant features.
+
+    Combines scalar weights with vector features via outer products.
+    Supports 1o (odd) and 1e (even) vector channels independently.
+    """
+
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        make_w_pos: bool = True,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+    ):
+        super().__init__()
+        self.irreps_in = o3.Irreps(irreps_in)
+        self.make_w_pos = make_w_pos
+        # cueq uses ir_mul layout, which interleaves vector components differently.
+        self.ir_mul = get_layout(cueq_config) == "ir_mul"
+
+        self.linear = Linear(
+            irreps_in=self.irreps_in,
+            irreps_out=self.irreps_in,
+            cueq_config=cueq_config,
+        )
+
+        self.scalar_slices: List[Tuple[int, int]] = []
+        self.vector_1o_slices: List[Tuple[int, int]] = []
+        self.vector_1e_slices: List[Tuple[int, int]] = []
+
+        n_scalar = 0
+        n_1o = 0
+        n_1e = 0
+        offset = 0
+
+        for mul, ir in self.irreps_in:
+            block_dim = mul * ir.dim
+
+            if ir.l == 0 and ir.p == 1:  # 0e
+                self.scalar_slices.append((offset, offset + block_dim))
+                n_scalar += mul
+            elif ir.l == 1 and ir.p == -1:  # 1o
+                self.vector_1o_slices.append((offset, offset + block_dim))
+                n_1o += mul
+            elif ir.l == 1 and ir.p == 1:  # 1e
+                self.vector_1e_slices.append((offset, offset + block_dim))
+                n_1e += mul
+
+            offset += block_dim
+
+        if n_scalar == 0:
+            raise ValueError("Need at least one 0e block for weights.")
+        if n_1o + n_1e == 0:
+            raise ValueError("Need at least one 1o or 1e block.")
+
+        self.n_scalar = n_scalar
+        self.n_1o = n_1o
+        self.n_1e = n_1e
+
+        self.scalar_to_weight_1o = (
+            torch.nn.Linear(n_scalar, n_1o, bias=True) if n_1o > 0 else None
+        )
+        self.scalar_to_weight_1e = (
+            torch.nn.Linear(n_scalar, n_1e, bias=True) if n_1e > 0 else None
+        )
+
+    def _collect_scalars(self, y: torch.Tensor) -> torch.Tensor:
+        return torch.cat([y[:, s:e] for s, e in self.scalar_slices], dim=-1)
+
+    def _collect_vectors(
+        self, y: torch.Tensor, slices: List[Tuple[int, int]]
+    ) -> torch.Tensor:
+        vecs: List[torch.Tensor] = []
+        for s, e in slices:
+            block = y[:, s:e]
+            if self.ir_mul:
+                vecs.append(block.reshape(y.shape[0], 3, -1).transpose(1, 2))
+            else:
+                vecs.append(block.reshape(y.shape[0], -1, 3))
+        return torch.cat(vecs, dim=1)
+
+    def _dyadic_sum(self, w: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return (w[:, :, None, None] * v[:, :, None, :] * v[:, :, :, None]).sum(dim=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        heads: Optional[torch.Tensor] = None,  # pylint: disable=unused-argument
+    ) -> torch.Tensor:
+        if not hasattr(self, "ir_mul"):  # checkpoints saved before the cueq-layout fix
+            self.ir_mul = False
+        y = self.linear(x)
+        s = self._collect_scalars(y)
+        a = y.new_zeros((y.shape[0], 3, 3))
+
+        if self.n_1o > 0 and self.scalar_to_weight_1o is not None:
+            v_1o = self._collect_vectors(y, self.vector_1o_slices)
+            w_1o = self.scalar_to_weight_1o(s)
+            if self.make_w_pos:
+                w_1o = w_1o**2
+            a = a + self._dyadic_sum(w_1o, v_1o)
+
+        if self.n_1e > 0 and self.scalar_to_weight_1e is not None:
+            v_1e = self._collect_vectors(y, self.vector_1e_slices)
+            w_1e = self.scalar_to_weight_1e(s)
+            a = a + self._dyadic_sum(w_1e, v_1e)
+
+        return a
+
+
+@compile_mode("script")
+class NonLinearLesReadoutBlock(torch.nn.Module):
+    """Nonlinear version of LinearLesReadoutBlock using an MLP for channel mixing."""
+
+    def __init__(
+        self,
+        irreps_in: o3.Irreps,
+        hidden_dim: int = 32,
+        cueq_config: Optional[CuEquivarianceConfig] = None,
+    ):
+        super().__init__()
+        self.irreps_in = o3.Irreps(irreps_in)
+        # cueq uses ir_mul layout, which interleaves vector components differently.
+        self.ir_mul = get_layout(cueq_config) == "ir_mul"
+
+        self.linear = Linear(
+            irreps_in=self.irreps_in,
+            irreps_out=self.irreps_in,
+            cueq_config=cueq_config,
+        )
+
+        self._build_slices()
+
+        self.mlp = torch.nn.Sequential(
+            torch.nn.Linear(self.n_scalar, hidden_dim),
+            torch.nn.SiLU(),
+            torch.nn.Linear(hidden_dim, self.n_1o * self.n_1o),
+        )
+
+    def _build_slices(self) -> None:
+        # Record 0e/1o block boundaries instead of assuming uniform multiplicity
+        # and [0e, 1o, ...] ordering.
+        self.scalar_slices: List[Tuple[int, int]] = []
+        self.vector_1o_slices: List[Tuple[int, int]] = []
+        n_scalar = 0
+        n_1o = 0
+        offset = 0
+        for mul, ir in self.irreps_in:
+            block_dim = mul * ir.dim
+            if ir.l == 0 and ir.p == 1:  # 0e
+                self.scalar_slices.append((offset, offset + block_dim))
+                n_scalar += mul
+            elif ir.l == 1 and ir.p == -1:  # 1o
+                self.vector_1o_slices.append((offset, offset + block_dim))
+                n_1o += mul
+            offset += block_dim
+
+        if n_scalar == 0:
+            raise ValueError("Need at least one 0e block for weights.")
+        if n_1o == 0:
+            raise ValueError("Need at least one 1o block.")
+
+        self.n_scalar = n_scalar
+        self.n_1o = n_1o
+
+    def _collect_scalars(self, y: torch.Tensor) -> torch.Tensor:
+        return torch.cat([y[:, s:e] for s, e in self.scalar_slices], dim=-1)
+
+    def _collect_vectors(self, y: torch.Tensor) -> torch.Tensor:
+        vecs: List[torch.Tensor] = []
+        for s, e in self.vector_1o_slices:
+            block = y[:, s:e]
+            if self.ir_mul:
+                vecs.append(block.reshape(y.shape[0], 3, -1).transpose(1, 2))
+            else:
+                vecs.append(block.reshape(y.shape[0], -1, 3))
+        return torch.cat(vecs, dim=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        heads: Optional[torch.Tensor] = None,  # pylint: disable=unused-argument
+    ) -> torch.Tensor:
+        # checkpoints saved before the cueq-layout fix used a single `cdim`
+        if not hasattr(self, "n_1o"):
+            self.ir_mul = False
+            self.irreps_in = o3.Irreps(self.irreps_in)
+            self._build_slices()
+        y = self.linear(x)
+        s = self._collect_scalars(y)
+        v = self._collect_vectors(y)
+        M = self.mlp(s).reshape(y.shape[0], self.n_1o, self.n_1o)
+        M = 0.5 * (M + M.transpose(-1, -2))
+        tmp = torch.einsum("ncd,ndj->ncj", M, v)
+        a = torch.einsum("nci,ncj->nij", tmp, v)
+        return 0.5 * (a + a.transpose(-1, -2))

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -23,7 +23,12 @@ from mace.modules.blocks import (
     NonLinearReadoutBlock,
 )
 from mace.modules.models import ScaleShiftMACE
-from mace.modules.utils import get_atomic_virials_stresses, get_outputs, prepare_graph
+from mace.modules.utils import (
+    get_atomic_virials_stresses,
+    get_outputs,
+    prepare_graph,
+    safe_double,
+)
 from mace.modules.wrapper_ops import (
     CuEquivarianceConfig,
     OEQConfig,
@@ -237,7 +242,7 @@ class MACELES(ScaleShiftMACE):
         inter_e = scatter_sum(node_inter_es, data["batch"], dim=-1, dim_size=num_graphs)
 
         total_energy = e0 + inter_e
-        node_energy = node_e0.clone().double() + node_inter_es.clone().double()
+        node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
         les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1)
         les_result = self.les(
@@ -740,7 +745,7 @@ class PolarMACE(ScaleShiftMACE):
             fukui_input = fukui_to_mul_ir(fukui_input)
         fukui_sources = self.fukui_source_map(fukui_input)
         fukui_norm = scatter_sum(
-            src=fukui_sources.double(),
+            src=safe_double(fukui_sources),
             index=data["batch"],
             dim=0,
             dim_size=num_graphs,
@@ -752,7 +757,7 @@ class PolarMACE(ScaleShiftMACE):
         Q_p_S = (data["total_charge"] + (data["total_spin"] - 1))[data["batch"]]
         Q_m_S = (data["total_charge"] - (data["total_spin"] - 1))[data["batch"]]
         pred_total_charges_0 = scatter_sum(
-            src=spin_charge_density[:, :, 0].double(),
+            src=safe_double(spin_charge_density[:, :, 0]),
             index=data["batch"],
             dim=0,
             dim_size=num_graphs,
@@ -798,7 +803,7 @@ class PolarMACE(ScaleShiftMACE):
 
             # Add external field contribution and subtract barycenter for gauge invariance
             barycenter = scatter_mean(
-                src=positions.double(),
+                src=safe_double(positions),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -840,7 +845,7 @@ class PolarMACE(ScaleShiftMACE):
             spin_charge_density = spin_charge_density + spin_charge_density_sources
 
             fukui_norm2 = scatter_sum(
-                src=current_fukui_sources.double(),
+                src=safe_double(current_fukui_sources),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -850,7 +855,7 @@ class PolarMACE(ScaleShiftMACE):
             )
             current_fukui_sources = current_fukui_sources / fukui_norm2
             pred_total_charges = scatter_sum(
-                src=spin_charge_density[:, :, 0].double(),
+                src=safe_double(spin_charge_density[:, :, 0]),
                 index=data["batch"],
                 dim=0,
                 dim_size=num_graphs,
@@ -958,7 +963,8 @@ class PolarMACE(ScaleShiftMACE):
 
         return {
             "energy": total_energy,
-            "node_energy": node_e0.clone().double() + node_inter_es.clone().double(),
+            "node_energy": safe_double(node_e0.clone())
+            + safe_double(node_inter_es.clone()),
             "interaction_energy": inter_e,
             "forces": forces,
             "edge_forces": edge_forces,

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -69,30 +69,31 @@ from .utils import get_edge_vectors_and_lengths, get_symmetric_displacement
 
 def _copy_mace_readout(
     mace_readout: torch.nn.Module,
-    change_irrep_out: Optional[str] = None, # o3.Irreps("1x1o")
-    cueq_config: Optional[CuEquivarianceConfig] = None
+    change_irrep_out: Optional[str] = None,  # o3.Irreps("1x1o")
+    cueq_config: Optional[CuEquivarianceConfig] = None,
 ) -> torch.nn.Module:
     """
     Helper function to copy a MACE readout block.
     """
     if isinstance(mace_readout, LinearReadoutBlock):
         return LinearReadoutBlock(
-            irreps_in=mace_readout.linear.irreps_in,  # type:ignore
-            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear.irreps_out,  # type:ignore
+            irreps_in=mace_readout.linear.irreps_in,  # type: ignore
+            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear.irreps_out,  # type: ignore
             cueq_config=cueq_config,
         )
-    if isinstance(mace_readout, NonLinearReadoutBlock):  # type:ignore
+    if isinstance(mace_readout, NonLinearReadoutBlock):  # type: ignore
         return NonLinearReadoutBlock(
-            irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+            irreps_in=mace_readout.linear_1.irreps_in,  # type: ignore
             MLP_irreps=mace_readout.hidden_irreps,
             gate=mace_readout.non_linearity._modules["acts"][  # pylint: disable=W0212
                 0
             ].f,
-            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear_2.irreps_out,  # type:ignore
+            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear_2.irreps_out,  # type: ignore
             num_heads=mace_readout.num_heads,
             cueq_config=cueq_config,
         )
     raise TypeError("Unsupported readout type.")
+
 
 def _copy_mace_readout_tp(
     mace_readout: torch.nn.Module,
@@ -107,32 +108,33 @@ def _copy_mace_readout_tp(
     if isinstance(mace_readout, LinearReadoutBlock):
         if use_nonlinear_readout:
             return NonLinearLesReadoutBlock(
-                irreps_in=mace_readout.linear.irreps_in,  # type:ignore
+                irreps_in=mace_readout.linear.irreps_in,  # type: ignore
                 cueq_config=cueq_config,
             )
         return LinearLesReadoutBlock(
-            irreps_in=mace_readout.linear.irreps_in,  # type:ignore
+            irreps_in=mace_readout.linear.irreps_in,  # type: ignore
             make_w_pos=make_w_pos,
             cueq_config=cueq_config,
         )
-    if isinstance(mace_readout, NonLinearReadoutBlock):  # type:ignore
+    if isinstance(mace_readout, NonLinearReadoutBlock):  # type: ignore
         if use_nonlinear_readout:
             return NonLinearLesReadoutBlock(
-                irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+                irreps_in=mace_readout.linear_1.irreps_in,  # type: ignore
                 cueq_config=cueq_config,
             )
         return LinearLesReadoutBlock(
-            irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+            irreps_in=mace_readout.linear_1.irreps_in,  # type: ignore
             make_w_pos=make_w_pos,
             cueq_config=cueq_config,
         )
     raise TypeError("Unsupported readout type.")
 
+
 def _get_readout_input_dim(block: torch.nn.Module) -> int:
     if isinstance(block, LinearReadoutBlock):
-        return block.linear.irreps_in.dim  # type:ignore
-    if isinstance(block, NonLinearReadoutBlock):  # type:ignore
-        return block.linear_1.irreps_in.dim  # type:ignore
+        return block.linear.irreps_in.dim  # type: ignore
+    if isinstance(block, NonLinearReadoutBlock):  # type: ignore
+        return block.linear_1.irreps_in.dim  # type: ignore
     raise TypeError("Unsupported readout type for input dimension retrieval.")
 
 
@@ -157,9 +159,13 @@ class MACELES(ScaleShiftMACE):
         self.use_quads = les_arguments.get("use_quad", False)
         self.use_induced_charges = les_arguments.get("use_induced_charge", False)
         self.use_induced_dipoles = les_arguments.get("use_induced_dipole", False)
-        self.use_anisotropic_polarizability = les_arguments.get("use_anisotropic_polarizability", False)
-        self.alpha_irreps = les_arguments.get("alpha_irreps", '0e+1o+2e')
-        self.alpha_1o_nonlinear_readout = les_arguments.get("alpha_1o_nonlinear_readout", False)
+        self.use_anisotropic_polarizability = les_arguments.get(
+            "use_anisotropic_polarizability", False
+        )
+        self.alpha_irreps = les_arguments.get("alpha_irreps", "0e+1o+2e")
+        self.alpha_1o_nonlinear_readout = les_arguments.get(
+            "alpha_1o_nonlinear_readout", False
+        )
         self.alpha_1o_linear_w_pos = les_arguments.get("alpha_1o_linear_w_pos", True)
         self.make_alpha_positive = les_arguments.get("make_alpha_positive", False)
         self.make_kappa_positive = les_arguments.get("make_kappa_positive", False)
@@ -182,34 +188,45 @@ class MACELES(ScaleShiftMACE):
         self.les_alpha_scale = les_arguments.get("alpha_scale", 0.01)
 
         self.readout_input_dims = [
-            _get_readout_input_dim(readout) for readout in self.readouts  # type:ignore
+            _get_readout_input_dim(readout) for readout in self.readouts  # type: ignore
         ]
         cueq_config = kwargs.get("cueq_config", None)
-        for readout in self.readouts:  # type:ignore
+        for readout in self.readouts:  # type: ignore
             self.les_readouts.append(
                 _copy_mace_readout(readout, cueq_config=cueq_config)
             )
             if self.use_dipoles:
                 self.les_u_readouts.append(
-                    #_copy_mace_readout(readout,  change_irrep_out="1x1o", cueq_config=cueq_config)
-                    _copy_mace_readout(self.readouts[0],  change_irrep_out="1x1o", cueq_config=cueq_config)
+                    # _copy_mace_readout(readout,  change_irrep_out="1x1o", cueq_config=cueq_config)
+                    _copy_mace_readout(
+                        self.readouts[0],
+                        change_irrep_out="1x1o",
+                        cueq_config=cueq_config,
+                    )
                 )
             if self.use_quads:
                 mace_irreps = str(self.readouts[0].linear.irreps_in)
                 if "2e" in mace_irreps:
                     logging.info("Using l=2 readout to predict quadrupoles.")
-                    change_of_basis_quads = ReducedTensorProducts('ij=ji', i="1o", filter_ir_out=['2e']).change_of_basis
+                    change_of_basis_quads = ReducedTensorProducts(
+                        "ij=ji", i="1o", filter_ir_out=["2e"]
+                    ).change_of_basis
                     self.les_quad_2e_readouts.append(
-                        _copy_mace_readout(self.readouts[0], change_irrep_out="1x2e", cueq_config=cueq_config)
+                        _copy_mace_readout(
+                            self.readouts[0],
+                            change_irrep_out="1x2e",
+                            cueq_config=cueq_config,
+                        )
                     )
                     self.register_buffer("change_of_basis_quads", change_of_basis_quads)
                 if "1o" in mace_irreps:
                     logging.info("Using l=1 readout to predict quadrupoles.")
                     self.les_quad_1o_readouts.append(
-                        _copy_mace_readout_tp(self.readouts[0],
-                        use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
-                        make_w_pos=False,
-                        cueq_config=cueq_config
+                        _copy_mace_readout_tp(
+                            self.readouts[0],
+                            use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
+                            make_w_pos=False,
+                            cueq_config=cueq_config,
                         )
                     )
             if self.use_induced_charges:
@@ -220,24 +237,39 @@ class MACELES(ScaleShiftMACE):
                 if self.use_anisotropic_polarizability:
                     mace_irreps = str(self.readouts[0].linear.irreps_in)
                     if "2e" in mace_irreps and "2e" in self.alpha_irreps:
-                        logging.info("Using l=2 readout to predict anisotropic polarizability.")
-                        change_of_basis = CartesianTensor("ij=ji").reduced_tensor_products().change_of_basis
+                        logging.info(
+                            "Using l=2 readout to predict anisotropic polarizability."
+                        )
+                        change_of_basis = (
+                            CartesianTensor("ij=ji")
+                            .reduced_tensor_products()
+                            .change_of_basis
+                        )
                         self.les_alpha_2e_readouts.append(
-                            _copy_mace_readout(self.readouts[0], change_irrep_out="1x0e + 1x2e", cueq_config=cueq_config)
+                            _copy_mace_readout(
+                                self.readouts[0],
+                                change_irrep_out="1x0e + 1x2e",
+                                cueq_config=cueq_config,
+                            )
                         )
                         self.register_buffer("change_of_basis", change_of_basis)
                     if "1o" in mace_irreps and "1o" in self.alpha_irreps:
-                        #Obtain 2e from l=1 outer products
-                        logging.info("Using l=1 readout to predict anisotropic polarizability.")
+                        # Obtain 2e from l=1 outer products
+                        logging.info(
+                            "Using l=1 readout to predict anisotropic polarizability."
+                        )
                         self.les_alpha_1o_readouts.append(
-                            _copy_mace_readout_tp(self.readouts[0],
-                            use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
-                            make_w_pos=self.alpha_1o_linear_w_pos,
-                            cueq_config=cueq_config
+                            _copy_mace_readout_tp(
+                                self.readouts[0],
+                                use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
+                                make_w_pos=self.alpha_1o_linear_w_pos,
+                                cueq_config=cueq_config,
                             )
                         )
                     if not ("1o" in mace_irreps or "2e" in mace_irreps):
-                        raise ValueError("Unsupported irreps for anisotropic polarizability. Expected '1o' or '2e' in the readout irreps.")
+                        raise ValueError(
+                            "Unsupported irreps for anisotropic polarizability. Expected '1o' or '2e' in the readout irreps."
+                        )
                 if not self.use_anisotropic_polarizability or "0e" in self.alpha_irreps:
                     self.les_alpha_readouts.append(
                         _copy_mace_readout(readout, cueq_config=cueq_config)
@@ -285,11 +317,11 @@ class MACELES(ScaleShiftMACE):
 
         # for backward compatibility
         if not hasattr(self, "les_output_scale"):
-            self.les_output_scale = 1.
+            self.les_output_scale = 1.0
         if not hasattr(self, "les_kappa_scale"):
-            self.les_kappa_scale = 1.
+            self.les_kappa_scale = 1.0
         if not hasattr(self, "les_alpha_scale"):
-            self.les_alpha_scale = 1.
+            self.les_alpha_scale = 1.0
         if not hasattr(self, "use_anisotropic_polarizability"):
             self.use_anisotropic_polarizability = False
 
@@ -299,14 +331,16 @@ class MACELES(ScaleShiftMACE):
         no_pbc_mask_cfg = ~pbc_tensor.any(dim=-1)
         no_pbc_mask_rows = no_pbc_mask_cfg.repeat_interleave(3)
         cell_les[no_pbc_mask_rows] = torch.zeros(
-            (no_pbc_mask_rows.sum(), 3),
-            dtype=cell_les.dtype,
-            device=cell_les.device
+            (no_pbc_mask_rows.sum(), 3), dtype=cell_les.dtype, device=cell_les.device
         )
         if displacement is not None:
-            symmetric_displacement = 0.5 * (displacement + displacement.transpose(-1, -2))
+            symmetric_displacement = 0.5 * (
+                displacement + displacement.transpose(-1, -2)
+            )
             cell_les_view = cell_les.view(-1, 3, 3)
-            cell_les_view = cell_les_view + torch.matmul(cell_les_view, symmetric_displacement)
+            cell_les_view = cell_les_view + torch.matmul(
+                cell_les_view, symmetric_displacement
+            )
             cell_les = cell_les_view.view_as(cell_les)
 
         # Atomic energies
@@ -398,62 +432,81 @@ class MACELES(ScaleShiftMACE):
             ]
             node_qs = les_readout(node_feats_list[feat_idx], node_heads)[
                 num_atoms_arange, node_heads
-            ]  # type:ignore
+            ]  # type: ignore
             node_qs_list.append(node_qs)
             node_es_list.append(node_es)
             if hasattr(self, "use_dipoles") and self.use_dipoles:
                 les_u_readout = self.les_u_readouts[i]
                 node_us = les_u_readout(node_feats_list[feat_idx])[
                     num_atoms_arange
-                ]  # type:ignore
+                ]  # type: ignore
                 node_us_list.append(node_us)
-                #print('dipoles', i, node_us[:3])
+                # print('dipoles', i, node_us[:3])
             if hasattr(self, "use_induced_charges") and self.use_induced_charges:
                 les_kappa_readout = self.les_kappa_readouts[i]
                 node_kappas = les_kappa_readout(node_feats_list[feat_idx], node_heads)[
                     num_atoms_arange, node_heads
-                    ]  # type:ignore
+                ]  # type: ignore
                 node_kappas_list.append(node_kappas)
             if hasattr(self, "use_quads"):
-                if hasattr(self, "les_quad_2e_readouts") and len(self.les_quad_2e_readouts) > i:
+                if (
+                    hasattr(self, "les_quad_2e_readouts")
+                    and len(self.les_quad_2e_readouts) > i
+                ):
                     les_quad_readout = self.les_quad_2e_readouts[i]
                     node_quads = les_quad_readout(node_feats_list[feat_idx])[
                         num_atoms_arange
-                    ]  # type:ignore
+                    ]  # type: ignore
                     node_quads = spherical_to_cartesian(
                         node_quads, self.change_of_basis_quads
                     )
                     node_quads_list.append(node_quads)
-                if hasattr(self, "les_quad_1o_readouts") and len(self.les_quad_1o_readouts) > i:
+                if (
+                    hasattr(self, "les_quad_1o_readouts")
+                    and len(self.les_quad_1o_readouts) > i
+                ):
                     les_quad_readout = self.les_quad_1o_readouts[i]
                     node_quads = les_quad_readout(node_feats_list[feat_idx])[
                         num_atoms_arange
-                    ]  # type:ignore
+                    ]  # type: ignore
                     node_quads_list.append(node_quads)
             if hasattr(self, "use_induced_dipoles") and self.use_induced_dipoles:
-                if hasattr(self, "les_alpha_1o_readouts") and len(self.les_alpha_1o_readouts) > i:
+                if (
+                    hasattr(self, "les_alpha_1o_readouts")
+                    and len(self.les_alpha_1o_readouts) > i
+                ):
                     les_alpha_readout = self.les_alpha_1o_readouts[i]
                     node_alphas = les_alpha_readout(node_feats_list[feat_idx])[
                         num_atoms_arange
-                        ]  # type:ignore
+                    ]  # type: ignore
                     node_alphas_list.append(node_alphas)
-                if hasattr(self, "les_alpha_2e_readouts") and len(self.les_alpha_2e_readouts) > i:
+                if (
+                    hasattr(self, "les_alpha_2e_readouts")
+                    and len(self.les_alpha_2e_readouts) > i
+                ):
                     les_alpha_readout = self.les_alpha_2e_readouts[i]
                     node_alphas = les_alpha_readout(node_feats_list[feat_idx])[
                         num_atoms_arange
-                        ]  # type:ignore
+                    ]  # type: ignore
                     node_alphas = spherical_to_cartesian(
                         node_alphas, self.change_of_basis
                     )
                     node_alphas_list.append(node_alphas)
                 if len(self.les_alpha_readouts) > i:
                     les_alpha_readout = self.les_alpha_readouts[i]
-                    node_alphas = les_alpha_readout(node_feats_list[feat_idx], node_heads)[
+                    node_alphas = les_alpha_readout(
+                        node_feats_list[feat_idx], node_heads
+                    )[
                         num_atoms_arange, node_heads
-                        ]  # type:ignore
-                    if hasattr(self, "use_anisotropic_polarizability") and self.use_anisotropic_polarizability:
-                        eye = torch.eye(3,device=node_alphas.device)
-                        node_alphas = node_alphas.unsqueeze(-1).unsqueeze(-1) * eye.unsqueeze(0)
+                    ]  # type: ignore
+                    if (
+                        hasattr(self, "use_anisotropic_polarizability")
+                        and self.use_anisotropic_polarizability
+                    ):
+                        eye = torch.eye(3, device=node_alphas.device)
+                        node_alphas = node_alphas.unsqueeze(-1).unsqueeze(
+                            -1
+                        ) * eye.unsqueeze(0)
                     node_alphas_list.append(node_alphas)
 
         node_feats_out = torch.cat(node_feats_list, dim=-1)
@@ -464,20 +517,31 @@ class MACELES(ScaleShiftMACE):
         total_energy = e0 + inter_e
         node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
-        les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1) * self.les_output_scale
+        les_q = (
+            torch.sum(torch.stack(node_qs_list, dim=1), dim=1) * self.les_output_scale
+        )
         if len(node_us_list) > 0:
-            les_u = torch.sum(torch.stack(node_us_list, dim=-1), dim=-1) * self.les_output_scale
+            les_u = (
+                torch.sum(torch.stack(node_us_list, dim=-1), dim=-1)
+                * self.les_output_scale
+            )
         else:
             les_u = None
 
         if len(node_kappas_list) > 0:
-            les_kappa = torch.sum(torch.stack(node_kappas_list, dim=1), dim=1) * self.les_kappa_scale
+            les_kappa = (
+                torch.sum(torch.stack(node_kappas_list, dim=1), dim=1)
+                * self.les_kappa_scale
+            )
         else:
             les_kappa = None
 
         if len(node_quads_list) > 0:
-            les_quad = torch.sum(torch.stack(node_quads_list, dim=1), dim=1) * self.les_output_scale
-            #Make quads traceless:
+            les_quad = (
+                torch.sum(torch.stack(node_quads_list, dim=1), dim=1)
+                * self.les_output_scale
+            )
+            # Make quads traceless:
             traces = les_quad.diagonal(dim1=-1, dim2=-2).sum(dim=1)
             eye = torch.eye(3, device=les_quad.device)
             les_quad = les_quad - eye[None, :, :] * traces[:, None, None] / 3
@@ -485,17 +549,32 @@ class MACELES(ScaleShiftMACE):
             les_quad = None
 
         if len(node_alphas_list) > 0:
-            les_alpha = torch.sum(torch.stack(node_alphas_list, dim=1), dim=1) * self.les_alpha_scale
-            #print('les_alpha', les_alpha.shape, les_alpha[:3])
+            les_alpha = (
+                torch.sum(torch.stack(node_alphas_list, dim=1), dim=1)
+                * self.les_alpha_scale
+            )
+            # print('les_alpha', les_alpha.shape, les_alpha[:3])
         else:
             les_alpha = None
 
-        if hasattr(self, 'make_alpha_positive') and self.make_alpha_positive and les_alpha is not None:
+        if (
+            hasattr(self, "make_alpha_positive")
+            and self.make_alpha_positive
+            and les_alpha is not None
+        ):
             if les_alpha.dim() == 2:
                 les_alpha = les_alpha**2
-            if les_alpha.dim() == 3 and les_alpha.shape[1] == 3 and les_alpha.shape[2] == 3:
+            if (
+                les_alpha.dim() == 3
+                and les_alpha.shape[1] == 3
+                and les_alpha.shape[2] == 3
+            ):
                 les_alpha = torch.einsum("nij,nkj->nik", les_alpha, les_alpha)
-        if hasattr(self, 'make_kappa_positive') and self.make_kappa_positive and les_kappa is not None:
+        if (
+            hasattr(self, "make_kappa_positive")
+            and self.make_kappa_positive
+            and les_kappa is not None
+        ):
             les_kappa = les_kappa**2
 
         les_positions = data["positions"] if displacement is not None else positions
@@ -566,6 +645,8 @@ class MACELES(ScaleShiftMACE):
             "latent_quads": les_quad,
             "BEC": les_result["BEC"],
         }
+
+
 def _permute_to_e3nn_convention(x: torch.Tensor) -> torch.Tensor:
     return x[..., torch.LongTensor([1, 2, 0]).to(x.device)]
 

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Any, Dict, List, Optional
 
 import torch
 from e3nn import o3
+from e3nn.io import CartesianTensor
+from e3nn.o3._reduce import ReducedTensorProducts
 from e3nn.util.jit import compile_mode
 
 try:
@@ -18,8 +21,10 @@ except (ImportError, ModuleNotFoundError):
     GRAPH_LONGRANGE_AVAILABLE = False
 
 from mace.modules.blocks import (
+    LinearLesReadoutBlock,
     LinearReadoutBlock,
     NonLinearBiasReadoutBlock,
+    NonLinearLesReadoutBlock,
     NonLinearReadoutBlock,
 )
 from mace.modules.models import ScaleShiftMACE
@@ -35,6 +40,7 @@ from mace.modules.wrapper_ops import (
     TransposeIrrepsLayoutWrapper,
 )
 from mace.tools.scatter import scatter_mean, scatter_sum
+from mace.tools.torch_tools import spherical_to_cartesian
 
 from .field_blocks import (
     EnvironmentDependentSpinSourceBlock,
@@ -46,42 +52,80 @@ from .utils import compute_total_charge_dipole_permuted
 
 
 def _copy_mace_readout(
-    mace_readout: torch.nn.Module, cueq_config: Optional[CuEquivarianceConfig] = None
+    mace_readout: torch.nn.Module,
+    change_irrep_out: Optional[str] = None, # o3.Irreps("1x1o")
+    cueq_config: Optional[CuEquivarianceConfig] = None
 ) -> torch.nn.Module:
     """
     Helper function to copy a MACE readout block.
     """
     if isinstance(mace_readout, LinearReadoutBlock):
         return LinearReadoutBlock(
-            irreps_in=mace_readout.linear.irreps_in,  # type: ignore
-            irrep_out=mace_readout.linear.irreps_out,  # type: ignore
+            irreps_in=mace_readout.linear.irreps_in,  # type:ignore
+            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear.irreps_out,  # type:ignore
             cueq_config=cueq_config,
         )
-    if isinstance(mace_readout, NonLinearReadoutBlock):  # type: ignore
+    if isinstance(mace_readout, NonLinearReadoutBlock):  # type:ignore
         return NonLinearReadoutBlock(
-            irreps_in=mace_readout.linear_1.irreps_in,  # type: ignore
+            irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
             MLP_irreps=mace_readout.hidden_irreps,
             gate=mace_readout.non_linearity._modules["acts"][  # pylint: disable=W0212
                 0
             ].f,
-            irrep_out=mace_readout.linear_2.irreps_out,  # type: ignore
+            irrep_out=o3.Irreps(change_irrep_out) if change_irrep_out is not None else mace_readout.linear_2.irreps_out,  # type:ignore
             num_heads=mace_readout.num_heads,
             cueq_config=cueq_config,
         )
     raise TypeError("Unsupported readout type.")
 
+def _copy_mace_readout_tp(
+    mace_readout: torch.nn.Module,
+    make_w_pos: bool = True,
+    cueq_config: Optional[CuEquivarianceConfig] = None,
+    use_nonlinear_readout: bool = False,
+) -> torch.nn.Module:
+    """
+    Helper function to copy a MACE readout block.
+    """
+    logging.debug(f"use_nonlinear_readout for alpha? {use_nonlinear_readout}")
+    if isinstance(mace_readout, LinearReadoutBlock):
+        if use_nonlinear_readout:
+            return NonLinearLesReadoutBlock(
+                irreps_in=mace_readout.linear.irreps_in,  # type:ignore
+                cueq_config=cueq_config,
+            )
+        return LinearLesReadoutBlock(
+            irreps_in=mace_readout.linear.irreps_in,  # type:ignore
+            make_w_pos=make_w_pos,
+            cueq_config=cueq_config,
+        )
+    if isinstance(mace_readout, NonLinearReadoutBlock):  # type:ignore
+        if use_nonlinear_readout:
+            return NonLinearLesReadoutBlock(
+                irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+                cueq_config=cueq_config,
+            )
+        return LinearLesReadoutBlock(
+            irreps_in=mace_readout.linear_1.irreps_in,  # type:ignore
+            make_w_pos=make_w_pos,
+            cueq_config=cueq_config,
+        )
+    raise TypeError("Unsupported readout type.")
 
 def _get_readout_input_dim(block: torch.nn.Module) -> int:
     if isinstance(block, LinearReadoutBlock):
-        return block.linear.irreps_in.dim  # type: ignore
-    if isinstance(block, NonLinearReadoutBlock):  # type: ignore
-        return block.linear_1.irreps_in.dim  # type: ignore
+        return block.linear.irreps_in.dim  # type:ignore
+    if isinstance(block, NonLinearReadoutBlock):  # type:ignore
+        return block.linear_1.irreps_in.dim  # type:ignore
     raise TypeError("Unsupported readout type for input dimension retrieval.")
 
 
 @compile_mode("script")
 class MACELES(ScaleShiftMACE):
     def __init__(self, les_arguments: Optional[Dict] = None, **kwargs):
+        # MACELES requires full irreps at all interaction layers so that LES
+        # readout blocks can access vector features (e.g. dipoles, quadrupoles).
+        kwargs["keep_last_layer_irreps"] = True
         super().__init__(**kwargs)
         try:
             from les import Les
@@ -93,16 +137,95 @@ class MACELES(ScaleShiftMACE):
             les_arguments = {"use_atomwise": False}
         self.compute_bec = les_arguments.get("compute_bec", False)
         self.bec_output_index = les_arguments.get("bec_output_index", None)
+        self.use_dipoles = les_arguments.get("use_dipole", False)
+        self.use_quads = les_arguments.get("use_quad", False)
+        self.use_induced_charges = les_arguments.get("use_induced_charge", False)
+        self.use_induced_dipoles = les_arguments.get("use_induced_dipole", False)
+        self.use_anisotropic_polarizability = les_arguments.get("use_anisotropic_polarizability", False)
+        self.alpha_irreps = les_arguments.get("alpha_irreps", '0e+1o+2e')
+        self.alpha_1o_nonlinear_readout = les_arguments.get("alpha_1o_nonlinear_readout", False)
+        self.alpha_1o_linear_w_pos = les_arguments.get("alpha_1o_linear_w_pos", True)
+        self.make_alpha_positive = les_arguments.get("make_alpha_positive", False)
+        self.make_kappa_positive = les_arguments.get("make_kappa_positive", False)
+
+        logging.info(f"use_dipoles {self.use_dipoles}")
+        logging.info(f"use_induced_charges {self.use_induced_charges}")
+        logging.info(f"use_induced_dipoles {self.use_induced_dipoles}")
         self.les = Les(les_arguments=les_arguments)
+
         self.les_readouts = torch.nn.ModuleList()
+        self.les_u_readouts = torch.nn.ModuleList()
+        self.les_quad_2e_readouts = torch.nn.ModuleList()
+        self.les_quad_1o_readouts = torch.nn.ModuleList()
+        self.les_alpha_readouts = torch.nn.ModuleList()
+        self.les_alpha_1o_readouts = torch.nn.ModuleList()
+        self.les_alpha_2e_readouts = torch.nn.ModuleList()
+        self.les_kappa_readouts = torch.nn.ModuleList()
+        self.les_output_scale = les_arguments.get("output_scale", 0.1)
+        self.les_kappa_scale = les_arguments.get("kappa_scale", 0.01)
+        self.les_alpha_scale = les_arguments.get("alpha_scale", 0.01)
+
         self.readout_input_dims = [
-            _get_readout_input_dim(readout) for readout in self.readouts  # type: ignore
+            _get_readout_input_dim(readout) for readout in self.readouts  # type:ignore
         ]
         cueq_config = kwargs.get("cueq_config", None)
-        for readout in self.readouts:  # type: ignore
+        for readout in self.readouts:  # type:ignore
             self.les_readouts.append(
                 _copy_mace_readout(readout, cueq_config=cueq_config)
             )
+            if self.use_dipoles:
+                self.les_u_readouts.append(
+                    #_copy_mace_readout(readout,  change_irrep_out="1x1o", cueq_config=cueq_config)
+                    _copy_mace_readout(self.readouts[0],  change_irrep_out="1x1o", cueq_config=cueq_config)
+                )
+            if self.use_quads:
+                mace_irreps = str(self.readouts[0].linear.irreps_in)
+                if "2e" in mace_irreps:
+                    logging.info("Using l=2 readout to predict quadrupoles.")
+                    change_of_basis_quads = ReducedTensorProducts('ij=ji', i="1o", filter_ir_out=['2e']).change_of_basis
+                    self.les_quad_2e_readouts.append(
+                        _copy_mace_readout(self.readouts[0], change_irrep_out="1x2e", cueq_config=cueq_config)
+                    )
+                    self.register_buffer("change_of_basis_quads", change_of_basis_quads)
+                if "1o" in mace_irreps:
+                    logging.info("Using l=1 readout to predict quadrupoles.")
+                    self.les_quad_1o_readouts.append(
+                        _copy_mace_readout_tp(self.readouts[0],
+                        use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
+                        make_w_pos=False,
+                        cueq_config=cueq_config
+                        )
+                    )
+            if self.use_induced_charges:
+                self.les_kappa_readouts.append(
+                    _copy_mace_readout(readout, cueq_config=cueq_config)
+                )
+            if self.use_induced_dipoles:
+                if self.use_anisotropic_polarizability:
+                    mace_irreps = str(self.readouts[0].linear.irreps_in)
+                    if "2e" in mace_irreps and "2e" in self.alpha_irreps:
+                        logging.info("Using l=2 readout to predict anisotropic polarizability.")
+                        change_of_basis = CartesianTensor("ij=ji").reduced_tensor_products().change_of_basis
+                        self.les_alpha_2e_readouts.append(
+                            _copy_mace_readout(self.readouts[0], change_irrep_out="1x0e + 1x2e", cueq_config=cueq_config)
+                        )
+                        self.register_buffer("change_of_basis", change_of_basis)
+                    if "1o" in mace_irreps and "1o" in self.alpha_irreps:
+                        #Obtain 2e from l=1 outer products
+                        logging.info("Using l=1 readout to predict anisotropic polarizability.")
+                        self.les_alpha_1o_readouts.append(
+                            _copy_mace_readout_tp(self.readouts[0],
+                            use_nonlinear_readout=self.alpha_1o_nonlinear_readout,
+                            make_w_pos=self.alpha_1o_linear_w_pos,
+                            cueq_config=cueq_config
+                            )
+                        )
+                    if not ("1o" in mace_irreps or "2e" in mace_irreps):
+                        raise ValueError("Unsupported irreps for anisotropic polarizability. Expected '1o' or '2e' in the readout irreps.")
+                if not self.use_anisotropic_polarizability or "0e" in self.alpha_irreps:
+                    self.les_alpha_readouts.append(
+                        _copy_mace_readout(readout, cueq_config=cueq_config)
+                    )
 
     def forward(
         self,
@@ -125,6 +248,7 @@ class MACELES(ScaleShiftMACE):
             compute_displacement=compute_displacement,
             lammps_mliap=lammps_mliap,
         )
+
         is_lammps = ctx.is_lammps
         num_atoms_arange = ctx.num_atoms_arange
         num_graphs = ctx.num_graphs
@@ -138,14 +262,36 @@ class MACELES(ScaleShiftMACE):
         lammps_natoms = interaction_kwargs.lammps_natoms
         lammps_class = interaction_kwargs.lammps_class
 
+        e_ext = data.get("external_field", None)
+        # external_field may default to zeros(1,3) from atomic_data.py; treat as None
+        if e_ext is not None and not e_ext.any():
+            e_ext = None
+
+        # for backward compatibility
+        if not hasattr(self, "les_output_scale"):
+            self.les_output_scale = 1.
+        if not hasattr(self, "les_kappa_scale"):
+            self.les_kappa_scale = 1.
+        if not hasattr(self, "les_alpha_scale"):
+            self.les_alpha_scale = 1.
+        if not hasattr(self, "use_anisotropic_polarizability"):
+            self.use_anisotropic_polarizability = False
+
         # Setting LES cell input to zero when boundary conditions are not periodic
         cell_les = cell.clone()
         pbc_tensor = data["pbc"].to(device=data["cell"].device)
         no_pbc_mask_cfg = ~pbc_tensor.any(dim=-1)
         no_pbc_mask_rows = no_pbc_mask_cfg.repeat_interleave(3)
         cell_les[no_pbc_mask_rows] = torch.zeros(
-            (no_pbc_mask_rows.sum(), 3), dtype=cell_les.dtype, device=cell_les.device
+            (no_pbc_mask_rows.sum(), 3),
+            dtype=cell_les.dtype,
+            device=cell_les.device
         )
+        if displacement is not None:
+            symmetric_displacement = 0.5 * (displacement + displacement.transpose(-1, -2))
+            cell_les_view = cell_les.view(-1, 3, 3)
+            cell_les_view = cell_les_view + torch.matmul(cell_les_view, symmetric_displacement)
+            cell_les = cell_les_view.view_as(cell_les)
 
         # Atomic energies
         node_e0 = self.atomic_energies_fn(data["node_attrs"])[
@@ -198,6 +344,10 @@ class MACELES(ScaleShiftMACE):
         node_es_list = [pair_node_energy]
         node_feats_list: List[torch.Tensor] = []
         node_qs_list: List[torch.Tensor] = []
+        node_us_list: List[torch.Tensor] = []
+        node_quads_list: List[torch.Tensor] = []
+        node_kappas_list: List[torch.Tensor] = []
+        node_alphas_list: List[torch.Tensor] = []
 
         for i, (interaction, product) in enumerate(
             zip(self.interactions, self.products)
@@ -232,9 +382,63 @@ class MACELES(ScaleShiftMACE):
             ]
             node_qs = les_readout(node_feats_list[feat_idx], node_heads)[
                 num_atoms_arange, node_heads
-            ]  # type: ignore
+            ]  # type:ignore
             node_qs_list.append(node_qs)
             node_es_list.append(node_es)
+            if hasattr(self, "use_dipoles") and self.use_dipoles:
+                les_u_readout = self.les_u_readouts[i]
+                node_us = les_u_readout(node_feats_list[feat_idx])[
+                    num_atoms_arange
+                ]  # type:ignore
+                node_us_list.append(node_us)
+                #print('dipoles', i, node_us[:3])
+            if hasattr(self, "use_induced_charges") and self.use_induced_charges:
+                les_kappa_readout = self.les_kappa_readouts[i]
+                node_kappas = les_kappa_readout(node_feats_list[feat_idx], node_heads)[
+                    num_atoms_arange, node_heads
+                    ]  # type:ignore
+                node_kappas_list.append(node_kappas)
+            if hasattr(self, "use_quads"):
+                if hasattr(self, "les_quad_2e_readouts") and len(self.les_quad_2e_readouts) > i:
+                    les_quad_readout = self.les_quad_2e_readouts[i]
+                    node_quads = les_quad_readout(node_feats_list[feat_idx])[
+                        num_atoms_arange
+                    ]  # type:ignore
+                    node_quads = spherical_to_cartesian(
+                        node_quads, self.change_of_basis_quads
+                    )
+                    node_quads_list.append(node_quads)
+                if hasattr(self, "les_quad_1o_readouts") and len(self.les_quad_1o_readouts) > i:
+                    les_quad_readout = self.les_quad_1o_readouts[i]
+                    node_quads = les_quad_readout(node_feats_list[feat_idx])[
+                        num_atoms_arange
+                    ]  # type:ignore
+                    node_quads_list.append(node_quads)
+            if hasattr(self, "use_induced_dipoles") and self.use_induced_dipoles:
+                if hasattr(self, "les_alpha_1o_readouts") and len(self.les_alpha_1o_readouts) > i:
+                    les_alpha_readout = self.les_alpha_1o_readouts[i]
+                    node_alphas = les_alpha_readout(node_feats_list[feat_idx])[
+                        num_atoms_arange
+                        ]  # type:ignore
+                    node_alphas_list.append(node_alphas)
+                if hasattr(self, "les_alpha_2e_readouts") and len(self.les_alpha_2e_readouts) > i:
+                    les_alpha_readout = self.les_alpha_2e_readouts[i]
+                    node_alphas = les_alpha_readout(node_feats_list[feat_idx])[
+                        num_atoms_arange
+                        ]  # type:ignore
+                    node_alphas = spherical_to_cartesian(
+                        node_alphas, self.change_of_basis
+                    )
+                    node_alphas_list.append(node_alphas)
+                if len(self.les_alpha_readouts) > i:
+                    les_alpha_readout = self.les_alpha_readouts[i]
+                    node_alphas = les_alpha_readout(node_feats_list[feat_idx], node_heads)[
+                        num_atoms_arange, node_heads
+                        ]  # type:ignore
+                    if hasattr(self, "use_anisotropic_polarizability") and self.use_anisotropic_polarizability:
+                        eye = torch.eye(3,device=node_alphas.device)
+                        node_alphas = node_alphas.unsqueeze(-1).unsqueeze(-1) * eye.unsqueeze(0)
+                    node_alphas_list.append(node_alphas)
 
         node_feats_out = torch.cat(node_feats_list, dim=-1)
         node_inter_es = torch.sum(torch.stack(node_es_list, dim=0), dim=0)
@@ -244,15 +448,55 @@ class MACELES(ScaleShiftMACE):
         total_energy = e0 + inter_e
         node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
-        les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1)
+        les_q = torch.sum(torch.stack(node_qs_list, dim=1), dim=1) * self.les_output_scale
+        if len(node_us_list) > 0:
+            les_u = torch.sum(torch.stack(node_us_list, dim=-1), dim=-1) * self.les_output_scale
+        else:
+            les_u = None
+
+        if len(node_kappas_list) > 0:
+            les_kappa = torch.sum(torch.stack(node_kappas_list, dim=1), dim=1) * self.les_kappa_scale
+        else:
+            les_kappa = None
+
+        if len(node_quads_list) > 0:
+            les_quad = torch.sum(torch.stack(node_quads_list, dim=1), dim=1) * self.les_output_scale
+            #Make quads traceless:
+            traces = les_quad.diagonal(dim1=-1, dim2=-2).sum(dim=1)
+            eye = torch.eye(3, device=les_quad.device)
+            les_quad = les_quad - eye[None, :, :] * traces[:, None, None] / 3
+        else:
+            les_quad = None
+
+        if len(node_alphas_list) > 0:
+            les_alpha = torch.sum(torch.stack(node_alphas_list, dim=1), dim=1) * self.les_alpha_scale
+            #print('les_alpha', les_alpha.shape, les_alpha[:3])
+        else:
+            les_alpha = None
+
+        if hasattr(self, 'make_alpha_positive') and self.make_alpha_positive and les_alpha is not None:
+            if les_alpha.dim() == 2:
+                les_alpha = les_alpha**2
+            if les_alpha.dim() == 3 and les_alpha.shape[1] == 3 and les_alpha.shape[2] == 3:
+                les_alpha = torch.einsum("nij,nkj->nik", les_alpha, les_alpha)
+        if hasattr(self, 'make_kappa_positive') and self.make_kappa_positive and les_kappa is not None:
+            les_kappa = les_kappa**2
+
+        les_positions = data["positions"] if displacement is not None else positions
         les_result = self.les(
+            atomic_numbers=data["atomic_numbers"],
             latent_charges=les_q,
-            positions=positions,
+            latent_dipoles=les_u,
+            latent_quads=les_quad,
+            latent_alphas=les_alpha,
+            latent_kappas=les_kappa,
+            positions=les_positions,
             cell=cell_les.view(-1, 3, 3),
             batch=data["batch"],
             compute_energy=True,
             compute_bec=(compute_bec or self.compute_bec),
             bec_output_index=self.bec_output_index,
+            e_ext=e_ext,
         )
         les_energy_opt = les_result["E_lr"]
         if les_energy_opt is None:
@@ -299,11 +543,13 @@ class MACELES(ScaleShiftMACE):
             "hessian": hessian,
             "node_feats": node_feats_out,
             "les_energy": les_energy,
-            "latent_charges": les_q,
+            "latent_charges": les_result["latent_charges"],
+            "latent_dipoles": les_result["latent_dipoles"],
+            "latent_kappas": les_kappa,
+            "latent_alphas": les_result["latent_alphas"],
+            "latent_quads": les_quad,
             "BEC": les_result["BEC"],
         }
-
-
 def _permute_to_e3nn_convention(x: torch.Tensor) -> torch.Tensor:
     return x[..., torch.LongTensor([1, 2, 0]).to(x.device)]
 

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -39,6 +39,7 @@ from .utils import (
     get_outputs,
     get_symmetric_displacement,
     prepare_graph,
+    safe_double,
 )
 
 
@@ -578,7 +579,7 @@ class ScaleShiftMACE(MACE):
         inter_e = scatter_sum(node_inter_es, data["batch"], dim=-1, dim_size=num_graphs)
 
         total_energy = e0 + inter_e
-        node_energy = node_e0.clone().double() + node_inter_es.clone().double()
+        node_energy = safe_double(node_e0.clone()) + safe_double(node_inter_es.clone())
 
         forces, virials, stress, hessian, edge_forces = get_outputs(
             energy=inter_e,

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -167,7 +167,7 @@ class MACE(torch.nn.Module):
             radial_MLP = [64, 64, 64]
         # Interactions and readout
         self.atomic_energies_fn = AtomicEnergiesBlock(atomic_energies)
-        if num_interactions == 1:
+        if num_interactions == 1 and not keep_last_layer_irreps:
             hidden_irreps_out = str(hidden_irreps[0])
         else:
             hidden_irreps_out = hidden_irreps

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -19,6 +19,17 @@ from mace.tools.torch_geometric.batch import Batch
 from .blocks import AtomicEnergiesBlock
 
 
+def safe_double(t: torch.Tensor) -> torch.Tensor:
+    """Cast to float64 for accumulation precision, except on MPS.
+
+    The Apple-Silicon MPS backend does not support float64, so there the
+    tensor is returned unchanged in its working dtype.
+    """
+    if t.device.type == "mps":
+        return t
+    return t.double()
+
+
 def compute_forces(
     energy: torch.Tensor, positions: torch.Tensor, training: bool = True
 ) -> torch.Tensor:

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -130,13 +130,29 @@ def with_scatter_sum(conv_tp: torch.nn.Module) -> torch.nn.Module:
     conv_tp.forward = types.MethodType(forward, conv_tp)
     return conv_tp
 
+class CueqConvFusionWrapper(torch.nn.Module):
+    """A serializable wrapper around cuet.SegmentedPolynomial / mptp.ff.
 
-def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
-    """Wraps a cuet.ConvTensorProduct to use conv fusion"""
-    conv_tp.original_forward = conv_tp.forward
-    num_segment = conv_tp.m.buffer_num_segments[0]
-    num_operands = conv_tp.m.operand_extent
-    conv_tp.weight_numel = num_segment * num_operands
+    It adapts MACE conv-style forward:
+
+        forward(node_feats, edge_attrs, tp_weights, edge_index)
+
+    to cuEq SegmentedPolynomial forward:
+
+        forward([tp_weights, node_feats, edge_attrs], input_indices, output_shapes, output_indices)
+    """
+
+    def __init__(self, conv_tp: torch.nn.Module):
+        super().__init__()
+        self.conv_tp = conv_tp
+
+        num_segment = conv_tp.m.buffer_num_segments[0]
+        num_operands = conv_tp.m.operand_extent
+        self.weight_numel = num_segment * num_operands
+
+    @property
+    def m(self):
+        return self.conv_tp.m
 
     def forward(
         self,
@@ -147,15 +163,18 @@ def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
     ) -> torch.Tensor:
         sender = edge_index[0]
         receiver = edge_index[1]
-        return self.original_forward(
+
+        return self.conv_tp(
             [tp_weights, node_feats, edge_attrs],
             {1: sender},
             {0: node_feats},
             {0: receiver},
         )[0]
 
-    conv_tp.forward = types.MethodType(forward, conv_tp)
-    return conv_tp
+
+def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
+    """Wraps a cuet.SegmentedPolynomial / ConvTensorProduct to use conv fusion."""
+    return CueqConvFusionWrapper(conv_tp)
 
 
 def with_oeq_conv_fusion(

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -130,6 +130,7 @@ def with_scatter_sum(conv_tp: torch.nn.Module) -> torch.nn.Module:
     conv_tp.forward = types.MethodType(forward, conv_tp)
     return conv_tp
 
+
 class CueqConvFusionWrapper(torch.nn.Module):
     """A serializable wrapper around cuet.SegmentedPolynomial / mptp.ff.
 

--- a/mace/modules/wrapper_ops.py
+++ b/mace/modules/wrapper_ops.py
@@ -4,7 +4,7 @@ Wrapper class for o3.Linear that optionally uses cuet.Linear
 
 import dataclasses
 import types
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import torch
 from e3nn import o3
@@ -143,13 +143,32 @@ class CueqConvFusionWrapper(torch.nn.Module):
         forward([tp_weights, node_feats, edge_attrs], input_indices, output_shapes, output_indices)
     """
 
-    def __init__(self, conv_tp: torch.nn.Module):
+    def __init__(self, conv_tp: torch.nn.Module, polynomial: Any):
         super().__init__()
-        self.conv_tp = conv_tp
 
-        num_segment = conv_tp.m.buffer_num_segments[0]
-        num_operands = conv_tp.m.operand_extent
-        self.weight_numel = num_segment * num_operands
+        # cuet.SegmentedPolynomial silently downgrades to SegmentedPolynomialNaive
+        # when cuequivariance_ops_torch cannot be imported: it warns and sets
+        # .method to "naive" even though uniform_1d was requested. The naive path
+        # has no fused conv, so refuse here instead of letting it surface later,
+        # far from the cause, as a missing attribute on the implementation object.
+        method = getattr(conv_tp, "method", None)
+        if method != "uniform_1d":
+            raise RuntimeError(
+                "cuEquivariance conv fusion needs the uniform_1d kernels, but "
+                f"cuequivariance selected method={method!r} "
+                f"({type(getattr(conv_tp, 'm', None)).__name__}). That means "
+                "cuequivariance_ops_torch could not be imported. Check that the "
+                "installed cueq-cuda-* extra matches torch.version.cuda, and note "
+                "the ops wheel links a specific cuBLAS while declaring only a "
+                "floor, so it can resolve against a cuBLAS it was not built for."
+            )
+
+        self.conv_tp = conv_tp
+        # operands[0] is the weight operand; its size is num_segments * extent,
+        # the same product the fused implementation exposes through
+        # buffer_num_segments/operand_extent. Reading it from the descriptor keeps
+        # this independent of which backend cuequivariance selected.
+        self.weight_numel = polynomial.operands[0].size
 
     @property
     def m(self):
@@ -173,9 +192,9 @@ class CueqConvFusionWrapper(torch.nn.Module):
         )[0]
 
 
-def with_cueq_conv_fusion(conv_tp: torch.nn.Module) -> torch.nn.Module:
+def with_cueq_conv_fusion(conv_tp: torch.nn.Module, polynomial: Any) -> torch.nn.Module:
     """Wraps a cuet.SegmentedPolynomial / ConvTensorProduct to use conv fusion."""
-    return CueqConvFusionWrapper(conv_tp)
+    return CueqConvFusionWrapper(conv_tp, polynomial)
 
 
 def with_oeq_conv_fusion(
@@ -270,19 +289,23 @@ class TensorProduct:
             and (cueq_config.optimize_all or cueq_config.optimize_channelwise)
         ):
             if cueq_config.conv_fusion and use_conv_fusion:
+                polynomial = (
+                    cue.descriptors.channelwise_tensor_product(
+                        cue.Irreps(cueq_config.group, irreps_in1),
+                        cue.Irreps(cueq_config.group, irreps_in2),
+                        cue.Irreps(cueq_config.group, irreps_out),
+                    )
+                    .flatten_coefficient_modes()
+                    .squeeze_modes()
+                    .polynomial
+                )
                 return with_cueq_conv_fusion(
                     cuet.SegmentedPolynomial(
-                        cue.descriptors.channelwise_tensor_product(
-                            cue.Irreps(cueq_config.group, irreps_in1),
-                            cue.Irreps(cueq_config.group, irreps_in2),
-                            cue.Irreps(cueq_config.group, irreps_out),
-                        )
-                        .flatten_coefficient_modes()
-                        .squeeze_modes()
-                        .polynomial,
+                        polynomial,
                         math_dtype=torch.get_default_dtype(),
                         method="uniform_1d",
-                    )
+                    ),
+                    polynomial,
                 )
             return cuet.ChannelWiseTensorProduct(
                 cue.Irreps(cueq_config.group, irreps_in1),

--- a/tests/test_maceles.py
+++ b/tests/test_maceles.py
@@ -14,6 +14,7 @@ from mace.calculators import MACECalculator
 from mace.cli.eval_configs import run as mace_eval_configs_run
 from mace.cli.run_train import run as mace_run
 from mace.modules import interaction_classes
+from mace.modules.blocks import LinearLesReadoutBlock, NonLinearLesReadoutBlock
 from mace.modules.extensions import MACELES
 from mace.modules.models import ScaleShiftMACE
 from mace.tools.arg_parser import build_default_arg_parser
@@ -381,10 +382,72 @@ def test_run_eval_no_bec(tmp_path: Path, maceles_model_path: Path, fitting_confi
     assert len(output_atoms) == len(fitting_configs)
     for at in output_atoms:
         assert isinstance(at, Atoms)
-        # Ensure BEC and latent charges are not present
+        # BEC is gated on --compute_bec, so it must be absent here
         assert "MACE_BEC" not in at.arrays
-        assert "MACE_latent_charges" not in at.arrays
+        # latent charges are always emitted by MACELES, independent of --compute_bec
+        assert "MACE_latent_charges" in at.arrays
         # Check that other expected arrays are present
         assert "MACE_energy" in at.info
         assert "MACE_stress" in at.info
         assert "MACE_forces" in at.arrays
+
+
+def _to_ir_mul(y: torch.Tensor, irreps: o3.Irreps, n: int) -> torch.Tensor:
+    """Re-lay-out a mul_ir feature tensor into cueq's ir_mul order, block by block."""
+    cols = []
+    off = 0
+    for mul, ir in irreps:
+        d = mul * ir.dim
+        block = y[:, off : off + d]
+        if ir.dim == 1:  # scalars are identical in both layouts
+            cols.append(block)
+        else:  # [n, mul, ir.dim] -> [n, ir.dim, mul]
+            cols.append(block.reshape(n, mul, ir.dim).transpose(1, 2).reshape(n, d))
+        off += d
+    return torch.cat(cols, dim=1)
+
+
+@pytest.mark.parametrize("block_cls", [LinearLesReadoutBlock, NonLinearLesReadoutBlock])
+def test_les_readout_equivariance(block_cls):
+    """The predicted 3x3 tensor must rotate as R T R^T under input rotations."""
+    torch.manual_seed(0)
+    irreps = o3.Irreps("8x0e + 4x1o")
+    block = block_cls(irreps).eval()
+
+    x = torch.randn(5, irreps.dim)
+    rot = o3.rand_matrix()
+    x_rot = x @ irreps.D_from_matrix(rot).T
+
+    with torch.no_grad():
+        t = block(x)
+        t_rot = block(x_rot)
+
+    expected = torch.einsum("ij,njk,lk->nil", rot, t, rot)
+    assert t.shape == (5, 3, 3)
+    assert torch.allclose(t_rot, expected, atol=1e-4)
+
+
+@pytest.mark.parametrize("block_cls", [LinearLesReadoutBlock, NonLinearLesReadoutBlock])
+def test_les_readout_layout_invariance(block_cls):
+    """The cueq ir_mul path must recover the same vectors as the e3nn mul_ir path."""
+    torch.manual_seed(0)
+    irreps = o3.Irreps("8x0e + 5x1o")  # non-uniform mult exercises the slice logic
+    block = block_cls(irreps).eval()
+    n = 4
+    y = block.linear(torch.randn(n, irreps.dim))
+
+    is_linear = block_cls is LinearLesReadoutBlock
+    slices = block.vector_1o_slices
+
+    block.ir_mul = False
+    v_mulir = block._collect_vectors(y, slices) if is_linear else block._collect_vectors(y)
+
+    block.ir_mul = True
+    y_irmul = _to_ir_mul(y, irreps, n)
+    v_irmul = (
+        block._collect_vectors(y_irmul, slices)
+        if is_linear
+        else block._collect_vectors(y_irmul)
+    )
+
+    assert torch.allclose(v_mulir, v_irmul, atol=1e-6)


### PR DESCRIPTION
`main` and `develop` have drifted. This brings the four commits that landed on main into develop so the two branches match again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches force computation (BEC + external field), a large MACELES forward path, and breaks `mace_mp(..., damping=...)`; incorrect electrostatic or dielectric logic could silently bias MD/relaxation results.
> 
> **Overview**
> Brings **main** into **develop** with a large **LES / MACELES** update plus several calculator and infrastructure fixes.
> 
> **MACELES** now predicts and passes **latent dipoles, quadrupoles, kappas, and polarizabilities** into the `les` solver, with optional **anisotropic** readouts (`LinearLesReadoutBlock` / `NonLinearLesReadoutBlock`), output scaling, and support for **external electric fields** and **atomic numbers** on the graph. Forces are differentiated through **short-range + LES** energy, with LES cell handling updated for stress/displacement.
> 
> **`MACECalculator`** gains **`compute_bec`**, **`external_field`**, and related options: it can request BEC from the model, expose **LES alphas/kappas**, and **add BEC-derived forces** (with optional high-frequency dielectric correction via `eps_infty`).
> 
> **`eval_configs`** writes additional per-atom arrays when the model returns them (**latent charges/dipoles/kappas/alphas/quads**), with more flexible BEC reshaping.
> 
> **`mace_mp`**: renames **`damping` → `dispersion_damping`** (breaking for callers using the old kwarg) and adds **`dispersion_coord_cutoff`** for D3.
> 
> Smaller changes: **`safe_double`** avoids float64 on MPS; **cuEq conv fusion** is a serializable **`CueqConvFusionWrapper`** with clearer errors; single-interaction models respect **`keep_last_layer_irreps`** for full vector features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be88f10791afe20d7cc3c4c7ca4f1e14f26a0eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->