### PR TITLE
Shard the nightly coverage job and scope the LAMMPS real tier

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -34,7 +34,10 @@ inputs:
     required: false
     default: ""
   coverage:
-    description: Collect coverage (term + xml + html reports)
+    description: >
+      "true" collects coverage and writes the term + xml + html reports;
+      "data" collects it and writes only the `.coverage` data file, for a
+      sharded job that combines the shards and reports once.
     required: false
     default: "false"
   store-durations:
@@ -90,7 +93,7 @@ runs:
                   --splitting-algorithm=least_duration \
                   --durations-path=tests/.test_durations )
         fi
-        if [ "$IN_COVERAGE" = "true" ]; then
+        if [ "$IN_COVERAGE" != "false" ]; then
           # PEP 669 monitoring instead of coverage's default C tracer. This is
           # not a micro-optimisation: cuEquivariance's CPU fallback runs a
           # torch.fx module of ~55k generated lines per forward, and the C
@@ -99,7 +102,13 @@ runs:
           # Measured with sysmon: 98s, and byte-identical totals. Ignored
           # without harm below 3.12, where sys.monitoring does not exist.
           export COVERAGE_CORE=sysmon
-          args+=( --cov=mace --cov-report=term --cov-report=xml --cov-report=html )
+          args+=( --cov=mace )
+          if [ "$IN_COVERAGE" = "data" ]; then
+            # Empty --cov-report: keep only .coverage, for the combining job.
+            args+=( --cov-report= )
+          else
+            args+=( --cov-report=term --cov-report=xml --cov-report=html )
+          fi
         fi
         if [ "$IN_STORE_DURATIONS" = "true" ]; then
           args+=( --store-durations --durations-path=tests/.test_durations )

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -155,8 +155,24 @@ jobs:
     # THE project coverage number: full fixed CPU scope (network, cueq, polar,
     # les, torchsim, schedulefree), comparable night to night. The per-PR
     # coverage job measures only the deterministic PR slice by design.
