### PR TITLE
Make the nightly's LAMMPS tier and durations upload actually work

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -133,6 +133,16 @@ jobs:
           python -m pip install -U pip
           python -m pip install ".[dev, cueq]"
           python -c "import lammps; print('lammps import OK')"
+      # The conda env activates only in a login shell, and this job's
+      # `defaults.run.shell` does NOT reach steps inside a composite action --
+      # run-tests hardcodes `shell: bash`, so pytest was simply not found
+      # (exit 127) and the real tier never ran a single test. Putting the env's
+      # bin on PATH is what makes it visible to the action.
+      - name: Expose the conda env to non-login shells
+        run: |
+          test -n "$CONDA_PREFIX" || { echo "conda env is not active"; exit 1; }
+          test -x "$CONDA_PREFIX/bin/pytest" || { echo "no pytest in $CONDA_PREFIX"; exit 1; }
+          echo "$CONDA_PREFIX/bin" >> "$GITHUB_PATH"
       - uses: ./.github/actions/run-tests
         with:
           tests: tests/integrations
@@ -215,3 +225,7 @@ jobs:
           name: test-durations
           path: tests/.test_durations
           retention-days: 30
+          # The path is a dotfile and upload-artifact skips hidden files by
+          # default: without this the job stayed green while uploading nothing,
+          # so the committed durations silently went stale.
+          include-hidden-files: true


### PR DESCRIPTION
Two jobs in `nightly.yaml` were green while doing nothing.

`lammps-real` failed with `pytest: command not found`. The conda env only activates in a login shell, and job defaults do not reach steps inside a composite action, so `run-tests` never saw it.
 
`durations-refresh` stored `tests/.test_durations` and then uploaded nothing, because `upload-artifact` skips dotfiles by default. Added `include-hidden-files: true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to PATH and artifact upload flags; no application or security-sensitive code paths.
> 
> **Overview**
> Fixes two **nightly jobs that stayed green while not doing their job**.
> 
> For **`lammps-real`**, adds a step that prepends the active conda env’s `bin` to `GITHUB_PATH` (with checks on `CONDA_PREFIX` and `pytest`) so `run-tests` can find `pytest`. Composite `run-tests` uses plain `bash`, so the job’s login-shell defaults never applied and the tier was failing with “command not found” without running integration tests.
> 
> For **`durations-refresh`**, sets **`include-hidden-files: true`** on the `test-durations` artifact upload so `tests/.test_durations` is actually uploaded instead of being skipped as a dotfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41316c20023c7dd5b59fe7c756ef4400505a1d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->