### PR TITLE
Stop a failed download poisoning the model cache, and read stress from the right committee member

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -38,6 +38,19 @@ def _normalize_github_download_url(url: str) -> str:
     return normalized
 
 
+def _discard_cached_download(path):
+    """Remove a just-downloaded file that turned out not to be a checkpoint.
+
+    Only ever called for a path the caller has just created, since every call
+    site is guarded by `if not os.path.isfile(path)`, so this cannot delete a
+    model the user already had.
+    """
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
 def _urlretrieve_with_timeout(url, filename, timeout=_DOWNLOAD_TIMEOUT):
     """Download *url* to *filename* with a per-read socket timeout.
 
@@ -176,6 +189,12 @@ def download_mace_mp_checkpoint(model: Optional[Union[str, Path]] = None) -> str
         print(f"Downloading MACE model from {checkpoint_url!r}")
         _, http_msg = _urlretrieve_with_timeout(checkpoint_url, cached_model_path)
         if "Content-Type: text/html" in str(http_msg):
+            # The fetch succeeded at the HTTP layer, so the helper already
+            # renamed the body into place: an error page is now sitting where
+            # the checkpoint belongs. Leaving it there poisons the cache, since
+            # the isfile check above skips the download from then on and
+            # torch.load reports a zip-archive error instead of this one.
+            _discard_cached_download(cached_model_path)
             raise RuntimeError(
                 f"Model download failed, please check the URL {checkpoint_url}"
             )
@@ -218,6 +237,12 @@ def download_mace_polar_checkpoint(model: Union[str, Path]) -> str:
         print(f"Downloading MACE-Polar model from {checkpoint_url!r}")
         _, http_msg = _urlretrieve_with_timeout(checkpoint_url, cached_model_path)
         if "Content-Type: text/html" in str(http_msg):
+            # The fetch succeeded at the HTTP layer, so the helper already
+            # renamed the body into place: an error page is now sitting where
+            # the checkpoint belongs. Leaving it there poisons the cache, since
+            # the isfile check above skips the download from then on and
+            # torch.load reports a zip-archive error instead of this one.
+            _discard_cached_download(cached_model_path)
             raise RuntimeError(
                 f"Model download failed, please check the URL {checkpoint_url}"
             )
@@ -650,6 +675,9 @@ def mace_mdp(
                     checkpoint_url, cached_model_path
                 )
                 if "Content-Type: text/html" in str(http_msg):
+                    # See download_mace_mp_checkpoint: the body is already at
+                    # the cache path, and leaving it there poisons the cache.
+                    _discard_cached_download(cached_model_path)
                     raise RuntimeError(
                         f"Model download failed, please check the URL {checkpoint_url}"
                     )

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -1364,6 +1364,7 @@ class MagneticMACECalculator(Calculator):
         ret_tensors = self._create_result_tensors(
             self.model_type, self.num_models, len(atoms)
         )
+        stress_available = False
         for i, model in enumerate(self.models):
             batch = self._clone_batch(batch_base)
             # Scoped for the same reason as MACECalculator: extensions build
@@ -1381,6 +1382,8 @@ class MagneticMACECalculator(Calculator):
                 ret_tensors["forces"][i] = out["forces"].detach()
                 if out["stress"] is not None:
                     ret_tensors["stress"][i] = out["stress"].detach()
+                if i == 0:
+                    stress_available = out["stress"] is not None
             if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
                 ret_tensors["dipole"][i] = out["dipole"].detach()
             if "equilibrated_magmom" in out.keys():
@@ -1422,7 +1425,11 @@ class MagneticMACECalculator(Calculator):
                     * self.energy_units_to_eV
                     / self.length_units_to_A
                 )
-            if out["stress"] is not None:
+            # The first member decides, as in MACECalculator, where
+            # _create_result_tensors only allocates a key when the first
+            # model's output has it. Reading `out` here instead took the last
+            # member, since it outlives the loop.
+            if stress_available:
                 self.results["stress"] = full_3x3_to_voigt_6_stress(
                     torch.mean(ret_tensors["stress"], dim=0).cpu().numpy()
                     * self.energy_units_to_eV

--- a/tests/extensions/magnetic/test_magmace.py
+++ b/tests/extensions/magnetic/test_magmace.py
@@ -1020,3 +1020,63 @@ def test_magnetic_calculator_runs_under_a_foreign_global_dtype():
         energy = atoms.get_potential_energy()
 
     assert np.isfinite(energy)
+
+
+class _NoStressModel(torch.nn.Module):
+    """Wraps a magnetic model and drops stress from its output."""
+
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    def __getattr__(self, name):
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.__dict__["_modules"]["inner"], name)
+
+    def forward(self, *args, **kwargs):
+        out = self.inner(*args, **kwargs)
+        out["stress"] = None
+        return out
+
+
+def test_committee_stress_follows_the_first_member_not_the_last():
+    """Whether stress is published is decided by the first committee member.
+
+    That is the rule the rest of the code follows: MACECalculator's
+    _create_result_tensors only allocates a key when the first model's output
+    has it, and everything downstream reads ret_tensors. The magnetic copy
+    instead read `out` after the loop, which is the *last* member, so the two
+    disagreed whenever a committee was not uniform.
+
+    Not asserted here: what the mean should be when only some members produced
+    stress. MACECalculator averages in the zeros left in the unfilled slots,
+    and this now matches it rather than inventing a stricter rule.
+    """
+    with default_dtype(torch.float32):
+        good = _tiny_magnetic_model()
+        partial = _NoStressModel(_tiny_magnetic_model())
+
+    def stress_of(models):
+        atoms = Atoms(
+            numbers=[26, 26],
+            positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+            cell=[6.0] * 3,
+            pbc=True,
+        )
+        atoms.arrays["REF_magmom"] = np.tile([[0.0, 0.0, 2.2]], (2, 1))
+        calc = MagneticMACECalculator(
+            models=models,
+            device="cpu",
+            default_dtype="float32",
+            magmom_key="REF_magmom",
+        )
+        atoms.calc = calc
+        atoms.get_potential_energy()
+        return "stress" in calc.results
+
+    # first member has stress -> published, whatever the last one did
+    assert stress_of([good, partial]) is True
+    # first member has none -> not published, even though the last one had it
+    assert stress_of([partial, good]) is False

--- a/tests/unit/test_download_cache.py
+++ b/tests/unit/test_download_cache.py
@@ -1,0 +1,66 @@
+"""A failed model download must not leave anything at the cache path.
+
+_urlretrieve_with_timeout renames the body into place as soon as the HTTP fetch
+succeeds, which is before the caller inspects the content type. An error page
+served with 200 therefore lands exactly where the checkpoint belongs. Since
+every loader guards its download with `if not os.path.isfile(path)`, leaving it
+there poisons the cache for good: later calls skip the download and hand the
+HTML to torch.load, which fails with a zip-archive error bearing no relation to
+the original problem.
+"""
+
+import os
+
+import pytest
+
+from mace.calculators import foundations_models as fm
+
+
+@pytest.fixture(name="html_download")
+def fixture_html_download(tmp_path, monkeypatch):
+    """Point the cache at tmp_path and serve an HTML error page for every fetch."""
+    monkeypatch.setattr(fm, "get_cache_dir", lambda: str(tmp_path))
+
+    def fake_download(url, filename, timeout=None):
+        # the real helper has already renamed the body into place by this point
+        with open(filename, "w", encoding="utf-8") as handle:
+            handle.write("<html>404 not found</html>")
+        return filename, "Content-Type: text/html\nContent-Length: 26"
+
+    monkeypatch.setattr(fm, "_urlretrieve_with_timeout", fake_download)
+    return tmp_path
+
+
+def test_html_response_leaves_no_cached_file(html_download):
+    with pytest.raises(RuntimeError, match="Model download failed"):
+        fm.download_mace_mp_checkpoint("medium")
+
+    leftovers = os.listdir(html_download)
+    assert not leftovers, f"cache poisoned with {leftovers}"
+
+
+def test_second_attempt_retries_instead_of_reusing_the_error_page(html_download):
+    """The failure has to be reproducible, not masked by the first attempt."""
+    calls = []
+    original = fm._urlretrieve_with_timeout
+
+    def counting(url, filename, timeout=None):
+        calls.append(url)
+        return original(url, filename, timeout)
+
+    fm._urlretrieve_with_timeout = counting
+    try:
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match="Model download failed"):
+                fm.download_mace_mp_checkpoint("medium")
+    finally:
+        fm._urlretrieve_with_timeout = original
+
+    assert len(calls) == 2, (
+        "the second call reused the cached error page instead of retrying"
+    )
+
+
+def test_discard_is_quiet_when_the_file_is_already_gone(tmp_path):
+    """Cleanup must not raise on top of the error it is reporting."""
+    fm._discard_cached_download(str(tmp_path / "not-there"))


### PR DESCRIPTION
Two unrelated findings from PR #1617, both places where a hardened main path left a side path behind.

A failed download poisons the model cache

_urlretrieve_with_timeout renames the body into place as soon as the HTTP fetch succeeds, which is before the caller looks at the content type. An error page served with 200 therefore lands exactly where the checkpoint belongs. Every loader guards its download with if not os.path.isfile(path), so the bad file then stays: the next call skips the download and hands the HTML to torch.load, which fails with a zip archive error bearing no relation to the real problem. The user has to find and delete the file by hand.

The helper already cleans up its .part file when something throws. This case escaped because nothing threw. All three loaders now discard the file before raising, mace_mp and MACE Polar as well as the mace_mdp one that was reported.

The cleanup can only ever remove a file the caller just created, since the isfile guard above it means nothing was there before, so an existing cached model is unreachable from it. In a concurrent download race the outcome changes from a poisoned file to a missing one, which self heals on the next call.

Stress read from the last committee member instead of the first

MagneticMACECalculator decided whether to publish stress by reading out["stress"] after the committee loop, where out is only the last model's output. It now follows the convention the rest of the code uses: MACECalculator's _create_result_tensors allocates a key only when the first model's output has it, and everything downstream reads ret_tensors.

Nothing ever chose the last member. The gate dates from 2022, when the calculator held a single model and out was an ordinary local, and the comment it shipped with says what it is for: stress is None for a non periodic system even when compute_stress is True. A committee loop was wrapped around that code in 2023 without revisiting the line, which is how it came to mean the last member. The same line was later removed from MACECalculator in the results extraction refactor, and reintroduced here when the magnetic calculator was written against the pre refactor version.

No behaviour change for any supported configuration. With a single model the first member is the last one, and the full results dict is byte identical before and after. A committee is only reachable for magnetic models that do not emit equilibrated_magmom, since the others assert len(self.models) == 1. And the members cannot disagree in practice anyway: the condition is really asking whether the system is periodic, and pbc belongs to the atoms rather than the model, so every member sees the same answer. Producing a divergent committee for the test needed a wrapper model that reports no stress regardless of pbc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changes to download cleanup and magnetic calculator result assembly; tests cover both paths with no auth or data-model impact.
> 
> **Overview**
> Fixes two side paths left after hardened download and calculator refactors.
> 
> **Failed foundation-model downloads** no longer leave HTML error pages on the cache path. `_urlretrieve_with_timeout` already moves the response body into place before callers check `Content-Type`; when that body is `text/html`, MP, Polar, and MDP loaders now call `_discard_cached_download` before raising, so the next attempt retries instead of skipping download and confusing `torch.load` with a zip error. Unit tests cover empty cache after failure and a second retry.
> 
> **Magnetic committee stress** now follows the first model’s output, matching `MACECalculator`: `stress_available` is set when `i == 0` instead of reading `out["stress"]` after the loop (the last member). A regression test uses a wrapper that forces `stress=None` on one committee member.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f7c27d2d257ec4d7aeaa465c07feb8ef3b05f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->