### PR TITLE
Strip padding from the per-atom LES calculator outputs

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -470,6 +470,15 @@ class MACECalculator(Calculator):
             "atomic_dipoles",
             "node_feats",
             "fukui_functions",
+            # LES outputs are per-atom too. BEC, latent_alphas and
+            # latent_kappas are the three that reach self.results; the rest
+            # are listed so a future consumer does not inherit padded rows.
+            "BEC",
+            "latent_alphas",
+            "latent_kappas",
+            "latent_charges",
+            "latent_dipoles",
+            "latent_quads",
         }
         sliced: Dict[str, Union[torch.Tensor, None]] = {}
         for key, value in out.items():

--- a/tests/unit/test_padding.py
+++ b/tests/unit/test_padding.py
@@ -85,3 +85,55 @@ class TestBuildFakePaddingGraph:
             water_graph, num_atoms=4, num_edges=8, r_max=3.5
         )
         assert (fake["node_attrs"][:, 0] == 1.0).all()
+
+
+class TestSliceRealOutputs:
+    """Padding must be stripped from every per-atom key the calculator surfaces."""
+
+    N_REAL = 4
+    N_PAD = 9
+
+    def _out(self):
+        n = self.N_PAD
+        return {
+            "energy": torch.zeros(2),
+            "forces": torch.zeros(n, 3),
+            "node_energy": torch.zeros(n),
+            "BEC": torch.zeros(n, 3, 3),
+            "latent_alphas": torch.zeros(n),
+            "latent_kappas": torch.zeros(n),
+            "latent_charges": torch.zeros(n),
+            "latent_dipoles": torch.zeros(n, 3),
+            "latent_quads": torch.zeros(n, 3, 3),
+        }
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "forces",
+            "node_energy",
+            "BEC",
+            "latent_alphas",
+            "latent_kappas",
+            "latent_charges",
+            "latent_dipoles",
+            "latent_quads",
+        ],
+    )
+    def test_atom_level_keys_are_sliced(self, key):
+        from mace.calculators.mace import MACECalculator
+
+        sliced = MACECalculator._slice_real_outputs(self._out(), self.N_REAL)
+        assert sliced[key].shape[0] == self.N_REAL
+
+    def test_bec_forces_are_addable(self):
+        """forces += forces_bec broadcasts only if BEC was sliced like forces."""
+        from mace.calculators.mace import MACECalculator
+
+        sliced = MACECalculator._slice_real_outputs(self._out(), self.N_REAL)
+        forces = sliced["forces"].numpy()
+        forces_bec = np.einsum(
+            "nij,i->nj", sliced["BEC"].numpy(), np.array([0.1, 0.0, 0.0])
+        )
+        forces += forces_bec
+        assert forces.shape == (self.N_REAL, 3)


### PR DESCRIPTION
_slice_real_outputs lists the per-atom keys whose padding rows have to be removed, but it never listed BEC or the latent_* readouts. With atom padding active, those keys keep their padding rows while forces is sliced down to the real atoms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to padding stripping on calculator outputs; only affects padded inference paths and is covered by new unit tests.
> 
> **Overview**
> With **atom padding** enabled for compiled inference, `_slice_real_outputs` now treats **LES readouts** (`BEC`, `latent_alphas`, `latent_kappas`, and related `latent_*` tensors) like other per-atom outputs and keeps only the first `num_real_atoms` rows.
> 
> That aligns **BEC** with **forces** so external-field BEC corrections (`forces += forces_bec`) no longer hit shape/broadcast bugs from leftover padding atoms.
> 
> Adds **`TestSliceRealOutputs`** in `test_padding.py` to parametrize slicing for those keys and to assert BEC–forces addition stays `(N_real, 3)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f0988ff6e499f8e2895842ebc2de5722013227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->