### PR TITLE
Make the SCF wrapper answer for the model it wraps

### DIFF
--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -170,6 +170,16 @@ def run(args: argparse.Namespace) -> None:
     for param in model.parameters():
         param.requires_grad = False
 
+    # Model metadata needs no unwrapping: MagneticSCFMACE delegates attribute
+    # lookup to the model it wraps. Its forward signature is its own, though,
+    # and takes no compute_magforces.
+    if args.return_magforces and hasattr(model, "magmom_mace"):
+        raise ValueError(
+            "--return_magforces is not supported for SCF-wrapped magnetic models: "
+            f"{model.__class__.__name__}.forward does not accept compute_magforces. "
+            "Evaluate the underlying model instead."
+        )
+
     # Load data and prepare input
     atoms_list = ase.io.read(args.configs, index=":")
     if args.head is not None:

--- a/mace/data/augmentation.py
+++ b/mace/data/augmentation.py
@@ -25,6 +25,17 @@ class Random3DRotation(BaseTransform):
     """
     Apply a random SO(3) rotation to all magnetic moments in a configuration.
     A single rotation is applied per structure, preserving relative orientation.
+
+    This is how a spin-orbit-coupled model is taught the non-SOC symmetry: the
+    moments turn while the positions stay put, so training sees every
+    orientation of the spins against the same lattice.
+
+    Assigning to `data` below is deliberate and safe. Callers reach this through
+    BaseTransform.__call__, which is `self.forward(copy.copy(data))`, so the
+    object here is already a shallow copy and the dataset's own sample is never
+    touched. Do not add another copy: AtomicData cannot be cloned (Data.clone
+    rebuilds via cls(), and AtomicData.__init__ takes 27 required arguments),
+    and copying again would only cost a dict per sample per epoch.
     """
 
     def forward(self, data):

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1988,6 +1988,28 @@ class MagneticSCFMACE(torch.nn.Module):
 
         self.cache_magmom = None
 
