### PR TITLE
Write ML-IAP results back through the coupling LAMMPS actually has

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -110,12 +110,10 @@ jobs:
           if-no-files-found: ignore
 
   lammps-real:
-    # Real-tier LAMMPS via conda-forge (ML-IAP unified path). Deliberately
-    # continue-on-error while it proves itself; promote to blocking after a
-    # stable green streak.
+    # Real-tier LAMMPS via conda-forge (ML-IAP unified path). Runs a
+    # single-layer model; tests/integrations/README.md says why.
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    continue-on-error: true
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/mace/calculators/lammps_mliap_mace.py
+++ b/mace/calculators/lammps_mliap_mace.py
@@ -5,6 +5,7 @@ import time
 from contextlib import contextmanager
 from typing import Dict, Tuple
 
+import numpy as np
 import torch
 from ase.data import chemical_symbols
 from e3nn.util.jit import compile_mode
@@ -223,14 +224,44 @@ class LAMMPS_MLIAP_MACE(MLIAPUnified):
         }
 
     def _update_lammps_data(self, data, atom_energies, pair_forces, natoms):
-        """Update LAMMPS data structures with computed energies and forces."""
-        if self.dtype == torch.float32:
-            pair_forces = pair_forces.double()
-        eatoms = torch.as_tensor(data.eatoms)
-        atom_energies_real = atom_energies[:natoms].detach()
-        eatoms.copy_(atom_energies_real)
-        data.energy = atom_energies_real.sum().item()
-        data.update_pair_forces_gpu(pair_forces)
+        """Write per-atom energies and pair forces back into LAMMPS.
+
+        The two ML-IAP couplings expose two different writeback APIs, and only
+        the KOKKOS one takes device pointers: its ``MLIAPDataPy`` has an
+        ``eatoms`` getter (a view to copy into) and ``update_pair_forces_gpu``.
+        The plain coupling (``src/ML-IAP/mliap_unified_couple.pyx``) declares
+        ``eatoms`` write-only and offers only ``update_pair_forces``, which
+        wants a contiguous host array -- so on a stock non-KOKKOS build the
+        model used to run to completion and then die here on ``property
+        'eatoms' ... has no getter``, three frames below anything that names
+        the build. Both branches end in the same C ``update_pair_forces``;
+        only where the pointer comes from differs.
+        """
+        atom_energies_real = atom_energies[:natoms].detach().double()
+        total_energy = atom_energies_real.sum().item()
+        pair_forces = pair_forces.detach().double()
+
+        if hasattr(data, "update_pair_forces_gpu"):
+            torch.as_tensor(data.eatoms).copy_(atom_energies_real)
+            data.energy = total_energy
+            data.update_pair_forces_gpu(pair_forces)
+            return
+
+        # The write-only setter fills exactly nlistatoms doubles and Cython
+        # rejects a length mismatch, so say which two counts disagree rather
+        # than leaving a bare ValueError from inside the .pyx. The KOKKOS
+        # branch above assumes the same equality (its getter is sized by
+        # nlistatoms while the slice is sized by nlocal).
+        nlistatoms = int(getattr(data, "nlistatoms", natoms))
+        if nlistatoms != natoms:
+            raise RuntimeError(
+                f"LAMMPS expects {nlistatoms} per-atom energies (nlistatoms) "
+                f"but this step computed {natoms} (nlocal). The ML-IAP "
+                f"writeback needs the two to agree."
+            )
+        data.eatoms = atom_energies_real.cpu().numpy()
+        data.energy = total_energy
+        data.update_pair_forces(np.ascontiguousarray(pair_forces.cpu().numpy()))
 
     def _manage_profiling(self):
         if not self.config.debug_profile:

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -23,6 +23,18 @@ path stays in the contract tier (`lammps/test_mliap_exchange.py`, which also
 pins the actionable error the non-KOKKOS case now raises), and no bump of the
 `lammps` package will change that.
 
