### PR TITLE
Fix LAMMPS export for models saved before avg_num_neighbors became a buffer

### DIFF
--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -6,8 +6,9 @@
 ###########################################################################################
 # pylint: disable=too-many-lines
 
+import itertools
 from abc import abstractmethod
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch.nn.functional
@@ -676,6 +677,58 @@ class InteractionBlock(torch.nn.Module):
         if self.cueq_config and self.cueq_config.conv_fusion:
             self.conv_fusion = self.cueq_config.conv_fusion
         self._setup()
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        super().__setstate__(state)
+        self._adopt_unpickled_avg_num_neighbors()
+
+    def _adopt_unpickled_avg_num_neighbors(self) -> None:
+        """Make a pickled float into the buffer this attribute now is.
+
+        `avg_num_neighbors` became a registered buffer with a declared
+        `torch.Tensor` type, and `_load_from_state_dict` covers checkpoints
+        loaded *as state dicts*. It does not cover the other way MACE ships a
+        model: `torch.load` of a whole pickled module, which is what the ASE
+        calculator, every `mace/cli` tool and the pretrained artifacts under
+        `mace/calculators/foundations_models/` all use. Unpickling restores
+        `__dict__` directly, so neither `__init__` nor `_load_from_state_dict`
+        runs, and the instance keeps the plain Python float it was pickled
+        with. Eager forward passes are indifferent -- a float promotes against
+        whatever it divides -- so this surfaces only under TorchScript, where
+        the declared type is checked:
+
+            Could not cast attribute 'avg_num_neighbors' to type Tensor
+
+        which made `mace_create_lammps_model` fail on every checkpoint written
+        before the buffer landed.
+
+        The dtype is taken from the module's own weights rather than from
+        `torch.get_default_dtype()`, because that is what preserves the
+        arithmetic. As a Python float the value participated at the precision
+        of whatever it was divided into, so a float64 model whose buffer was
+        built at the process default of float32 would silently round the
+        normalization -- a numerical change on load, in a value that scales
+        every message.
+        """
+        legacy = self.__dict__.pop("avg_num_neighbors", None)
+        if legacy is None:
+            return  # already a buffer: pickled after it became one
+        self.register_buffer(
+            "avg_num_neighbors", torch.as_tensor(legacy, dtype=self._parameter_dtype())
+        )
+
+    def _parameter_dtype(self) -> torch.dtype:
+        """The floating dtype of this block's weights, or the process default.
+
+        The weights live in submodules, and they are in place by the time
+        `__setstate__` runs -- pickle builds the whole state mapping, child
+        modules included, before handing it over. The fallback is for a block
+        that genuinely has no floating tensor yet.
+        """
+        for tensor in itertools.chain(self.parameters(), self.buffers()):
+            if tensor.is_floating_point():
+                return tensor.dtype
+        return torch.get_default_dtype()
 
     def set_avg_num_neighbors(self, value: Union[float, torch.Tensor]) -> None:
         """Copy neighbor normalization from current or legacy models."""

--- a/mace/modules/blocks.py
+++ b/mace/modules/blocks.py
@@ -702,23 +702,37 @@ class InteractionBlock(torch.nn.Module):
         which made `mace_create_lammps_model` fail on every checkpoint written
         before the buffer landed.
 
-        The dtype is taken from the module's own weights rather than from
-        `torch.get_default_dtype()`, because that is what preserves the
-        arithmetic. As a Python float the value participated at the precision
-        of whatever it was divided into, so a float64 model whose buffer was
-        built at the process default of float32 would silently round the
-        normalization -- a numerical change on load, in a value that scales
+        Both the dtype and the device come from the module's own weights, so
+        the promoted buffer lands beside them.
+
+        The dtype matters because it preserves the arithmetic. As a Python
+        float the value participated at the precision of whatever it was
+        divided into, so taking `torch.get_default_dtype()` instead would
+        silently round the normalization of a float64 model loaded under a
+        float32 default -- a numerical change on load, in a value that scales
         every message.
