### PR TITLE
Fix the magnetic calculator backends and the HDF5 test-set keys

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -994,6 +994,21 @@ class MagneticMACECalculator(Calculator):
         if enable_cueq:
             assert model_type == "MACE", "CuEq only supports MACE models"
             compile_mode = None
+        if enable_cueq and enable_oeq:
+            raise ValueError(
+                "MagneticMACECalculator has no hybrid cueq+oeq path, "
+                "enable only one of them"
+            )
+        # Without these the converters are None and the call below fails as a
+        # TypeError on a NoneType rather than saying what is missing.
+        if enable_cueq and not CUEQQ_AVAILABLE:
+            raise ImportError(
+                "cuequivariance is not installed so CuEq acceleration cannot be used"
+            )
+        if enable_oeq and not OEQ_AVAILABLE:
+            raise ImportError(
+                "openequivariance is not installed so OEq acceleration cannot be used"
+            )
         if "model_path" in kwargs:
             deprecation_message = (
                 "'model_path' argument is deprecated, please use 'model_paths'"
@@ -1061,17 +1076,14 @@ class MagneticMACECalculator(Calculator):
                 raise ValueError("No mace file names supplied")
             self.num_models = len(model_paths)
 
-            # Load models from files
+            # Load models from files. Acceleration is applied once further
+            # down, after the dtype conversion, and covers the `models=`
+            # branch too; converting here as well fed an already-converted
+            # model back into a converter that expects e3nn layout.
             self.models = [
                 torch.load(f=model_path, map_location=device)
                 for model_path in model_paths
             ]
-            if enable_cueq:
-                logging.info("Converting models to CuEq for acceleration")
-                self.models = [
-                    run_e3nn_to_cueq(model, device=device).to(device)
-                    for model in self.models
-                ]
 
         elif models is not None:
             if not isinstance(models, list):
@@ -1187,7 +1199,7 @@ class MagneticMACECalculator(Calculator):
                 run_e3nn_to_cueq(model, device=device).to(device)
                 for model in self.models
             ]
-        if enable_oeq:
+        elif enable_oeq:
             logging.info("Converting models to OEq for acceleration")
             self.models = [
                 run_e3nn_to_oeq(model, device=device).to(device)

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -1060,19 +1060,24 @@ def run(args) -> None:
                     for config in subset
                 ]
         if head_config.test_dir is not None:
+            # Same head-prefixed key as the ASE branch above: two heads whose
+            # test files share a basename would otherwise overwrite each other,
+            # and visualise_train looks the sets up by that prefix.
             if not args.multi_processed_test:
                 test_files = get_files_with_suffix(head_config.test_dir, "_test.h5")
                 for test_file in test_files:
                     name = os.path.splitext(os.path.basename(test_file))[0]
