### PR TITLE
Scope the magnetic calculator's dtype instead of setting it globally

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -866,14 +866,15 @@ class MACECalculator(Calculator):
                 "Only implemented for DipoleMACE or DipolePolarizabilityMACE models"
             )
         batch = self._atoms_to_batch(atoms)
-        outputs = [
-            model(
-                self._clone_batch(batch).to_dict(),
-                compute_dielectric_derivatives=True,
-                training=self.use_compile,
-            )
-            for model in self.models
-        ]
+        with torch_tools.default_dtype(self.default_dtype):
+            outputs = [
+                model(
+                    self._clone_batch(batch).to_dict(),
+                    compute_dielectric_derivatives=True,
+                    training=self.use_compile,
+                )
+                for model in self.models
+            ]
         dipole_derivatives = [
             output["dmu_dr"].clone().detach().cpu().numpy() for output in outputs
         ]
@@ -899,15 +900,16 @@ class MACECalculator(Calculator):
         if self.model_type not in ["MACE", "PolarMACE"]:
             raise NotImplementedError("Only implemented for MACE/PolarMACE models")
         batch = self._atoms_to_batch(atoms)
-        hessians = [
-            model(
-                self._clone_batch(batch).to_dict(),
-                compute_hessian=True,
-                compute_stress=False,
-                training=self.use_compile,
-            )["hessian"]
-            for model in self.models
-        ]
+        with torch_tools.default_dtype(self.default_dtype):
+            hessians = [
+                model(
+                    self._clone_batch(batch).to_dict(),
+                    compute_hessian=True,
+                    compute_stress=False,
+                    training=self.use_compile,
+                )["hessian"]
+                for model in self.models
+            ]
         hessians = [hessian.detach().cpu().numpy() for hessian in hessians]
         if self.num_models == 1:
             return hessians[0]
@@ -930,7 +932,10 @@ class MACECalculator(Calculator):
         if num_layers == -1:
             num_layers = num_interactions
         batch = self._atoms_to_batch(atoms)
-        descriptors = [model(batch.to_dict())["node_feats"] for model in self.models]
+        with torch_tools.default_dtype(self.default_dtype):
+            descriptors = [
+                model(batch.to_dict())["node_feats"] for model in self.models
+            ]
 
         irreps_out = o3.Irreps(str(self.models[0].products[0].linear.irreps_out))
         l_max = irreps_out.lmax
@@ -1466,15 +1471,16 @@ class MagneticMACECalculator(Calculator):
                 "you want."
             )
         batch = self._atoms_to_batch(atoms)
-        hessians = [
-            model(
-                self._clone_batch(batch).to_dict(),
-                compute_hessian=True,
-                compute_stress=False,
-                training=self.use_compile,
-            )["hessian"]
-            for model in self.models
-        ]
+        with torch_tools.default_dtype(self.default_dtype):
+            hessians = [
+                model(
+                    self._clone_batch(batch).to_dict(),
+                    compute_hessian=True,
+                    compute_stress=False,
+                    training=self.use_compile,
+                )["hessian"]
+                for model in self.models
+            ]
         hessians = [hessian.detach().cpu().numpy() for hessian in hessians]
         if self.num_models == 1:
             return hessians[0]
@@ -1499,7 +1505,10 @@ class MagneticMACECalculator(Calculator):
         if num_layers == -1:
             num_layers = num_interactions
         batch = self._atoms_to_batch(atoms)