+
+        The device matters because a float has none. `torch.load(...,
+        map_location="cuda")` puts the weights on the accelerator, and a
+        promoted buffer built without a device would stay on the CPU, leaving
+        the module's tensors split across two devices for any caller that does
+        not go on to `.to()` -- the raw-model foundation loaders, and anything
+        that hands a freshly loaded model straight to DDP. `avg_num_neighbors`
+        is zero-dim, so the division itself would survive under torch's
+        cpu-scalar rule; what does not survive is everything that assumes a
+        module's tensors are colocated. `set_avg_num_neighbors` above already
+        carries both, and this is the same rule.
         """
         legacy = self.__dict__.pop("avg_num_neighbors", None)
         if legacy is None:
             return  # already a buffer: pickled after it became one
+        dtype, device = self._weight_dtype_and_device()
         self.register_buffer(
-            "avg_num_neighbors", torch.as_tensor(legacy, dtype=self._parameter_dtype())
+            "avg_num_neighbors", torch.as_tensor(legacy, dtype=dtype, device=device)
         )
 
-    def _parameter_dtype(self) -> torch.dtype:
-        """The floating dtype of this block's weights, or the process default.
+    def _weight_dtype_and_device(self) -> Tuple[torch.dtype, torch.device]:
+        """Where this block's weights are, or the process defaults.
 
         The weights live in submodules, and they are in place by the time
         `__setstate__` runs -- pickle builds the whole state mapping, child
@@ -727,8 +741,8 @@ class InteractionBlock(torch.nn.Module):
         """
         for tensor in itertools.chain(self.parameters(), self.buffers()):
             if tensor.is_floating_point():
-                return tensor.dtype
-        return torch.get_default_dtype()
+                return tensor.dtype, tensor.device
+        return torch.get_default_dtype(), torch.device("cpu")
 
     def set_avg_num_neighbors(self, value: Union[float, torch.Tensor]) -> None:
         """Copy neighbor normalization from current or legacy models."""

--- a/tests/unit/test_avg_num_neighbors_buffer.py
+++ b/tests/unit/test_avg_num_neighbors_buffer.py
@@ -155,18 +155,23 @@ def test_the_promoted_buffer_follows_a_map_location_onto_the_device():
     devices. `avg_num_neighbors` is zero-dim, so the division itself survives
     under torch's cpu-scalar rule; what breaks is every caller that assumes a
     module's tensors are colocated, DDP among them.