+`forward_exchange` is not the only KOKKOS-only call, and the second one is
+worse because it lands *after* the model has run: the writeback in
+`lammps_mliap_mace._update_lammps_data` used `data.eatoms` (a getter that
+exists only in the KOKKOS coupling — the plain one declares it a
+`write_only_property`) and `update_pair_forces_gpu` (KOKKOS-only outright).
+A single-layer model on a stock build therefore still died, with
+`property 'eatoms' ... has no getter` surfacing as a bare
+`mliap_unified.cpp:71 compute_forces failure`. The writeback now branches on
+the coupling, and both branches are pinned in `lammps/test_mliap_writeback.py`
+with stubs that reproduce each `.pyx`'s property shape — the real tier can only
+ever exercise the non-KOKKOS one.
+
 ## Adding integration X
 
 1. Create `tests/integrations/<x>/` with contract tests (and a `_harness.py`

--- a/tests/integrations/README.md
+++ b/tests/integrations/README.md
@@ -44,7 +44,10 @@ ever exercise the non-KOKKOS one.
    a broken install must read as unavailable).
 3. Mark real-tier tests `@pytest.mark.bin_<x>`.
 4. Add a paths-filtered contract job to `.github/workflows/ci-integrations.yaml`
-   and a real-tier job to `nightly.yaml` (start it with `continue-on-error:
-   true`; promote to blocking once it has been green for a while).
+   and a **blocking** real-tier job to `nightly.yaml`. Not
+   `continue-on-error`: a job that cannot turn the run red is indistinguishable
+   from a job that does not exist, and LAMMPS proved it by failing every night
+   for weeks under a green nightly. Too flaky to block means land it disabled,
+   or leave it out until it is not.
 5. If tests need a trained model, use the session-scoped
    `trained_tiny_model_path` fixture — never train per-test.

