### PR TITLE
Fix the develop CI failures: forward dtype scope and polar tolerance

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -696,7 +696,13 @@ class MACECalculator(Calculator):
             if getattr(self, "compute_bec", False):
                 model_kwargs["compute_bec"] = True
 
-            out = model(batch_dict, **model_kwargs)
+            # Scoped, not just around batch construction: extensions build
+            # tensors during the forward without an explicit dtype (les does
+            # for its 3x3 identities), so they pick up the process-wide
+            # default. If that disagrees with the model, the mixed dtypes only
+            # surface in the backward, as a dtype error from a linalg op.
+            with torch_tools.default_dtype(self.default_dtype):
+                out = model(batch_dict, **model_kwargs)
             if is_padded:
                 out = self._slice_real_outputs(out, num_real_atoms)
             if i == 0:

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -503,7 +503,11 @@ class MACELES(ScaleShiftMACE):
                         hasattr(self, "use_anisotropic_polarizability")
                         and self.use_anisotropic_polarizability
                     ):
-                        eye = torch.eye(3, device=node_alphas.device)
+                        eye = torch.eye(
+                            3,
+                            device=node_alphas.device,
+                            dtype=node_alphas.dtype,
+                        )
                         node_alphas = node_alphas.unsqueeze(-1).unsqueeze(
                             -1
                         ) * eye.unsqueeze(0)
@@ -543,7 +547,7 @@ class MACELES(ScaleShiftMACE):
             )
             # Make quads traceless:
             traces = les_quad.diagonal(dim1=-1, dim2=-2).sum(dim=1)
-            eye = torch.eye(3, device=les_quad.device)
+            eye = torch.eye(3, device=les_quad.device, dtype=les_quad.dtype)
             les_quad = les_quad - eye[None, :, :] * traces[:, None, None] / 3
         else:
             les_quad = None

--- a/tests/extensions/les/test_maceles.py
+++ b/tests/extensions/les/test_maceles.py
@@ -452,7 +452,12 @@ def test_keep_neutral_does_not_mutate_stored_bec(
         )
         atoms = fitting_configs[2].copy()
         atoms.calc = calc
-        atoms.get_potential_energy()
+        # float64 ambient against a float32 model on purpose. Anything the
+        # forward creates without an explicit dtype follows the process-wide
+        # default, and the resulting mismatch only shows up in the backward.
+        # Leaving this to test ordering made it an intermittent xdist failure.
+        with default_dtype(torch.float64):
+            atoms.get_potential_energy()
         return calc.results["bec"]
 
     bec_neutral = stored_bec(True)

--- a/tests/extensions/polar/test_polar_models.py
+++ b/tests/extensions/polar/test_polar_models.py
@@ -679,6 +679,26 @@ POLAR_COMPONENTS = {
 POLAR_CHECKPOINT_ATOL = {"float32": 5e-4, "float64": 5e-8}
 POLAR_COMPONENT_ATOL = {"float32": 5e-4, "float64": 1e-8}
 
+# The totals compared here are ~2.1e3, where one float32 ulp is 2.4e-4: the
+# absolute tolerances above are TWO ulps for those, which a float32 reduction
+# cannot be expected to survive, since thread count and BLAS kernel both
+# reorder it. The float64 legs agree to 2e-11 relative everywhere this has run
+# (macOS arm64, Linux x86_64, GitHub runners), so the code path is identical
+# and only float32 rounding differs. Add a relative term for the large
+# magnitudes; the absolute floors above still govern the small components, so
+# no comparison in this file gets tighter than it was.
+POLAR_CHECKPOINT_RTOL = {"float32": 1e-5, "float64": 0.0}
+POLAR_COMPONENT_RTOL = {"float32": 1e-5, "float64": 0.0}
+
+
+def _assert_energy_close(actual, expected, atol, rtol, label):
+    tolerance = atol + rtol * abs(expected)
+    delta = abs(actual - expected)
+    assert delta <= tolerance, (
+        f"{label}: got {actual!r}, expected {expected!r} "
+        f"(delta {delta:.3e} > tolerance {tolerance:.3e})"
+    )
+
 
 @pytest.mark.network
 @pytest.mark.parametrize("model_name, expected_energy", POLAR_MODELS)
@@ -696,7 +716,13 @@ def test_polar_checkpoint_evaluates(model_name, expected_energy):
 
     energy = atoms.get_potential_energy()
     assert np.isfinite(energy)
-    assert abs(float(energy) - expected_energy) < POLAR_CHECKPOINT_ATOL["float32"]
+    _assert_energy_close(
+        float(energy),
+        expected_energy,
+        POLAR_CHECKPOINT_ATOL["float32"],
+        POLAR_CHECKPOINT_RTOL["float32"],
+        f"{model_name} float32 checkpoint energy",
+    )
 
 
 @pytest.mark.network
@@ -715,7 +741,13 @@ def test_polar_checkpoint_evaluates_float64(model_name, expected_energy):
 
     energy = atoms.get_potential_energy()
     assert np.isfinite(energy)
-    assert abs(float(energy) - expected_energy) < POLAR_CHECKPOINT_ATOL["float64"]
+    _assert_energy_close(
+        float(energy),
+        expected_energy,
+        POLAR_CHECKPOINT_ATOL["float64"],
+        POLAR_CHECKPOINT_RTOL["float64"],
+        f"{model_name} float64 checkpoint energy",
+    )
 
 
 @pytest.mark.network
@@ -755,10 +787,17 @@ def test_polar_checkpoint_energy_components(dtype_name, dtype, model_name, _):
     }
     expected = POLAR_COMPONENTS[dtype_name][model_name]
     atol = POLAR_COMPONENT_ATOL[dtype_name]
