### PR TITLE
Refuse hessians for SCF-wrapped magnetic models

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -1438,6 +1438,20 @@ class MagneticMACECalculator(Calculator):
             atoms = self.atoms
         if self.model_type != "MACE":
             raise NotImplementedError("Only implemented for MACE models")
+        # Refuse rather than fall through to magmom_mace. The wrapper's forward
+        # takes no compute_hessian, but the inner model's hessian is also a
+        # different quantity: it holds the moments fixed, so it drops the term
+        # coming from their relaxation, dm*/dr. Returning that under the name
+        # "hessian" would be silently wrong instead of loudly unsupported.
+        if any(hasattr(model, "magmom_mace") for model in self.models):
+            raise NotImplementedError(
+                "Hessians are not available for SCF-wrapped magnetic models "
+                "(MagneticSCFMACE). Its forward does not accept compute_hessian, "
+                "and the inner model's hessian holds the magnetic moments fixed, "
+                "so it is not the hessian of the self-consistent energy. Call the "
+                "inner magmom_mace directly if the fixed-moment hessian is what "
+                "you want."
+            )
         batch = self._atoms_to_batch(atoms)
         hessians = [
             model(

--- a/tests/extensions/magnetic/test_magmace.py
+++ b/tests/extensions/magnetic/test_magmace.py
@@ -917,3 +917,53 @@ def test_eval_configs_descriptors_for_scf_wrapped_models(tmp_path, magnetic_conf
     out = ase.io.read(str(output_path), index=":")
     assert len(out) == 2
     assert any("descriptor" in k.lower() for at in out for k in at.arrays)
+
+
+def test_hessian_refused_for_scf_wrapped_models():
+    """An SCF wrapper cannot give a hessian, and the inner one is not a substitute.
+
+    MagneticSCFMACE.forward takes no compute_hessian, so the request used to
+    surface as a bare TypeError from the forward call. Falling through to
+    magmom_mace would be worse than the error: that hessian holds the magnetic
+    moments fixed and so omits the dm*/dr term, making it the hessian of a
+    different energy than the one the calculator reports.
+    """
+    with default_dtype(torch.float32):
+        scf = MagneticSCFMACE(
+            model=_tiny_magnetic_model(), n_scf_step=2, scf_logging=False
+        )
+
+    atoms = Atoms(
+        numbers=[26, 26],
+        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+        cell=[6.0] * 3,
+        pbc=True,
+    )
+    atoms.arrays["REF_magmom"] = np.tile([[0.0, 0.0, 2.2]], (2, 1))
+    calc = MagneticMACECalculator(
+        models=[scf], device="cpu", default_dtype="float32", magmom_key="REF_magmom"
+    )
+
+    with pytest.raises(NotImplementedError, match="SCF-wrapped"):
+        calc.get_hessian(atoms=atoms)
+
+
+def test_hessian_still_works_for_plain_magnetic_models():
+    """The refusal must be scoped to wrappers, not to magnetic models at large."""
+    with default_dtype(torch.float32):
+        model = _tiny_magnetic_model()
+
+    atoms = Atoms(
+        numbers=[26, 26],
+        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+        cell=[6.0] * 3,
+        pbc=True,
+    )
+    atoms.arrays["REF_magmom"] = np.tile([[0.0, 0.0, 2.2]], (2, 1))
+    calc = MagneticMACECalculator(
+        models=[model], device="cpu", default_dtype="float32", magmom_key="REF_magmom"
+    )
+
+    hessian = calc.get_hessian(atoms=atoms)
+    assert hessian.shape == (3 * len(atoms), len(atoms), 3)
+    assert np.isfinite(hessian).all()


### PR DESCRIPTION
get_hessian forwards compute_hessian=True into every loaded model, and MagneticSCFMACE.forward does not accept it, so hessian requests on SCF-wrapped checkpoints raise a bare TypeError from inside the forward call.

It now refuses rather than falling through to magmom_mace. Attribute delegation from #1625 makes the inner model easy to reach, but its hessian is not the quantity being asked for: it holds the magnetic moments fixed, so it drops the term from their relaxation and is the second derivative of a different energy than the one this calculator reports. Returning it would be silently wrong instead of loudly unsupported. The message says so and points at magmom_mace for anyone who wants the fixed-moment hessian.

Scoped to wrappers. Plain magnetic models still compute hessians, pinned by a second test.

I checked the rest of the calculator the same way rather than fixing only what was reported. Of the three model(...) call sites in MagneticMACECalculator, this is the only one passing an argument the SCF forward rejects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on an unsupported path with clearer errors; plain magnetic Hessians are regression-tested and unchanged in behavior.
> 
> **Overview**
> **`MagneticMACECalculator.get_hessian`** now fails fast when any loaded model is an SCF wrapper (`magmom_mace` present), raising **`NotImplementedError`** with guidance instead of a **`TypeError`** from **`MagneticSCFMACE.forward`** (no **`compute_hessian`**) or a misleading fixed-moment hessian from the inner model.
> 
> The error explains that the inner **`magmom_mace`** Hessian holds magnetic moments fixed and is **not** the second derivative of the self-consistent energy the calculator reports; callers who need that quantity are pointed at the inner model directly.
> 
> Tests lock in **`NotImplementedError`** for **`MagneticSCFMACE`** and confirm plain magnetic models still return finite Hessians of the expected shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4299fa1d208dfb2a389853220602df1cfb51c48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->