-        descriptors = [model(batch.to_dict())["node_feats"] for model in self.models]
+        with torch_tools.default_dtype(self.default_dtype):
+            descriptors = [
+                model(batch.to_dict())["node_feats"] for model in self.models
+            ]
 
         irreps_out = o3.Irreps(
             str(

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -1194,7 +1194,12 @@ class MagneticMACECalculator(Calculator):
                 self.models = [model.double() for model in self.models]
             elif default_dtype == "float32":
                 self.models = [model.float() for model in self.models]
-        torch_tools.set_default_dtype(default_dtype)
+        # Recorded, not applied process-wide. Setting the global dtype here
+        # would reach every other calculator in the session, and would still
+        # leave this one running at whatever dtype happened to be current by
+        # the time it is called. It is scoped around batch construction and
+        # the forward instead, as MACECalculator does.
+        self.default_dtype = default_dtype
         if enable_cueq:
             logging.info("Converting models to CuEq for acceleration")
             self.models = [
@@ -1297,23 +1302,27 @@ class MagneticMACECalculator(Calculator):
         keyspec = mace_data.KeySpecification(
             info_keys=self.info_keys, arrays_keys=self.arrays_keys
         )
-        config = mace_data.config_from_atoms(
-            atoms, key_specification=keyspec, head_name=self.head
-        )
-        data_loader = torch_geometric.dataloader.DataLoader(
-            dataset=[
-                mace_data.AtomicData.from_config(
-                    config,
-                    z_table=self.z_table,
-                    cutoff=self.r_max,
-                    heads=self.available_heads,
-                )
-            ],
-            batch_size=1,
-            shuffle=False,
-            drop_last=False,
-        )
-        batch = next(iter(data_loader)).to(self.device)
+        # The scope has to cover AtomicData.from_config too, not just the
+        # config: that is where the tensors are built, and it reads the
+        # process-wide default dtype for every one of them.
+        with torch_tools.default_dtype(self.default_dtype):
+            config = mace_data.config_from_atoms(
+                atoms, key_specification=keyspec, head_name=self.head
+            )
+            data_loader = torch_geometric.dataloader.DataLoader(
+                dataset=[
+                    mace_data.AtomicData.from_config(
+                        config,
+                        z_table=self.z_table,
+                        cutoff=self.r_max,
+                        heads=self.available_heads,
+                    )
+                ],
+                batch_size=1,
+                shuffle=False,
+                drop_last=False,
+            )
+            batch = next(iter(data_loader)).to(self.device)
         return batch
 
     def _clone_batch(self, batch):
@@ -1352,11 +1361,15 @@ class MagneticMACECalculator(Calculator):
         )
         for i, model in enumerate(self.models):
             batch = self._clone_batch(batch_base)
-            out = model(
-                batch.to_dict(),
-                compute_stress=compute_stress,
-                training=self.use_compile,
-            )
+            # Scoped for the same reason as MACECalculator: extensions build
+            # tensors mid-forward without an explicit dtype, and would follow
+            # the process-wide default instead of the model's.
+            with torch_tools.default_dtype(self.default_dtype):
+                out = model(
+                    batch.to_dict(),
+                    compute_stress=compute_stress,
+                    training=self.use_compile,
+                )
             if self.model_type in ["MACE", "EnergyDipoleMACE"]:
                 ret_tensors["energies"][i] = out["energy"].detach()
                 ret_tensors["node_energy"][i] = (out["node_energy"] - node_e0).detach()

--- a/tests/extensions/magnetic/test_magmace.py
+++ b/tests/extensions/magnetic/test_magmace.py
@@ -967,3 +967,56 @@ def test_hessian_still_works_for_plain_magnetic_models():
     hessian = calc.get_hessian(atoms=atoms)
     assert hessian.shape == (3 * len(atoms), len(atoms), 3)
     assert np.isfinite(hessian).all()
+
+
+def _fe_dimer():
+    atoms = Atoms(
+        numbers=[26, 26],
+        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+        cell=[6.0] * 3,
+        pbc=True,
+    )
+    atoms.arrays["REF_magmom"] = np.tile([[0.0, 0.0, 2.2]], (2, 1))
+    return atoms
+
+
+def test_magnetic_calculator_does_not_change_the_global_dtype():
+    """Constructing a calculator must not reach into the rest of the session.
+
+    It used to call torch_tools.set_default_dtype process-wide, so building a
+    float32 magnetic calculator silently reconfigured every other calculator
+    and every later tensor built from the default.
+    """
+    before = torch.get_default_dtype()
+    with default_dtype(torch.float64):
+        MagneticMACECalculator(
+            models=[_tiny_magnetic_model()],
+            device="cpu",
+            default_dtype="float32",
+            magmom_key="REF_magmom",
+        )
+        assert torch.get_default_dtype() is torch.float64
+    assert torch.get_default_dtype() is before
+
+
+def test_magnetic_calculator_runs_under_a_foreign_global_dtype():
+    """The forward must use the model's dtype, not whatever the process has set.
+
+    This is the failure #1619 fixed for MACECalculator: extensions build
+    tensors mid-forward without an explicit dtype and follow the global
+    default, and the mismatch only shows up in the backward as a dtype error
+    out of a linalg op.
+    """
+    with default_dtype(torch.float32):
+        model = _tiny_magnetic_model()
+
+    calc = MagneticMACECalculator(
+        models=[model], device="cpu", default_dtype="float32", magmom_key="REF_magmom"
+    )
+    atoms = _fe_dimer()
+    atoms.calc = calc
+
+    with default_dtype(torch.float64):  # hostile ambient dtype
+        energy = atoms.get_potential_energy()
+
+    assert np.isfinite(energy)

--- a/tests/unit/test_calculator_dtype_scope.py
+++ b/tests/unit/test_calculator_dtype_scope.py
@@ -1,0 +1,57 @@
+"""Every calculator entry point must run the model at the model's dtype.
+
+Extensions create tensors mid-forward without an explicit dtype and follow the
+process-wide default. When that disagrees with the model, the mismatch survives
+the forward through type promotion and only fails in the backward, as a dtype
+error out of a linalg op -- which is what #1619 chased down for `calculate`.
+
+An entry point is only safe if its model call sits inside a
+`default_dtype(self.default_dtype)` block, so this checks the source rather
+than exercising each method: several need optional extras or a model type the
+unit suite does not build, and an untested entry point is exactly how the gap
+reappeared in get_hessian, get_descriptors and get_dielectric_derivatives after
+calculate was fixed.
+"""
+
+import ast
+import inspect
+
+import pytest
+
+from mace.calculators import mace as mace_calc_module
+
+
+def _unscoped_forwards(class_name):
+    tree = ast.parse(inspect.getsource(mace_calc_module))
+    cls = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == class_name
+    )
+    scopes = [
+        (n.lineno, n.end_lineno)
+        for n in ast.walk(cls)
+        if isinstance(n, ast.With)
+        and "default_dtype" in ast.dump(n.items[0].context_expr)
+    ]
+    unscoped = []
+    for fn in (n for n in cls.body if isinstance(n, ast.FunctionDef)):
+        for node in ast.walk(fn):
+            is_forward = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "model"
+            )
+            if is_forward and not any(a <= node.lineno <= b for a, b in scopes):
+                unscoped.append(f"{fn.name} (line {node.lineno})")
+    return unscoped
+
+
+@pytest.mark.parametrize("class_name", ["MACECalculator", "MagneticMACECalculator"])
+def test_every_forward_runs_under_the_calculator_dtype(class_name):
+    unscoped = _unscoped_forwards(class_name)
+    assert not unscoped, (
+        f"{class_name} calls the model outside a default_dtype scope in: "
+        f"{', '.join(unscoped)}. Wrap the call in "
+        "`with torch_tools.default_dtype(self.default_dtype):`"
+    )