+    #
+    # Sharded, one xdist worker per shard, because this is the ONLY job that
+    # installs every extra at once: extensions-refresh runs polar, les,
+    # torchsim and backends-cpu in separate jobs, and durations-refresh runs
+    # the same paths with `dev` alone, so they all skip the heavy ones. On
+    # 2026-08-06 the single job died at 87% with the runner itself killed
+    # ("the runner has received a shutdown signal") while one worker was in a
+    # cueq CPU-fallback polar case and the other was loading the omol
+    # foundation model. Shards bound both the concurrent peak and how much a
+    # single process accumulates; `[METRICS] mem/peak rss` in the log says
+    # which of the two it was, should it come back.
+    name: coverage-full (group ${{ matrix.split-group }})
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    strategy:
+      fail-fast: false
+      matrix:
+        split-group: [ 1, 2, 3 ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-mace
@@ -180,10 +196,48 @@ jobs:
           markers: not gpu and not benchmark
           require-caps: network,cueq,polar,les,torchsim,schedulefree
           allow-network: "true"
-          coverage: "true"
+          coverage: "data"
+          splits: "3"
+          group: ${{ matrix.split-group }}
+          numprocs: "1"
           timeout: "1200"
+      - name: Name this shard's coverage data
+        run: mv .coverage ".coverage.${{ matrix.split-group }}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-data-${{ matrix.split-group }}
+          path: .coverage.${{ matrix.split-group }}
+          retention-days: 7
+          # A dotfile, and upload-artifact skips hidden files by default --
+          # the same trap that silently emptied the durations upload.
+          include-hidden-files: true
+
+  coverage-report:
+    # Each shard measures a third of the suite: this is where the nightly
+    # coverage number is actually produced. Deliberately NOT `if: always()` --
+    # a report combined from a subset of the shards would read as the project
+    # number while missing whatever the failed shard covered.
+    needs: coverage-full
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # `coverage` alone, not the whole dev stack: combining and reporting
+      # needs the data files and the sources, not an importable mace.
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - run: python -m pip install "coverage[toml]"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+      - name: Combine the shards
+        run: |
+          coverage combine
+          coverage xml
+          coverage html
       - name: Coverage summary
-        if: always()
         run: |
           {
             echo '## Full-scope CPU coverage (nightly)'
@@ -192,7 +246,6 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
         with:
           name: coverage-full
           path: |

--- a/mace/calculators/lammps_mliap_mace.py
+++ b/mace/calculators/lammps_mliap_mace.py
@@ -150,6 +150,29 @@ class LAMMPS_MLIAP_MACE(MLIAPUnified):
         logging.info(f"MACE model initialized on device: {device}")
         self.initialized = True
 
+    def _check_ghost_exchange_support(self, data):
+        """Fail early when the build cannot exchange ghost node features.
+
+        Every interaction layer past the first needs the node features of the
+        ghost atoms, which only LAMMPS can fill in. The call that does it,
+        ``forward_exchange``, exists solely in the KOKKOS coupling
+        (``src/KOKKOS/mliap_unified_couple_kokkos.pyx``); the plain ML-IAP
+        ``MLIAPDataPy`` has no such method, so a stock non-KOKKOS build used
+        to reach the second layer and die there on a bare ``AttributeError``
+        with nothing pointing at the build.
+        """
+        num_interactions = int(self.model.num_interactions)
+        if num_interactions <= 1 or hasattr(data, "forward_exchange"):
+            return
+        raise RuntimeError(
+            f"This MACE model has {num_interactions} interaction layers, so it "
+            f"needs LAMMPS to exchange ghost-atom features between layers, but "
+            f"{type(data).__module__}.{type(data).__name__} provides no "
+            f"forward_exchange(). That call only exists in LAMMPS's KOKKOS "
+            f"ML-IAP coupling: rebuild LAMMPS with -D PKG_KOKKOS=yes and run "
+            f"it with '-k on -sf kk', or export a single-layer model."
+        )
+
     def compute_forces(self, data):
         natoms = data.nlocal
         ntotal = data.ntotal
@@ -159,6 +182,7 @@ class LAMMPS_MLIAP_MACE(MLIAPUnified):
 
         if not self.initialized:
             self._initialize_device(data)
+            self._check_ghost_exchange_support(data)
 
         self.step += 1
         self._manage_profiling()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
+import resource
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
@@ -129,7 +131,13 @@ _DIR_MARKERS = {
 }
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):  # pylint: disable=unused-argument
+    # tryfirst for two reasons, both silent when wrong: the directory-derived
+    # markers below must exist before the builtin mark plugin applies `-m`,
+    # and the zero-collection guard at the end must see the WHOLE collection,
+    # before pytest-split deselects the other shards' tests -- otherwise a
+    # sharded job fails on whichever capability did not land in its group.
     for item in items:
         try:
             rel = Path(item.path).relative_to(_TESTS_DIR).parts[:-1]
@@ -231,6 +239,40 @@ def fixture_trained_tiny_model_path(tmp_path_factory):
     return model_path
 
 
+@pytest.fixture(scope="session", name="trained_tiny_1layer_model_path")
+def fixture_trained_tiny_1layer_model_path(tmp_path_factory):
+    """`trained_tiny_model_path` with a single interaction layer.
+
+    Same purpose and cost, one message-passing layer instead of two, so the
+    forward never asks LAMMPS to exchange ghost node features. That is what
+    makes the real-tier ML-IAP test runnable against a stock (non-KOKKOS)
+    LAMMPS build -- see `mace.calculators.lammps_mliap_mace`.
+    """
+    import ase.io
+
+    from tests.helpers import base_mace_params, make_fitting_configs, run_mace_train
+
+    tmp = tmp_path_factory.mktemp("tiny_1layer_model")
+    ase.io.write(tmp / "fit.xyz", make_fitting_configs())
+    params = base_mace_params()
+    params.update(
+        {
+            "name": "tiny1l",
+            "hidden_irreps": "16x0e + 16x1o",
+            "num_interactions": 1,
+            "checkpoints_dir": str(tmp),
+            "model_dir": str(tmp),
+            "train_file": str(tmp / "fit.xyz"),
+            "max_num_epochs": 6,
+            "start_swa": 4,
+        }
+    )
+    run_mace_train(params)
+    model_path = tmp / "tiny1l.model"
+    assert model_path.exists()
+    return model_path
+
+
 @pytest.fixture(name="pretraining_configs")
 def fixture_pretraining_configs():
     configs = []
@@ -258,13 +300,44 @@ def fixture_pretraining_configs():
     return configs
 
 
+# ru_maxrss is in bytes on macOS and in kilobytes on Linux.
+_MAXRSS_TO_BYTES = 1 if sys.platform == "darwin" else 2**10
+
+
+def _mem_available_gb():
+    """System-wide free memory, or None where /proc/meminfo does not exist.
+
+    The counterpart of the disc figure below: a CI runner that is killed
+    outright ("the runner has received a shutdown signal") leaves no other
+    trace of having run out of memory, and per-test peak RSS alone cannot
+    tell a big-but-fine test from the one that crossed the line.
+    """
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (2**20)
+    except OSError:
+        pass
+    return None
+
+
 def pytest_runtest_logreport(report):
     """Prints a line about available disc space & test duration after each test."""
     if report.when == "call":
         _total, _used, free = shutil.disk_usage("/")
+        # Children too: the workflow tests do their real work in subprocesses.
+        peak = _MAXRSS_TO_BYTES * (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        )
+        mem_available = _mem_available_gb()
+        mem = "" if mem_available is None else f"mem: {mem_available:.3f}GB free, "
         print(
             f"\n[METRICS] "
             f"{report.nodeid}: "
             f"disc: {free / (2**30):.3f}GB free, "
+            f"{mem}"
+            f"peak rss: {peak / (2**30):.3f}GB, "
             f"time: {report.duration:.2f}s"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,22 @@ def fixture_pretraining_configs():
 _MAXRSS_TO_BYTES = 1 if sys.platform == "darwin" else 2**10
 
 
+def _peak_rss_gb():
+    """High-water mark of this process plus its reaped children, in GiB.
+
+    Children count because the workflow tests do their real work in
+    ``run_mace_train`` subprocesses.
+    """
+    return (
+        _MAXRSS_TO_BYTES
+        * (
+            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        )
+        / (2**30)
+    )
+
+
 def _mem_available_gb():
     """System-wide free memory, or None where /proc/meminfo does not exist.
 
@@ -322,22 +338,37 @@ def _mem_available_gb():
     return None
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report):
-    """Prints a line about available disc space & test duration after each test."""
-    if report.when == "call":
-        _total, _used, free = shutil.disk_usage("/")
-        # Children too: the workflow tests do their real work in subprocesses.
-        peak = _MAXRSS_TO_BYTES * (
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-            + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-        )
-        mem_available = _mem_available_gb()
-        mem = "" if mem_available is None else f"mem: {mem_available:.3f}GB free, "
-        print(
-            f"\n[METRICS] "
-            f"{report.nodeid}: "
-            f"disc: {free / (2**30):.3f}GB free, "
-            f"{mem}"
-            f"peak rss: {peak / (2**30):.3f}GB, "
-            f"time: {report.duration:.2f}s"
-        )
+    """Print disc, memory and duration after each test.
+
+    Under xdist this hook fires in two processes: the worker that ran the
+    test, whose stdout never reaches the log, and then the controller, which
+    is the line you actually see. Only the worker's rusage describes the
+    test — a still-live child does not count towards the controller's
+    RUSAGE_CHILDREN, so measuring on the controller reports its own idle
+    footprint and the figure stays flat no matter what the test allocates.
+    So the worker stashes the numbers on the report (tryfirst, ahead of the
+    xdist hook that serialises it — `TestReport` round-trips unknown
+    attributes through its `**extra`) and the controller prints them.
+    """
+    if report.when != "call":
+        return
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        report.mace_peak_rss_gb = _peak_rss_gb()
+        report.mace_mem_available_gb = _mem_available_gb()
+        return
+    if hasattr(report, "mace_peak_rss_gb"):
+        peak, mem_available = report.mace_peak_rss_gb, report.mace_mem_available_gb
+    else:  # no xdist: this process is the one that ran the test
+        peak, mem_available = _peak_rss_gb(), _mem_available_gb()
+    _total, _used, free = shutil.disk_usage("/")
+    mem = "" if mem_available is None else f"mem: {mem_available:.3f}GB free, "
+    print(
+        f"\n[METRICS] "
+        f"{report.nodeid}: "
+        f"disc: {free / (2**30):.3f}GB free, "
+        f"{mem}"
+        f"peak rss: {peak:.3f}GB, "
+        f"time: {report.duration:.2f}s"
+    )

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -14,6 +14,15 @@ directory and is tested in **two tiers**:
    is absent and *fails* in the CI job that guarantees it
    (`MACE_REQUIRE_CAPS`, see `tests/conftest.py`). Runs in `nightly.yaml`.
 
+What the real tier can cover is bounded by the binary CI can install, and for
+LAMMPS that bound is sharp: conda-forge builds every CPU variant with
+`PKG_KOKKOS=OFF`, and `forward_exchange` — the ghost node-feature exchange
+every interaction layer past the first needs — exists **only** in the KOKKOS
+ML-IAP coupling. So the real tier runs a *single-layer* model, the multi-layer
+path stays in the contract tier (`lammps/test_mliap_exchange.py`, which also
+pins the actionable error the non-KOKKOS case now raises), and no bump of the
+`lammps` package will change that.
+
 ## Adding integration X
 
 1. Create `tests/integrations/<x>/` with contract tests (and a `_harness.py`

--- a/tests/integrations/lammps/test_lammps_real.py
+++ b/tests/integrations/lammps/test_lammps_real.py
@@ -6,6 +6,15 @@ plugin compilation required. The native `pair_style mace` route needs a
 patched LAMMPS build and is intentionally out of scope here (containerized
 job, future work).
 
+The model here has ONE interaction layer, and that is not a size choice: past
+the first layer MACE asks LAMMPS to exchange ghost node features through
+`forward_exchange`, which exists only in the KOKKOS ML-IAP coupling
+(`src/KOKKOS/mliap_unified_couple_kokkos.pyx`). conda-forge builds LAMMPS with
+`PKG_KOKKOS=OFF` on every CPU variant, so no version of the package this job
+installs can run a multi-layer model — the ghost-exchange branch is covered in
+the contract tier instead (`test_mliap_exchange.py`), and the guard that turns
+the multi-layer case into an actionable error is tested there too.
+
 Capability `bin_lammps`: skipped wherever LAMMPS is absent, enforced
 (skip=fail) in the nightly job that installs it. The mliap export also needs
 cueq (the exporter converts to the cueq layout).
@@ -26,9 +35,9 @@ pytestmark = [pytest.mark.bin_lammps, pytest.mark.cueq]
 
 
 @pytest.fixture(name="mliap_artifact")
-def fixture_mliap_artifact(trained_tiny_model_path, tmp_path):
+def fixture_mliap_artifact(trained_tiny_1layer_model_path, tmp_path):
     dest = tmp_path / "tiny.model"
-    shutil.copy(trained_tiny_model_path, dest)
+    shutil.copy(trained_tiny_1layer_model_path, dest)
     run_mace_train(
         {"format": "mliap"}, extra_argv=[str(dest)], script=CREATE_LAMMPS_MODEL
     )

--- a/tests/integrations/lammps/test_mliap_exchange.py
+++ b/tests/integrations/lammps/test_mliap_exchange.py
@@ -1,8 +1,10 @@
 import types
 
+import pytest
 import torch
 from e3nn import o3
 
+from mace.calculators.lammps_mliap_mace import LAMMPS_MLIAP_MACE
 from mace.modules import blocks
 from mace.modules.blocks import (
     RealAgnosticDensityResidualInteractionBlock,
@@ -125,3 +127,44 @@ def test_mliap_exchange_density_residual(monkeypatch):
     assert DummyMP.last_shape == (n_real + n_ghost, node_feat_dim)
     assert out.shape[0] == n_real
     assert sc.shape[0] == n_real
+
+
+class _StubMACE(torch.nn.Module):
+    """The metadata `MACEEdgeForcesWrapper` reads off a real MACE model."""
+
+    def __init__(self, num_interactions):
+        super().__init__()
+        self.register_buffer("atomic_numbers", torch.tensor([1, 8]))
+        self.register_buffer("r_max", torch.tensor(3.5))
+        self.register_buffer("num_interactions", torch.tensor(num_interactions))
+        self.lin = torch.nn.Linear(1, 1)
+
+
+def _mliap_data(**attrs):
+    """A stand-in for LAMMPS's MLIAPDataPy, with only the attributes named."""
+    return types.SimpleNamespace(elems=torch.zeros(3, dtype=torch.int64), **attrs)
+
+
+@pytest.mark.parametrize("num_interactions", [2, 3])
+def test_multilayer_without_forward_exchange_is_actionable(num_interactions):
+    # conda-forge's CPU LAMMPS builds with PKG_KOKKOS=OFF, so its MLIAPDataPy
+    # has no forward_exchange and a >1-layer model used to die on a bare
+    # AttributeError three frames deep in the second interaction block.
+    unified = LAMMPS_MLIAP_MACE(_StubMACE(num_interactions))
+    data = _mliap_data()
+
+    with pytest.raises(RuntimeError, match="PKG_KOKKOS"):
+        unified._check_ghost_exchange_support(data)  # pylint: disable=protected-access
+
+
+def test_single_layer_needs_no_forward_exchange():
+    # One layer never leaves the local atoms, which is what makes a stock
+    # non-KOKKOS build usable at all -- and what the real tier relies on.
+    unified = LAMMPS_MLIAP_MACE(_StubMACE(1))
+    unified._check_ghost_exchange_support(_mliap_data())  # pylint: disable=protected-access
+
+
+def test_multilayer_with_forward_exchange_is_accepted():
+    unified = LAMMPS_MLIAP_MACE(_StubMACE(2))
+    data = _mliap_data(forward_exchange=lambda *_: None)
+    unified._check_ghost_exchange_support(data)  # pylint: disable=protected-access


### PR DESCRIPTION
## coverage-full

This is the only job that installs every extra at once, so cuEquivariance's CPU fallback, polar, les and the foundation downloads all share a single 16 GB runner. It now runs as 3 shards of one xdist worker each, and a new `coverage-report` job combines them into the project number.

`run-tests` gains a `coverage: data` mode that writes only the `.coverage` file for the shards to upload. `tests/conftest.py` reports free memory and peak RSS per test, and its collection hook is now `tryfirst` so the zero collection capability guard sees the whole collection rather than one shard's slice.

## lammps-real

`forward_exchange`, the ghost node feature exchange that every interaction layer past the first needs, exists only in the KOKKOS ML-IAP coupling, and conda-forge builds every CPU `lammps` variant with `PKG_KOKKOS=OFF`. The real tier therefore exports a single layer model, the multi layer path stays in the contract tier, and `LAMMPS_MLIAP_MACE` now refuses up front with a message naming the build instead of failing on a bare `AttributeError` inside the second interaction block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI workflow changes affect the canonical nightly coverage number; LAMMPS integration behavior changes for multi-layer models on non-KOKKOS builds (intentional fail-fast).
> 
> **Overview**
> **Nightly full-scope coverage** is split into **three pytest-split shards** (one xdist worker each) so peak memory stays within runner limits; shards collect coverage in a new **`coverage: data`** mode (`.coverage` only), upload artifacts, and a **`coverage-report`** job merges shards and publishes xml/html. The **`run-tests`** action treats any non-`false` coverage value as “collect,” with **`data`** skipping term/xml/html reports.
> 
> **Test harness:** `pytest_collection_modifyitems` is **`tryfirst`** so capability guards see the full collection before sharding. Per-test **`[METRICS]`** logs add **peak RSS** (worker → controller under xdist) and **MemAvailable** on Linux.
> 
> **LAMMPS ML-IAP:** **`LAMMPS_MLIAP_MACE`** fails early when a **multi-layer** model runs against data without **`forward_exchange`** (non-KOKKOS builds), with a **KOKKOS rebuild** hint. The **real-tier** integration uses a **single-layer** session fixture; contract tests pin that error and ghost-exchange behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4bbbdb5a6f2d21a1a695e7f2096c07f420f90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->