+
+    Scoped to these buffers on purpose. "every buffer sits on the parameter
+    device" is the assertion a reader reaches for next, and it fails for a
+    reason that has nothing to do with this: e3nn keeps its Wigner 3j tables
+    inside `TensorProduct._compiled_main_left_right`, a `torch.fx.GraphModule`
+    that unpickles by regenerating itself, so those buffers come back on the
+    CPU whatever `map_location` said. That reproduces on a model pickled long
+    after this promotion existed, so it is e3nn's to answer for, not this.
     """
     buffer = io.BytesIO()
     torch.save(_make_legacy(_build_model()), buffer)
     buffer.seek(0)
     loaded = torch.load(buffer, weights_only=False, map_location="cuda")
 
-    block = loaded.interactions[0]
-    assert block.avg_num_neighbors.device.type == "cuda"
-    assert block.avg_num_neighbors.device == next(block.parameters()).device
-    assert {t.device for t in loaded.buffers()} == {
-        p.device for p in loaded.parameters()
-    }
+    for block in loaded.interactions:
+        assert block.avg_num_neighbors.device.type == "cuda"
+        assert block.avg_num_neighbors.device == next(block.parameters()).device
 
 
 def test_a_model_pickled_after_the_buffer_landed_is_untouched():

--- a/tests/unit/test_avg_num_neighbors_buffer.py
+++ b/tests/unit/test_avg_num_neighbors_buffer.py
@@ -1,0 +1,185 @@
+"""`avg_num_neighbors` is a buffer, including on models pickled before it was.
+
+It became a registered buffer with a declared `torch.Tensor` type so that
+TorchScript could see it. `_load_from_state_dict` covers checkpoints loaded as
+state dicts; these tests cover the other way MACE ships a model, which is a
+`torch.load` of the whole pickled module -- the ASE calculator, every
+`mace/cli` tool, and the pretrained artifacts inside the wheel. Unpickling
+restores `__dict__` directly, so neither `__init__` nor `_load_from_state_dict`
+runs, and without `__setstate__` the instance keeps its plain Python float.
+
+That is invisible in eager mode, because a float promotes against whatever it
+divides. It is fatal under `torch.jit.script`, which is why
+`mace_create_lammps_model` is the test that matters here: exporting any
+pre-buffer checkpoint died on
+
+    Could not cast attribute 'avg_num_neighbors' to type Tensor
+"""
+
+import io
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from e3nn import o3
+
+from mace import modules, tools
+
+#: not exactly representable in float32, so a float32/float64 mix-up shows up as
+#: a changed value rather than passing by luck (4.59375, the value the committed
+#: anchor carries, is exact in both and would hide it).
+AVG_NUM_NEIGHBORS = 8.317_483_291_745_2
+
+TABLE = tools.AtomicNumberTable([1, 6])
+
+
+def _build_model() -> modules.ScaleShiftMACE:
+    return modules.ScaleShiftMACE(
+        r_max=3.0,
+        num_bessel=4,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e + 8x1o"),
+        MLP_irreps=o3.Irreps("4x0e"),
+        gate=F.silu,
+        atomic_energies=np.array([-1.0, -5.0]),
+        avg_num_neighbors=AVG_NUM_NEIGHBORS,
+        atomic_numbers=TABLE.zs,
+        correlation=2,
+        atomic_inter_scale=1.0,
+        atomic_inter_shift=0.0,
+    )
+
+
+def _make_legacy(
+    model: torch.nn.Module, value: float = AVG_NUM_NEIGHBORS
+) -> torch.nn.Module:
+    """The pickled shape of a pre-buffer checkpoint: a plain float attribute.
+
+    Written by hand rather than by committing an old checkpoint, so the test
+    says what the old shape *was* instead of depending on a binary.
+
+    `value` is set from the double it started as, not read back out of the
+    buffer: before the buffer existed nothing rounded it, so a real pre-buffer
+    checkpoint carries the full-precision float. Reading it back through the
+    current buffer -- which `__init__` builds at the *process* default dtype --
+    would hand the test an already-rounded number and hide exactly the
+    precision question the dtype case below asks.
+    """
+    for block in model.interactions:
+        del block._buffers["avg_num_neighbors"]
+        block.__dict__["avg_num_neighbors"] = value
+    return model
+
+
+def _round_trip(model: torch.nn.Module) -> torch.nn.Module:
+    """Save and load the whole module, which is how MACE ships a checkpoint."""
+    buffer = io.BytesIO()
+    torch.save(model, buffer)
+    buffer.seek(0)
+    return torch.load(buffer, weights_only=False, map_location="cpu")
+
+
+def test_a_legacy_pickle_comes_back_with_the_buffer():
+    legacy = _make_legacy(_build_model())
+    assert "avg_num_neighbors" not in legacy.interactions[0]._buffers
+
+    loaded = _round_trip(legacy)
+
+    for block in loaded.interactions:
+        assert "avg_num_neighbors" in block._buffers
+        assert "avg_num_neighbors" not in block.__dict__
+        assert isinstance(block.avg_num_neighbors, torch.Tensor)
+
+
+def test_a_legacy_pickle_can_be_torchscripted():
+    """The failure this fixes, at its narrowest: the declared type is checked
+    only when the module is scripted, which is what the LAMMPS export does."""
+    loaded = _round_trip(_make_legacy(_build_model()))
+    assert torch.jit.script(loaded.interactions[0]) is not None
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_the_promoted_buffer_keeps_the_value_at_the_models_precision(dtype):
+    loaded = _round_trip(_make_legacy(_build_model().to(dtype)))
+
+    buffer = loaded.interactions[0].avg_num_neighbors
+    assert buffer.dtype == dtype
+    assert buffer.item() == torch.tensor(AVG_NUM_NEIGHBORS, dtype=dtype).item()
+
+
+def test_the_dtype_follows_the_model_not_the_process_default():
+    """A float participated at the precision of whatever it divided, so taking
+    the process default would silently round the normalization of a float64
+    model loaded under a float32 default -- every message is scaled by it."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float32)  # set, not asserted: xdist shares a process
+    try:
+        loaded = _round_trip(_make_legacy(_build_model().double()))
+    finally:
+        torch.set_default_dtype(previous)
+
+    buffer = loaded.interactions[0].avg_num_neighbors
+    assert buffer.dtype == torch.float64
+    assert buffer.item() == AVG_NUM_NEIGHBORS
+
+
+def test_a_model_pickled_after_the_buffer_landed_is_untouched():
+    """The promotion must not fire twice, or re-cast a buffer somebody set."""
+    model = _build_model().double()
+    loaded = _round_trip(model)
+
+    buffer = loaded.interactions[0].avg_num_neighbors
+    assert buffer.dtype == torch.float64
+    assert buffer.item() == pytest.approx(AVG_NUM_NEIGHBORS)
+    assert "avg_num_neighbors" not in loaded.interactions[0].__dict__
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_promotion_reproduces_the_arithmetic_of_the_float_it_replaced(dtype):
+    """The reason the dtype follows the model, measured rather than argued.
+
+    The reference is the *legacy* block itself -- still holding the plain float,
+    which eager mode is happy to divide by -- so the comparison is against what
+    the checkpoint computed before the buffer existed, in the same module with
+    the same weights. Bit-exact, not close: the promotion is a change of storage
+    and must not be a change of numerics.
+    """
+    torch.manual_seed(2026)
+    legacy = _make_legacy(_build_model().to(dtype))
+    block = legacy.interactions[0]
+
+    node_attrs = torch.zeros(3, 2, dtype=dtype)
+    node_attrs[:, 0] = 1.0
+    node_feats = torch.randn(3, block.node_feats_irreps.dim, dtype=dtype)
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    vectors = torch.randn(4, 3, dtype=dtype)
+    edge_attrs = o3.spherical_harmonics(
+        block.edge_attrs_irreps, vectors, normalize=True, normalization="component"
+    )
+    edge_feats = torch.randn(4, block.edge_feats_irreps.dim, dtype=dtype)
+
+    def messages(module):
+        with torch.no_grad():
+            out, _ = module(
+                node_attrs=node_attrs,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+            )
+        return out
+
+    reference = messages(block)
+    promoted = messages(_round_trip(legacy).interactions[0])
+
+    torch.testing.assert_close(promoted, reference, rtol=0, atol=0)