+    rtol = POLAR_COMPONENT_RTOL[dtype_name]
 
     for key, expected_value in expected.items():
         assert np.isfinite(values[key])
-        assert abs(values[key] - expected_value) < atol
+        _assert_energy_close(
+            values[key],
+            expected_value,
+            atol,
+            rtol,
+            f"{model_name} {dtype_name} {key}",
+        )
 
 
 def test_polar_calculator_returns_fukui_functions_by_default():

--- a/tests/extensions/polar/test_polar_models.py
+++ b/tests/extensions/polar/test_polar_models.py
@@ -1202,7 +1202,13 @@ else:
     BENCH_ROOT = Path("")
 
 ATOL_BY_DTYPE = {
-    "float32": 5e-6,
+    # float32 sums in an order that depends on thread count and on which BLAS
+    # kernel is picked, so these references cannot be reproduced bit for bit
+    # across machines. At 5e-6 the X23 set failed on single force components
+    # by a few percent over the bound, on the same commit that passed in a
+    # sibling CI run. 5e-5 keeps about an order of magnitude of headroom and
+    # still catches a real regression, which moves these by far more.
+    "float32": 5e-5,
     "float64": 1e-9,
 }
 


### PR DESCRIPTION
Two unrelated CI failures on develop, both blocking PR #1617.

les: linalg.lu_solve dtype error

Not a flake. MACECalculator scoped default_dtype around batch construction only, so the model forward ran under whatever dtype the process had set globally. Extensions create tensors during the forward without an explicit dtype, les among them for its 3x3 identities, and those follow the process default rather than the model. Type promotion carried the mismatch through the forward, and it only failed in the backward as "linalg.lu_solve: Expected LU and B to have the same dtype".

It needed a preceding test in the same xdist worker to leave the default at float64, which is why it looked intermittent. The in process eval CLI tests do exactly that.

The forward is now scoped too, and the two identities in extensions.py get an explicit dtype so the model is also correct when called directly. The regression test sets the mismatch itself instead of inheriting it from test ordering.

polar: float32 regression tolerance

The hardcoded X23 references were compared at atol=5e-6 with no relative slack. float32 sums in an order that depends on thread count and on the BLAS kernel, so that bound sits inside the spread across machines instead of above it. Worst force deviation measured locally over all 46 structures is 2.3e-6; CI saw 5.1e-6 on succinic acid, on the same commit that passed in a sibling run. 5e-5 clears the worst observed by about an order of magnitude and still fails on a real regression. float64 is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted dtype scoping and test tolerance adjustments; no auth, security, or API contract changes beyond more consistent numerics in LES/BEC paths.
> 
> **Overview**
> Fixes two develop CI failures: **LES dtype mismatches** and **polar float32 regression flakes**.
> 
> **MACECalculator** now wraps the model **forward** (not just batch construction) in `torch_tools.default_dtype(self.default_dtype)`, so extension code that allocates tensors without an explicit dtype (e.g. LES 3×3 identities) matches the model instead of the process default—avoiding backward-only `linalg` dtype errors when a prior test left float64 as the global default. **MACELES** in `extensions.py` also passes `dtype=` into the two `torch.eye(3)` calls used for polarizability and traceless quadrupoles.
> 
> **Tests:** `test_maceles` deliberately runs float64 ambient against a float32 model inside `default_dtype(torch.float64)` so ordering under xdist cannot mask the bug. Polar checkpoint checks use `_assert_energy_close` with float32 **rtol** on large energies; X23 regression **float32 atol** moves from `5e-6` to `5e-5` for BLAS/thread reordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad48721e45ac5da27bf3743c29785d384ee26735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->