-                    test_sets[name] = data.HDF5Dataset(
+                    test_sets[head_config.head_name + "_" + name] = data.HDF5Dataset(
                         test_file, r_max=args.r_max, z_table=z_table, heads=heads, head=head_config.head_name
                     )
             else:
                 test_folders = glob(head_config.test_dir + "/*")
                 for folder in test_folders:
-                    name = os.path.splitext(os.path.basename(test_file))[0]
-                    test_sets[name] = data.dataset_from_sharded_hdf5(
-                        folder, r_max=args.r_max, z_table=z_table, heads=heads, head=head_config.head_name
+                    name = os.path.splitext(os.path.basename(folder))[0]
+                    test_sets[head_config.head_name + "_" + name] = (
+                        data.dataset_from_sharded_hdf5(
+                            folder, r_max=args.r_max, z_table=z_table, heads=heads, head=head_config.head_name
+                        )
                     )
         for test_name, test_set in test_sets.items():
             test_sampler = None

--- a/tests/extensions/magnetic/test_magmace.py
+++ b/tests/extensions/magnetic/test_magmace.py
@@ -536,3 +536,101 @@ def test_magnetic_mace_registers_all_trainable_parameters():
         train_one_body_contribution=True,
     )
     get_optimizer(args, get_params_options(args, model))
+
+
+# ----------------------------------------------------------
+# Accelerated-backend wiring
+# ----------------------------------------------------------
+def _tiny_magnetic_model():
+    return MagneticScaleShiftMACE(
+        r_max=3.5,
+        num_bessel=4,
+        num_polynomial_cutoff=4,
+        max_ell=2,
+        interaction_cls=interaction_classes[
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock"
+        ],
+        interaction_cls_first=interaction_classes[
+            "MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock"
+        ],
+        num_interactions=1,
+        num_elements=1,
+        hidden_irreps=o3.Irreps("8x0e"),
+        MLP_irreps=o3.Irreps("4x0e"),
+        atomic_energies=np.zeros(1),
+        avg_num_neighbors=1.0,
+        atomic_numbers=[26],
+        correlation=[1],
+        gate=torch.nn.functional.silu,
+        atomic_inter_shift=0.0,
+        atomic_inter_scale=1.0,
+        m_max=[3.0],
+        num_mag_radial_basis=8,
+        num_mag_radial_basis_one_body=10,
+        max_m_ell=1,
+        use_magmom_one_body=False,
+    )
+
+
+def test_magnetic_calculator_rejects_hybrid_backends():
+    """There is no hybrid cueq+oeq path here, so asking for both must not proceed."""
+    with pytest.raises(ValueError, match="hybrid"):
+        MagneticMACECalculator(
+            models=[_tiny_magnetic_model()],
+            device="cpu",
+            enable_cueq=True,
+            enable_oeq=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "flag,available_attr,library",
+    [
+        ("enable_cueq", "CUEQQ_AVAILABLE", "cuequivariance"),
+        ("enable_oeq", "OEQ_AVAILABLE", "openequivariance"),
+    ],
+)
+def test_magnetic_calculator_reports_missing_backend(
+    monkeypatch, flag, available_attr, library
+):
+    """A missing backend is an ImportError, not a TypeError on a None converter."""
+    from mace.calculators import mace as mace_calc_mod
+
+    monkeypatch.setattr(mace_calc_mod, available_attr, False)
+    with pytest.raises(ImportError, match=library):
+        MagneticMACECalculator(
+            models=[_tiny_magnetic_model()],
+            device="cpu",
+            **{flag: True},
+        )
+
+
+def test_magnetic_calculator_converts_to_cueq_once(monkeypatch, tmp_path):
+    """Loading from model_paths used to convert once on load and again later.
+
+    The second call handed an already-converted model to a converter that
+    expects the e3nn layout.
+    """
+    from mace.calculators import mace as mace_calc_mod
+
+    with default_dtype(torch.float32):
+        model_path = tmp_path / "magmace.model"
+        torch.save(_tiny_magnetic_model(), model_path)
+
+    calls = []
+
+    def fake_convert(model, device=None):
+        calls.append(model)
+        return model
+
+    monkeypatch.setattr(mace_calc_mod, "CUEQQ_AVAILABLE", True)
+    monkeypatch.setattr(mace_calc_mod, "run_e3nn_to_cueq", fake_convert)
+
+    MagneticMACECalculator(
+        model_paths=[str(model_path)],
+        device="cpu",
+        default_dtype="float32",
+        enable_cueq=True,
+    )
+
+    assert len(calls) == 1


### PR DESCRIPTION
Three problems reported on PR #1617. 

Double CuEq conversion

MagneticMACECalculator converted models to CuEq twice when they came from model_paths. Once on load, then again after the dtype conversion. The second call handed an already converted model to a converter that expects the e3nn layout. Only the later conversion is kept, since it covers the models= branch too and runs after the dtype change. Asking for cueq and oeq together now raises, because the two separate ifs would have converted twice in a row and there is no hybrid path here.

Missing backend guard

The magnetic calculator never checked that the backend was installed, unlike MACECalculator. A missing library surfaced as a TypeError on a None converter instead of an ImportError naming what to install. The guards now run before model loading.

Test set keys

run_train keyed ASE test sets by head but HDF5 and sharded ones by bare filename. visualise_train picks a head's datasets with head not in name, on both the train/valid and the test dict, so the unprefixed sets were silently dropped from every plot, and two heads sharing a test file basename overwrote each other. The sharded branch also derived its name from test_file, a variable belonging to the other branch's loop, so under --multi_processed_test it raised NameError rather than just mis keying.

Tests

Four new tests cover the calculator changes: the hybrid request, both missing backend cases, and a counting converter asserting exactly one conversion when loading from model_paths. All four fail without the fix.

The run_train change has no direct test. It lives inside run(), which needs a full training run with a test_dir to reach, and no existing test covers that path.

Verification

magnetic 20 passed, unit 280 passed, extensions 52 passed, multihead workflow tests 3 passed. pylint 10.00, black clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect magnetic ASE inference (acceleration wiring) and post-training test/metrics keying for HDF5 paths; mistakes could break CuEq loads or drop test evaluations in multi-head training, but scope is narrow and covered by new tests for the calculator.
> 
> **Overview**
> **MagneticMACECalculator** now matches the main calculator’s expectations for accelerated backends: enabling CuEq and OEq together raises a clear error (no hybrid path), missing `cuequivariance` / `openequivariance` raises **ImportError** instead of failing on a `None` converter, and CuEq/OEq conversion runs **once** after dtype handling for both `model_paths` and `models=` (fixing double CuEq when loading from disk). OEq conversion is **`elif`** so it cannot run after CuEq.
> 
> **`run_train`** registers HDF5 and sharded test datasets under **`{head_name}_{basename}`**, consistent with ASE-built test sets, so multi-head runs do not overwrite shared basenames and `visualise_train` can select tests by head prefix. The sharded `--multi_processed_test` loop now names entries from **`folder`**, fixing a **NameError** from reusing `test_file`.
> 
> Four magnetic extension tests cover hybrid rejection, missing-backend errors, and a single CuEq conversion when loading from `model_paths`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2071488862e1e2b111efb9b5929b302f0afff52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->