--- a/tests/integrations/lammps/_harness.py
+++ b/tests/integrations/lammps/_harness.py
@@ -19,6 +19,21 @@ from mace.tools import AtomicNumberTable, torch_geometric
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+class StubMACE(torch.nn.Module):
+    """The metadata the LAMMPS wrappers read off a real MACE model.
+
+    ``dtype`` follows ``r_max``, exactly as `LAMMPS_MLIAP_MACE.__init__` does,
+    so a float32 stub exercises the float32 writeback path.
+    """
+
+    def __init__(self, num_interactions: int, dtype: torch.dtype = torch.float64):
+        super().__init__()
+        self.register_buffer("atomic_numbers", torch.tensor([1, 8]))
+        self.register_buffer("r_max", torch.tensor(3.5, dtype=dtype))
+        self.register_buffer("num_interactions", torch.tensor(num_interactions))
+        self.lin = torch.nn.Linear(1, 1)
+
+
 def water_unit_cell() -> Atoms:
     """The periodic water box the tiny session model was trained on."""
     return Atoms(

--- a/tests/integrations/lammps/test_mliap_exchange.py
+++ b/tests/integrations/lammps/test_mliap_exchange.py
@@ -10,6 +10,7 @@ from mace.modules.blocks import (
     RealAgnosticDensityResidualInteractionBlock,
     RealAgnosticResidualNonLinearInteractionBlock,
 )
+from tests.integrations.lammps._harness import StubMACE
 
 
 class DummyMP(
@@ -129,17 +130,6 @@ def test_mliap_exchange_density_residual(monkeypatch):
     assert sc.shape[0] == n_real
 
 
-class _StubMACE(torch.nn.Module):
-    """The metadata `MACEEdgeForcesWrapper` reads off a real MACE model."""
-
-    def __init__(self, num_interactions):
-        super().__init__()
-        self.register_buffer("atomic_numbers", torch.tensor([1, 8]))
-        self.register_buffer("r_max", torch.tensor(3.5))
-        self.register_buffer("num_interactions", torch.tensor(num_interactions))
-        self.lin = torch.nn.Linear(1, 1)
-
-
 def _mliap_data(**attrs):
     """A stand-in for LAMMPS's MLIAPDataPy, with only the attributes named."""
     return types.SimpleNamespace(elems=torch.zeros(3, dtype=torch.int64), **attrs)
@@ -150,7 +140,7 @@ def test_multilayer_without_forward_exchange_is_actionable(num_interactions):
     # conda-forge's CPU LAMMPS builds with PKG_KOKKOS=OFF, so its MLIAPDataPy
     # has no forward_exchange and a >1-layer model used to die on a bare
     # AttributeError three frames deep in the second interaction block.
-    unified = LAMMPS_MLIAP_MACE(_StubMACE(num_interactions))
+    unified = LAMMPS_MLIAP_MACE(StubMACE(num_interactions))
     data = _mliap_data()
 
     with pytest.raises(RuntimeError, match="PKG_KOKKOS"):
@@ -160,11 +150,11 @@ def test_multilayer_without_forward_exchange_is_actionable(num_interactions):
 def test_single_layer_needs_no_forward_exchange():
     # One layer never leaves the local atoms, which is what makes a stock
     # non-KOKKOS build usable at all -- and what the real tier relies on.
-    unified = LAMMPS_MLIAP_MACE(_StubMACE(1))
+    unified = LAMMPS_MLIAP_MACE(StubMACE(1))
     unified._check_ghost_exchange_support(_mliap_data())  # pylint: disable=protected-access
 
 
 def test_multilayer_with_forward_exchange_is_accepted():
-    unified = LAMMPS_MLIAP_MACE(_StubMACE(2))
+    unified = LAMMPS_MLIAP_MACE(StubMACE(2))
     data = _mliap_data(forward_exchange=lambda *_: None)
     unified._check_ghost_exchange_support(data)  # pylint: disable=protected-access

--- a/tests/integrations/lammps/test_mliap_writeback.py
+++ b/tests/integrations/lammps/test_mliap_writeback.py
@@ -1,0 +1,135 @@
+"""Contract tier: the ML-IAP energy/force writeback, on both couplings.
+
+LAMMPS ships two ML-IAP Python couplings with *different* writeback APIs, and
+the difference is invisible until the model has already run:
+
+* ``src/KOKKOS/mliap_unified_couple_kokkos.pyx`` — ``eatoms`` has a getter
+  (a view sized by ``nlistatoms``, copied into in place) and there is an
+  ``update_pair_forces_gpu`` that takes a device pointer.
+* ``src/ML-IAP/mliap_unified_couple.pyx`` — ``eatoms`` is a
+  ``write_only_property`` (``property(fget=None, fset=...)``) and only
+  ``update_pair_forces`` exists, taking a contiguous host ``double[:, ::1]``.
+
+conda-forge builds every CPU ``lammps`` with ``PKG_KOKKOS=OFF``, so the plain
+coupling is what the nightly real tier actually gets — and reading ``eatoms``
+there raises ``property 'eatoms' of 'MLIAPDataPy' object has no getter``.
+The stubs below mirror both property shapes so the two branches stay covered
+without a LAMMPS binary; the real tier can only ever exercise one of them.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from mace.calculators.lammps_mliap_mace import LAMMPS_MLIAP_MACE
+from tests.integrations.lammps._harness import StubMACE
+
+
+class _PlainData:
+    """The non-KOKKOS MLIAPDataPy: write-only eatoms/energy, host forces."""
+
+    def __init__(self, natoms, nlistatoms=None):
+        self.nlocal = natoms
+        self.nlistatoms = natoms if nlistatoms is None else nlistatoms
+        self.eatoms_written = None
+        self.energy_written = None
+        self.forces_written = None
+
+    def _set_eatoms(self, value):
+        # Cython's `double[:] value_view = value` accepts only a real float64
+        # buffer -- a torch tensor or a float32 array raises there, so reject
+        # them here too instead of quietly recording something LAMMPS would
+        # not have taken.
+        assert isinstance(value, np.ndarray), f"eatoms got {type(value)}"
+        assert value.dtype == np.float64, value.dtype
+        assert value.shape == (self.nlistatoms,), value.shape
+        self.eatoms_written = value.copy()
+
+    def _set_energy(self, value):
+        assert isinstance(value, float), f"energy got {type(value)}"
+        self.energy_written = value
+
+    eatoms = property(fget=None, fset=_set_eatoms)
+    energy = property(fget=None, fset=_set_energy)
+
+    def update_pair_forces(self, fij):
+        assert isinstance(fij, np.ndarray), f"forces got {type(fij)}"
+        assert fij.dtype == np.float64, fij.dtype
+        assert fij.flags["C_CONTIGUOUS"], "update_pair_forces needs double[:, ::1]"
+        self.forces_written = fij.copy()
+
+
+class _KokkosData:
+    """The KOKKOS MLIAPDataPy: an eatoms view to copy into, forces by pointer."""
+
+    def __init__(self, natoms):
+        self.nlocal = natoms
+        self.nlistatoms = natoms
+        self.eatoms = torch.zeros(natoms, dtype=torch.float64)
+        self.energy = None
+        self.forces_written = None
+
+    def update_pair_forces_gpu(self, fij):
+        assert isinstance(fij, torch.Tensor), f"forces got {type(fij)}"
+        assert fij.dtype == torch.float64, fij.dtype
+        self.forces_written = fij
+
+
+def _writeback(data, unified, natoms=3, npairs=4):
+    atom_energies = torch.arange(1.0, natoms + 1, dtype=unified.dtype)
+    pair_forces = torch.arange(3.0 * npairs, dtype=unified.dtype).reshape(npairs, 3)
+    unified._update_lammps_data(  # pylint: disable=protected-access
+        data, atom_energies, pair_forces, natoms
+    )
+    return atom_energies.double(), pair_forces.double()
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32])
+def test_plain_coupling_writes_through_the_host_api(dtype):
+    # The regression: this path used to read data.eatoms, which the non-KOKKOS
+    # coupling does not expose, so the nightly real tier failed here with the
+    # model already evaluated.
+    unified = LAMMPS_MLIAP_MACE(StubMACE(1, dtype=dtype))
+    data = _PlainData(natoms=3)
+
+    energies, forces = _writeback(data, unified)
+
+    assert np.allclose(data.eatoms_written, energies.numpy())
+    assert data.energy_written == pytest.approx(energies.sum().item())
+    assert np.allclose(data.forces_written, forces.numpy())
+
+
+def test_kokkos_coupling_copies_into_the_eatoms_view():
+    unified = LAMMPS_MLIAP_MACE(StubMACE(1))
+    data = _KokkosData(natoms=3)
+    view = data.eatoms
+
+    energies, forces = _writeback(data, unified)
+
+    # In place: LAMMPS owns that buffer, so rebinding the attribute instead of
+    # copying would drop the energies on the floor.
+    assert view.data_ptr() == data.eatoms.data_ptr()
+    assert torch.allclose(view, energies)
+    assert data.energy == pytest.approx(energies.sum().item())
+    assert torch.allclose(data.forces_written, forces)
+
+
+def test_float32_model_hands_lammps_float64():
+    # LAMMPS reads both buffers as double regardless of the model's dtype.
+    unified = LAMMPS_MLIAP_MACE(StubMACE(1, dtype=torch.float32))
+    assert unified.dtype == torch.float32
+    data = _KokkosData(natoms=3)
+
+    _writeback(data, unified)
+
+    assert data.forces_written.dtype == torch.float64
+
+
+def test_atom_count_mismatch_is_actionable():
+    # The write-only setter fills exactly nlistatoms doubles and Cython rejects
+    # a length mismatch from inside the .pyx, naming neither count.
+    unified = LAMMPS_MLIAP_MACE(StubMACE(1))
+    data = _PlainData(natoms=3, nlistatoms=4)
+
+    with pytest.raises(RuntimeError, match="nlistatoms"):
+        _writeback(data, unified)


### PR DESCRIPTION
The nightly `lammps-real` job has never passed a single test.

The writeback in `_update_lammps_data` used two calls that only exist in LAMMPS's KOKKOS coupling: reading `data.eatoms`, and `update_pair_forces_gpu`. conda-forge builds LAMMPS without KOKKOS, so on the job's binary neither is there. The plain coupling has a write only `eatoms` and takes forces as a host array through `update_pair_forces`.

The error was unhelpful. The model ran fine, then LAMMPS reported `mliap_unified.cpp:71 compute_forces failure` over `property 'eatoms' of 'MLIAPDataPy' object has no getter`.

The writeback now picks the right API for whichever coupling is present. Both end in the same C call, so nothing changes on a KOKKOS build.

`test_mliap_writeback.py` covers both paths without a binary. Revert the fix and it reproduces the nightly failure. `tests/integrations` is 19 passed.

The job also loses `continue-on-error: true`. That flag is why the failure went unnoticed for weeks, since the nightly reported success by absence. If this breaks again we want a red run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7eb5d625947a3c3f0200ebca075a6897adc2249d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->