### PR TITLE
Fix cuEquivariance fusion device detection

### DIFF
--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -245,7 +245,7 @@ def run(
         layout=layout,
         group="O3_e3nn",
         optimize_all=True,
-        conv_fusion=(device == "cuda"),
+        conv_fusion=(torch.device(device).type == "cuda"),
     )
 
     # Create new model with cuequivariance config

--- a/tests/unit/test_convert_e3nn_cueq.py
+++ b/tests/unit/test_convert_e3nn_cueq.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from mace.cli import convert_e3nn_cueq
+
+
+class _HiddenIrrepsStub:
+    @staticmethod
+    def slices():
+        return [slice(0, 1)]
+
+
+class _ConversionModelStub(torch.nn.Module):
+    def __init__(self, **config):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(()))
+        self.products = []
+        self.interactions = []
+        self.cueq_config = config.get("cueq_config")
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+@pytest.mark.parametrize("device", ["cuda", torch.device("cuda")])
+def test_conversion_enables_convolution_fusion_for_cuda_devices(monkeypatch, device):
+    monkeypatch.setattr(
+        convert_e3nn_cueq,
+        "extract_config_mace_model",
+        lambda model: {
+            "hidden_irreps": _HiddenIrrepsStub(),
+            "correlation": 2,
+            "num_interactions": 0,
+        },
+    )
+
+    converted = convert_e3nn_cueq.run(_ConversionModelStub(), device=device)
+
+    assert converted.cueq_config.conv_fusion is True


### PR DESCRIPTION
## Summary
- normalize the conversion device through `torch.device(device).type` before enabling convolution fusion
- preserve existing behavior for string CUDA devices while fixing `torch.device("cuda")`, which is passed by training
- add a focused regression test for both accepted device representations

## Why
The previous string comparison disabled cuEquivariance convolution fusion when the training code passed a `torch.device`. Local RTX 5090 profiling showed the corrected converted route matches native `--only_cueq` throughput within measurement noise.

## Testing
- `python -m pytest tests/unit/test_convert_e3nn_cueq.py tests/backends/test_cueq.py -q` (28 passed)
- `python -m py_compile mace/cli/convert_e3nn_cueq.py tests/unit/test_convert_e3nn_cueq.py`
- `git diff --check origin/develop...HEAD`