+    def __getattr__(self, name):
+        """Fall back to the wrapped model for anything this class does not define.
+
+        Otherwise the wrapper hides every attribute of the model it stands in
+        for -- heads, atomic_numbers, r_max, num_interactions, products, the
+        blocks -- and each consumer has to know to reach through magmom_mace.
+        Most do not, so SCF checkpoints fail in eval, export and fine-tuning;
+        the one that does, MagneticMACECalculator, spells it out six times.
+
+        nn.Module.__getattr__ runs first, so parameters, buffers and submodules
+        resolve normally and forward stays this class's own. _modules is read
+        out of __dict__ deliberately: during unpickling __getattr__ can fire
+        before it exists, and self.magmom_mace would recurse.
+        """
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            inner = self.__dict__.get("_modules", {}).get("magmom_mace")
+            if inner is None or name == "magmom_mace":
+                raise
+            return getattr(inner, name)
+
     def forward(
         self,
         data: Dict[str, torch.Tensor],

--- a/tests/extensions/magnetic/test_magmace.py
+++ b/tests/extensions/magnetic/test_magmace.py
@@ -13,6 +13,8 @@ from e3nn import o3
 from mace.calculators import MACECalculator, MagneticMACECalculator
 from mace.cli.eval_configs import run as mace_eval_configs_run
 from mace.cli.run_train import run as mace_run
+from mace.data import AtomicData, KeySpecification, config_from_atoms
+from mace.tools import torch_geometric, utils
 from mace.tools.arg_parser import build_default_arg_parser
 from mace.tools.torch_tools import default_dtype
 
@@ -465,7 +467,18 @@ def _build_small_magnetic_model(seed=42):
 
 
 def test_magnetic_mace_rotation_equivariance():
-    """Rotating positions and magmoms together by R leaves E invariant and rotates F, magforces by R."""
+    """Rotating positions and magmoms TOGETHER by R leaves E invariant and rotates F, magforces by R.
+
+    Together is the operative word. This model has spin-orbit coupling, so the
+    energy depends on how the spins are oriented relative to the lattice. Only
+    the joint rotation is a symmetry; rotating the spins while holding the
+    positions is expected to change the energy and is NOT tested here.
+
+    Spin-only invariance is the non-SOC property. It is not built into this
+    architecture, it is induced during training by --data_aug_magmom, which
+    rotates the moments while leaving the positions alone. Test that by
+    training with the augmentation, not by calling this model.
+    """
     model = _build_small_magnetic_model().eval()
     R = _random_rotation(seed=1)
 
@@ -492,7 +505,15 @@ def test_magnetic_mace_rotation_equivariance():
 
 
 def test_magnetic_mace_inversion_parity():
-    """Flipping both positions and magmoms leaves E invariant; forces and magforces flip with them."""
+    """Flipping BOTH positions and magmoms leaves E invariant; forces and magforces flip with them.
+
+    Note what this does not claim. Inverting the positions while holding the
+    spins is not a symmetry of an SOC model, and the energy does change under
+    it: magnetic moments are axial vectors, so a parity operation that flips
+    the lattice but not the spins alters their relative orientation, which is
+    exactly what the SOC term reads. See the rotation test above for how the
+    spin-only case is handled instead.
+    """
     model = _build_small_magnetic_model().eval()
 
     data = _make_magnetic_cluster_data()
@@ -668,3 +689,231 @@ def test_magnetic_check_state_tracks_magmoms(magnetic_configs):
 
     atoms.arrays["REF_magmom"] = atoms.arrays["REF_magmom"] + 0.5
     assert "REF_magmom" in calc.check_state(atoms)
+
+
+def test_eval_configs_unwraps_scf_wrapped_models(tmp_path, magnetic_configs):
+    """mace_eval_configs must read model metadata off the inner module.
+
+    MagneticSCFMACE wraps the real model in `magmom_mace` and keeps none of
+    heads / atomic_numbers / r_max on itself, so reading them off the loaded
+    object raised AttributeError for every SCF checkpoint. The ASE calculator
+    already unwrapped with getattr(model, "magmom_mace", model); the eval CLI
+    did not, so the two disagreed about what a loaded model looks like.
+    """
+    with default_dtype(torch.float32):
+        scf_model = MagneticSCFMACE(
+            model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+        )
+        model_path = tmp_path / "scf.model"
+        torch.save(scf_model, model_path)
+
+    # reachable after a save/load round trip, which is where a __getattr__ that
+    # touched self.magmom_mace instead of __dict__ would recurse
+    loaded = torch.load(model_path, map_location="cpu")
+    assert float(loaded.r_max) == float(loaded.magmom_mace.r_max)
+
+    ase.io.write(tmp_path / "fit.xyz", magnetic_configs[1:3])
+    output_path = tmp_path / "out.xyz"
+    args = argparse.Namespace(
+        model=str(model_path),
+        configs=str(tmp_path / "fit.xyz"),
+        output=str(output_path),
+        device="cpu",
+        default_dtype="float32",
+        batch_size=1,
+        compute_stress=False,
+        compute_bec=False,
+        enable_cueq=False,
+        return_contributions=False,
+        return_descriptors=False,
+        return_node_energies=False,
+        return_magforces=False,
+        magmom_key="REF_magmom",
+        info_prefix="MACE_",
+        head=None,
+    )
+    mace_eval_configs_run(args)
+
+    assert output_path.exists()
+    assert len(ase.io.read(str(output_path), index=":")) == 2
+
+
+def test_eval_configs_refuses_magforces_for_scf_models(tmp_path, magnetic_configs):
+    """SCF wrappers take no compute_magforces, so asking for it must say so.
+
+    MagneticSCFMACE.forward accepts only data/training/compute_force/
+    compute_virials/compute_stress/compute_displacement. Passing the flag
+    through would surface as a bare TypeError from the forward call.
+    """
+    with default_dtype(torch.float32):
+        model_path = tmp_path / "scf.model"
+        torch.save(
+            MagneticSCFMACE(
+                model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+            ),
+            model_path,
+        )
+
+    ase.io.write(tmp_path / "fit.xyz", magnetic_configs[1:2])
+    args = argparse.Namespace(
+        model=str(model_path),
+        configs=str(tmp_path / "fit.xyz"),
+        output=str(tmp_path / "out.xyz"),
+        device="cpu",
+        default_dtype="float32",
+        batch_size=1,
+        compute_stress=False,
+        compute_bec=False,
+        enable_cueq=False,
+        return_contributions=False,
+        return_descriptors=False,
+        return_node_energies=False,
+        return_magforces=True,
+        magmom_key="REF_magmom",
+        info_prefix="MACE_",
+        head=None,
+    )
+    with pytest.raises(ValueError, match="return_magforces"):
+        mace_eval_configs_run(args)
+
+
+def test_random_rotation_loader_over_real_atomic_data(magnetic_configs):
+    """Pin the augmentation's contract through the loader it is wired into.
+
+    --data_aug_magmom wraps the train loader with create_random_rotation_loader,
+    so every ASE sample passes through Random3DRotation as a real AtomicData.
+    Two things are easy to get wrong about that path and both have been:
+
+    1. Random3DRotation.forward assigns onto `data`, which reads like it
+       corrupts the dataset, since for the ASE path the dataset is a plain list
+       and __getitem__ returns the same object every epoch. It does not:
+       TransformedDataset calls the transform, and BaseTransform.__call__ is
+       `self.forward(copy.copy(data))`, so forward only ever sees a copy.
+    2. "Fixing" 1. by copying inside forward crashes, because AtomicData cannot
+       be cloned: Data.clone rebuilds via cls() and AtomicData.__init__ takes
+       27 required arguments.
+
+    So this asserts the stored samples come through untouched after repeated
+    epochs, without requiring forward itself to copy. A stub-based unit test
+    can see neither point, since it takes a different copy path.
+    """
+    pytest.importorskip(
+        "torch_geometric", reason="loader path needs real torch_geometric"
+    )
+    from mace.data.augmentation import create_random_rotation_loader
+
+    z_table = utils.AtomicNumberTable([26])
+    keyspec = KeySpecification(
+        info_keys={"energy": "REF_energy"},
+        arrays_keys={"magmom": "REF_magmom", "magforces": "REF_magforces"},
+    )
+    dataset = [
+        AtomicData.from_config(
+            config_from_atoms(at, key_specification=keyspec),
+            z_table=z_table,
+            cutoff=3.5,
+        )
+        for at in magnetic_configs[1:5]
+    ]
+    stored = [d.magmom.clone() for d in dataset]
+
+    base_loader = torch_geometric.dataloader.DataLoader(
+        dataset=dataset, batch_size=2, shuffle=False, drop_last=False
+    )
+    loader = create_random_rotation_loader(base_loader)
+
+    for _ in range(2):  # two epochs over the same underlying objects
+        batches = list(loader)
+        assert batches, "loader yielded nothing"
+        for batch in batches:
+            assert batch.magmom.shape[-1] == 3
+            assert torch.isfinite(batch.magmom).all()
+
+    for original, item in zip(stored, dataset):
+        assert torch.equal(item.magmom, original), "dataset sample was mutated"
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "heads",
+        "atomic_numbers",
+        "r_max",
+        "num_interactions",
+        "products",
+        "interactions",
+        "radial_embedding",
+        "atomic_energies_fn",
+    ],
+)
+def test_scf_wrapper_delegates_inner_model_attributes(attr):
+    """The wrapper must answer for the model it wraps.
+
+    MagneticSCFMACE defines none of these: they live on magmom_mace. Without
+    delegation every consumer has to know that, and fixing them one report at
+    a time has already missed the eval CLI twice, first for heads /
+    atomic_numbers / r_max and then for the descriptors path's
+    num_interactions / products. Others are still reachable this way:
+    create_lammps_model and select_head read model.heads, and fine-tuning
+    reads model_foundation.interactions and .atomic_energies_fn.
+    """
+    scf = MagneticSCFMACE(
+        model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+    )
+    assert getattr(scf, attr) is getattr(scf.magmom_mace, attr)
+
+
+def test_scf_wrapper_keeps_its_own_forward_and_still_raises():
+    """Delegation must not swallow real mistakes or shadow the wrapper itself."""
+    scf = MagneticSCFMACE(
+        model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+    )
+    # forward is the wrapper's, not the inner model's
+    assert scf.forward.__func__ is MagneticSCFMACE.forward
+    # compute_magforces is still absent, which is why eval refuses it
+    import inspect
+
+    assert "compute_magforces" not in inspect.signature(scf.forward).parameters
+    with pytest.raises(AttributeError):
+        scf.definitely_not_a_real_attribute
+
+
+def test_eval_configs_descriptors_for_scf_wrapped_models(tmp_path, magnetic_configs):
+    """--return_descriptors needs num_interactions and products, both inner-only."""
+    with default_dtype(torch.float32):
+        model_path = tmp_path / "scf.model"
+        torch.save(
+            MagneticSCFMACE(
+                model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+            ),
+            model_path,
+        )
+
+    ase.io.write(tmp_path / "fit.xyz", magnetic_configs[1:3])
+    output_path = tmp_path / "out.xyz"
+    args = argparse.Namespace(
+        model=str(model_path),
+        configs=str(tmp_path / "fit.xyz"),
+        output=str(output_path),
+        device="cpu",
+        default_dtype="float32",
+        batch_size=1,
+        compute_stress=False,
+        compute_bec=False,
+        enable_cueq=False,
+        return_contributions=False,
+        return_descriptors=True,
+        descriptor_num_layers=-1,
+        descriptor_aggregation_method=None,
+        descriptor_invariants_only=True,
+        return_node_energies=False,
+        return_magforces=False,
+        magmom_key="REF_magmom",
+        info_prefix="MACE_",
+        head=None,
+    )
+    mace_eval_configs_run(args)
+
+    out = ase.io.read(str(output_path), index=":")
+    assert len(out) == 2
+    assert any("descriptor" in k.lower() for at in out for k in at.arrays)