### PR DESCRIPTION
MagneticMACECalculator called torch_tools.set_default_dtype at construction and scoped nothing afterwards. Building one reconfigured the process for every other calculator in the session, and its own batch build and forward then ran at whatever dtype happened to be current by the time they were called.

This is the failure #1619 fixed for MACECalculator, left behind one class over. Extensions create tensors mid forward without an explicit dtype and follow the global default, and the mismatch only surfaces in the backward, as a dtype error out of a linalg op.

The dtype is now recorded on the instance and scoped around batch construction and the forward. The batch scope has to cover AtomicData.from_config, not only config_from_atoms: that is where the tensors are built and where the default is read. MACECalculator already covers both, so only the magnetic copy needed it.

Both tests run under a hostile ambient dtype, float64 global against a float32 model, so the mismatch is deterministic rather than dependent on what ran before. One checks the constructor leaves the global alone, the other checks the forward still works. Both fail without the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches numerical dtype behavior across calculator entry points and multi-calculator sessions; mistakes could cause silent wrong dtypes or backward linalg failures, but the change mirrors an established MACECalculator pattern with targeted tests.
> 
> **Overview**
> **MagneticMACECalculator** no longer calls process-wide `set_default_dtype` at construction. It stores **`self.default_dtype`** and wraps **`_atoms_to_batch`** (including **`AtomicData.from_config`**), **`calculate`**, **`get_hessian`**, and **`get_descriptors`** in **`torch_tools.default_dtype(self.default_dtype)`**, matching **`MACECalculator`**.
> 
> **MACECalculator** gets the same scoped forwards on **`get_dielectric_derivatives`**, **`get_hessian`**, and **`get_descriptors`**, which were still unscoped after the **`calculate`** fix in #1619.
> 
> New tests assert the magnetic calculator does not alter the global dtype and still runs energy with a hostile ambient **`float64`** default; an AST-based unit test requires every **`model(...)`** call in both calculator classes to sit inside a **`default_dtype`** block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cc6f426b140dee7b4f097f894eca7894414b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->