### PR TITLE
Bring mace.py back under the module line limit

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -696,11 +696,10 @@ class MACECalculator(Calculator):
             if getattr(self, "compute_bec", False):
                 model_kwargs["compute_bec"] = True
 
-            # Scoped, not just around batch construction: extensions build
-            # tensors during the forward without an explicit dtype (les does
-            # for its 3x3 identities), so they pick up the process-wide
-            # default. If that disagrees with the model, the mixed dtypes only
-            # surface in the backward, as a dtype error from a linalg op.
+            # Scoped here too, not only around batch construction: extensions
+            # create tensors mid-forward without a dtype (les does, for its
+            # 3x3 identities) and would follow the process-wide default. The
+            # mismatch then only surfaces in the backward, from a linalg op.
             with torch_tools.default_dtype(self.default_dtype):
                 out = model(batch_dict, **model_kwargs)
             if is_padded:
@@ -1005,16 +1004,14 @@ class MagneticMACECalculator(Calculator):
                 "MagneticMACECalculator has no hybrid cueq+oeq path, "
                 "enable only one of them"
             )
-        # Without these the converters are None and the call below fails as a
-        # TypeError on a NoneType rather than saying what is missing.
-        if enable_cueq and not CUEQQ_AVAILABLE:
-            raise ImportError(
-                "cuequivariance is not installed so CuEq acceleration cannot be used"
-            )
-        if enable_oeq and not OEQ_AVAILABLE:
-            raise ImportError(
-                "openequivariance is not installed so OEq acceleration cannot be used"
-            )
+        # Without this the converter is None and the call below is a
+        # TypeError on a NoneType instead of naming what is missing.
+        for requested, available, lib in (
+            (enable_cueq, CUEQQ_AVAILABLE, "cuequivariance"),
+            (enable_oeq, OEQ_AVAILABLE, "openequivariance"),
+        ):
+            if requested and not available:
+                raise ImportError(f"{lib} is not installed, cannot accelerate")
         if "model_path" in kwargs:
             deprecation_message = (
                 "'model_path' argument is deprecated, please use 'model_paths'"
@@ -1082,10 +1079,9 @@ class MagneticMACECalculator(Calculator):
                 raise ValueError("No mace file names supplied")
             self.num_models = len(model_paths)
 
-            # Load models from files. Acceleration is applied once further
-            # down, after the dtype conversion, and covers the `models=`
-            # branch too; converting here as well fed an already-converted
-            # model back into a converter that expects e3nn layout.
+            # No conversion here: it happens once further down, after the
+            # dtype change and for the `models=` branch too. Doing it twice
+            # fed a converted model to a converter expecting e3nn layout.
             self.models = [
                 torch.load(f=model_path, map_location=device)
                 for model_path in model_paths


### PR DESCRIPTION
#1619 and #1620 each fit under max-module-lines on their own, but together they put mace.py at 1503, so lint only broke once both had landed.

Trims the comments the two added and folds the duplicated backend-availability check into one loop. No behaviour change. The file is at 1499 of 1500, so the next addition here will hit this again: splitting MagneticMACECalculator into its own module is the actual fix, and is more than a lint unblock should do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and structural refactors with at most minor ImportError message wording changes in MagneticMACECalculator.
> 
> **Overview**
> Brings **`mace/calculators/mace.py`** back under the **max-module-lines** limit (1500) after two prior PRs pushed it over, with **no intended runtime behavior change**.
> 
> **Comment edits** tighten wording around the `default_dtype` scope in `MACECalculator.calculate` (why the forward pass stays inside `torch_tools.default_dtype`) and around **when** e3nn→CuEq/OEq conversion runs when loading from `model_paths`.
> 
> **`MagneticMACECalculator.__init__`** replaces two separate `ImportError` blocks for missing `cuequivariance` / `openequivariance` with a single loop over `(enable_cueq, enable_oeq)`; error text is slightly shorter (`"{lib} is not installed, cannot accelerate"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1fc26cde59fdf45c33f6cc8f34582a341a7879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->