### PR TITLE
Cap the cuequivariance ops wheels below 0.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,9 +82,18 @@ magnetic =
     torch-geometric
 torchsim =
     torch-sim-atomistic; python_version >= "3.12"
-cueq = cuequivariance-torch>=0.2.0
+# The cueq ops wheels are capped below 0.11. The 0.11 ops binaries link a newer
+# cuBLAS than they declare (metadata says nvidia-cublas>=12.5.0), so pip can
+# satisfy them with the cuBLAS that torch pins -- 13.1.1.3 via cuda-toolkit --
+# and the extension then fails to import. cuequivariance falls back to
+# SegmentedPolynomialNaive on that failure with only a warning, which is why an
+# ops release surfaced as an AttributeError in every cueq test at once.
+# Upper bounds rather than == so patch releases still flow and pip keeps room to
+# resolve. Revisit when the ops metadata is fixed or torch moves its cuBLAS pin.
+cueq = cuequivariance-torch>=0.2.0,<0.12
 oeq = openequivariance
-cueq-cuda-11 = cuequivariance-ops-torch-cu11>=0.2.0
-cueq-cuda-12 = cuequivariance-ops-torch-cu12>=0.2.0
+# cu11 is a dead stream: its last release is 0.5.1.
+cueq-cuda-11 = cuequivariance-ops-torch-cu11>=0.2.0,<0.6
+cueq-cuda-12 = cuequivariance-ops-torch-cu12>=0.2.0,<0.11
 # cu13 ops start at 0.7.0; the cu11/cu12 floors above predate that split.
-cueq-cuda-13 = cuequivariance-ops-torch-cu13>=0.7.0
+cueq-cuda-13 = cuequivariance-ops-torch-cu13>=0.7.0,<0.11


### PR DESCRIPTION
The GPU suite went red on 2026-08-05 with 11 AttributeErrors, on a commit that changed none of the code involved. From the job's install log:

  Collecting nvidia-cublas>=12.5.0 (from cuequivariance-ops-cu13==0.11.0)
    Downloading nvidia_cublas-13.6.1.10 ... then backtracks to
    Downloading nvidia_cublas-13.1.1.3

The 0.11 ops binaries link a newer cuBLAS than their metadata declares, so pip legitimately satisfied them with the cuBLAS torch pins through cuda-toolkit==13.0.3. The extension then could not import, and cuequivariance falls back to SegmentedPolynomialNaive on that failure with only a UserWarning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change in `setup.cfg` with no runtime code paths modified; risk is limited to which cueq wheel versions get installed when using those extras.
> 
> **Overview**
> **Pins cuequivariance optional dependencies** so `pip install` with the `cueq` / `cueq-cuda-*` extras no longer pulls **cuequivariance-ops 0.11**, which was breaking GPU CI with import failures and widespread cueq test `AttributeError`s despite no MACE code changes.
> 
> Adds **upper bounds** on `cuequivariance-torch` (`<0.12`) and on the CUDA ops wheels (`cueq-cuda-12` / `cueq-cuda-13` `<0.11`, `cueq-cuda-11` `<0.6`), plus inline comments documenting the **cuBLAS metadata vs binary mismatch** and the silent fallback to `SegmentedPolynomialNaive`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 097f0aba116aff021dec9668e0a69dccd79bccba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->