--- a/tests/unit/test_augmentation.py
+++ b/tests/unit/test_augmentation.py
@@ -1,0 +1,75 @@
+"""Tests for the magnetic data augmentation used to train non-SOC models.
+
+--data_aug_magmom is not a regularizer here: it is how a spin-orbit-coupled
+architecture is taught the non-SOC symmetry. It rotates the magnetic moments
+while leaving the positions alone, so over training the model sees every
+orientation of the spins relative to the same lattice and learns that the
+energy does not depend on it.
+
+These cover the rotation itself. That it does not disturb the stored dataset is
+a property of the loader path, not of `forward`, and is tested there: see
+test_random_rotation_loader_over_real_atomic_data in the magnetic suite.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from mace.data.augmentation import Random3DRotation
+
+
+class _Sample:
+    """Minimal carrier for the two fields the rotation touches."""
+
+    magforces = None
+
+    def __init__(self, magmom, magforces=None):
+        self.magmom = magmom
+        self.magforces = magforces
+
+
+def test_rotation_keeps_magmom_and_magforces_consistent():
+    """magmom is an input and magforces (dE/dm) is its conjugate label.
+
+    Both must turn by the same R or the pair stops describing the same physical
+    state. This is the property that makes repeated rotation harmless.
+    """
+    torch.manual_seed(0)
+    m = torch.tensor([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0]])
+    f = torch.tensor([[0.0, 1.0, 0.0], [0.0, 0.0, 2.0]])
+
+    out = Random3DRotation().forward(_Sample(m.clone(), f.clone()))
+
+    # One rotation applied to every row preserves all inner products, including
+    # the cross terms between moments and forces. Had the two been turned by
+    # different rotations, those cross terms would move while the lengths
+    # within each block still looked right.
+    before = torch.cat([m, f]) @ torch.cat([m, f]).T
+    after = (
+        torch.cat([out.magmom, out.magforces])
+        @ torch.cat([out.magmom, out.magforces]).T
+    )
+    assert torch.allclose(after, before, atol=1e-5)
+
+
+@pytest.mark.parametrize("n_draws", [1, 5])
+def test_rotation_samples_orientations_uniformly(n_draws):
+    """Every epoch must present a uniformly random orientation.
+
+    Acting on a fixed unit vector, a uniform SO(3) rotation gives a z-component
+    uniform on [-1, 1], so std = 1/sqrt(3). Checked after repeated draws too:
+    a product of uniform rotations is still uniform, which is why it would not
+    matter even if rotations did accumulate across epochs.
+    """
+    torch.manual_seed(0)
+    transform = Random3DRotation()
+    z = []
+    for _ in range(4000):
+        sample = _Sample(torch.tensor([[0.0, 0.0, 1.0]]))
+        for _ in range(n_draws):
+            sample = transform.forward(sample)
+        z.append(sample.magmom[0, 2].item())
+
+    z = np.array(z)
+    assert abs(z.mean()) < 0.03
+    assert abs(z.std() - 1.0 / np.sqrt(3.0)) < 0.03


### PR DESCRIPTION
MagneticSCFMACE exposes none of the inner model's attributes. heads, atomic_numbers, r_max, num_interactions, products and every block live on magmom_mace, so consumers have to know to reach through it, and mostly do not.

mace_eval_configs failed for every SCF checkpoint. MagneticMACECalculator gets it right only by writing getattr(model, "magmom_mace", model) at six separate sites. create_lammps_model and select_head read model.heads. Fine-tuning reads model_foundation.interactions and .atomic_energies_fn.

Fixing that one call site at a time is whack-a-mole, and it had already missed the descriptors path in the eval CLI. The wrapper now delegates attribute lookup to the model it wraps, which fixes all of those at once. nn.Module.getattr runs first, so parameters, buffers and submodules resolve normally and forward stays the wrapper's own. _modules is read out of dict because during unpickling getattr can fire before it exists, and self.magmom_mace would recurse.

eval_configs keeps one SCF specific check. Metadata no longer needs unwrapping, but MagneticSCFMACE.forward genuinely takes no compute_magforces, so --return_magforces now says why instead of raising TypeError from inside the forward call.

Also in here, documentation only

Two things in the magnetic code were misread during review and are now written down where someone would look.

Random3DRotation.forward assigns onto data, which reads like it corrupts the dataset, since for the ASE path that dataset is a plain list and getitem returns the same object every epoch. It does not. BaseTransform.call is self.forward(copy.copy(data)), so forward only ever sees a copy. Copying again inside forward turns a non bug into a crash on every sample, because AtomicData cannot be cloned: Data.clone rebuilds via cls() and AtomicData.init takes 27 required arguments. No behaviour change, and a test now drives the real create_random_rotation_loader path to pin it.

The two symmetry tests now say which symmetry they assert. Both rotate spins and positions together, which is the only invariance an SOC model has. Spin only invariance is not a property of the architecture, --data_aug_magmom induces it during training, so it has to be tested by training rather than by calling the model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly delegation, clearer errors, docs, and tests; eval behavior for SCF checkpoints improves without altering inner model physics.
> 
> **Overview**
> **`MagneticSCFMACE` now transparently exposes the inner model** via `__getattr__`, so `heads`, `r_max`, `products`, and similar metadata work on loaded SCF checkpoints in `mace_eval_configs`, export, and fine-tuning without manual `magmom_mace` unwrapping (aligned with how the magnetic ASE calculator already behaved).
> 
> **Eval CLI** rejects `--return_magforces` on SCF-wrapped models with a clear `ValueError`, since `MagneticSCFMACE.forward` has no `compute_magforces` parameter.
> 
> **Magnetic moment augmentation** (`Random3DRotation`) gains documentation that in-place updates are safe because `BaseTransform.__call__` passes a shallow copy, and that extra cloning would break `AtomicData`. New tests cover rotation equivariance of `magmom`/`magforces`, uniform SO(3) sampling, loader non-mutation over epochs, SCF attribute delegation, and SCF eval paths (including descriptors).
> 
> **Symmetry test docstrings** now state they assert **joint** rotation/inversion of positions and spins (SOC), not spin-only invariance (which `--data_aug_magmom` trains in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd54798543a9c529a5c326ec8d32de3601b6d4f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->