### PR TITLE
Measure coverage with PEP 669 monitoring instead of the C tracer

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -91,6 +91,14 @@ runs:
                   --durations-path=tests/.test_durations )
         fi
         if [ "$IN_COVERAGE" = "true" ]; then
+          # PEP 669 monitoring instead of coverage's default C tracer. This is
+          # not a micro-optimisation: cuEquivariance's CPU fallback runs a
+          # torch.fx module of ~55k generated lines per forward, and the C
+          # tracer turns one tests/backends case from 96s into 1989s (20x),
+          # which is what pushed the nightly's full-scope job past its cap.
+          # Measured with sysmon: 98s, and byte-identical totals. Ignored
+          # without harm below 3.12, where sys.monitoring does not exist.
+          export COVERAGE_CORE=sysmon
           args+=( --cov=mace --cov-report=term --cov-report=xml --cov-report=html )
         fi
         if [ "$IN_STORE_DURATIONS" = "true" ]; then


### PR DESCRIPTION
The nightly's `coverage-full` job never finished. It hit its 150 minute cap with pytest still running, after about 100 minutes of per-test timeouts.

The suite is not the problem. cuEquivariance's CPU fallback runs a `torch.fx` module of roughly 55k generated lines on every forward, and coverage's default C tracer walks all of it. Measured on the CI stack (py3.12.13, torch 2.13.0, coverage 7.15.3, cueq 0.11.0), two `test_bidirectional_conversion` cases with `hidden_irreps1`:

| | time |
|---|---|
| no coverage | 96s |
| `--cov`, C tracer | 1989s (20x, so each case blows the 1200s timeout) |
| `--cov`, sysmon | 98s |

Totals are identical between the two cores, so the coverage number does not move. Below Python 3.12 the variable is ignored and coverage uses the C tracer as before, which is why it can live in the shared action instead of per job. Both coverage jobs get faster.

`coverage-full` stays red: three polar assertions in it still fail. The difference is that the job now finishes and prints them, instead of being killed before pytest reports anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only pytest/coverage configuration with no application code changes; older Python versions fall back to the previous tracer.
> 
> **Overview**
> When CI collects coverage, the shared **run-tests** action now sets `COVERAGE_CORE=sysmon` so coverage uses PEP 669’s monitoring API instead of the default C tracer.
> 
> That avoids a ~20× slowdown on heavy `torch.fx` paths (e.g. cuEquivariance CPU fallback in `tests/backends`), which was causing the nightly **coverage-full** job to hit its time limit before pytest finished. Reported coverage totals stay the same; on Python &lt; 3.12 the variable is ignored and behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7005bc9355571ae7b04a5f7ef740bc4081385651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->