--- a/tests/unit/test_avg_num_neighbors_buffer.py
+++ b/tests/unit/test_avg_num_neighbors_buffer.py
@@ -133,6 +133,42 @@ def test_the_dtype_follows_the_model_not_the_process_default():
     assert buffer.item() == AVG_NUM_NEIGHBORS
 
 
+def test_the_promoted_buffer_lands_beside_the_weights():
+    """A float has no device; a buffer does, and it has to be the right one.
+
+    Asserted on every host, but it can only *fail* where a second device
+    exists, so the gpu case below is the one that measures it. Together they
+    say the same thing: after promotion the module's tensors are colocated.
+    """
+    loaded = _round_trip(_make_legacy(_build_model()))
+
+    block = loaded.interactions[0]
+    assert block.avg_num_neighbors.device == next(block.parameters()).device
+
+
+@pytest.mark.gpu
+def test_the_promoted_buffer_follows_a_map_location_onto_the_device():
+    """`torch.load(..., map_location="cuda")` is a load path that never calls
+    `.to()`, so nothing downstream repairs a buffer left on the CPU.
+
+    Building the buffer without a device left the module split across two
+    devices. `avg_num_neighbors` is zero-dim, so the division itself survives
+    under torch's cpu-scalar rule; what breaks is every caller that assumes a
+    module's tensors are colocated, DDP among them.
+    """
+    buffer = io.BytesIO()
+    torch.save(_make_legacy(_build_model()), buffer)
+    buffer.seek(0)
+    loaded = torch.load(buffer, weights_only=False, map_location="cuda")
+
+    block = loaded.interactions[0]
+    assert block.avg_num_neighbors.device.type == "cuda"
+    assert block.avg_num_neighbors.device == next(block.parameters()).device
+    assert {t.device for t in loaded.buffers()} == {
+        p.device for p in loaded.parameters()
+    }
+
+
 def test_a_model_pickled_after_the_buffer_landed_is_untouched():
     """The promotion must not fire twice, or re-cast a buffer somebody set."""
     model = _build_model().double()


### PR DESCRIPTION
`mace_create_lammps_model` fails on any model file saved before #1538. That includes all the published foundation models.

```
RuntimeError: Could not cast attribute 'avg_num_neighbors' to type Tensor:
Unable to cast 15.652482986450195 to Tensor
```

To reproduce on develop:

```bash
python mace/cli/create_lammps_model.py tests/golden/models/tiny_scaleshift.model
```

#1538 turned `avg_num_neighbors` into a buffer, and handled old checkpoints loaded as state dicts. It did not handle whole pickled models, which is how MACE ships and loads them. Loading a pickle skips `__init__`, so the value stays a plain float. Normal inference still works, because a float divides fine. TorchScript rejects it.

The fix adds `__setstate__` to turn that float into the buffer. The dtype comes from the model's own weights, so the value is not rounded.

Only TorchScript export was broken. The calculator, `torch.load` and fine tuning all worked before and after.

Tests: 8 new cases in `tests/unit/test_avg_num_neighbors_buffer.py`, 5 of them fail without the fix. `tests/unit` and `tests/golden` pass (422). The LAMMPS tests pass (14). Exporting MACE-OFF23_small works now. float64 results are bit identical to develop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d95a1ba4f2f2651b5fb0fbf970a32f6bd8344024. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->