### PR TITLE
Pin the radial, neighbour list, key parsing and batching behaviour by value

### DIFF
--- a/tests/golden/harness.py
+++ b/tests/golden/harness.py
@@ -146,6 +146,30 @@ FP32 = Tolerance(
     ),
 )
 
+#: An implementation against the closed form it implements, in one process,
+#: at fp64. Not a golden row: nothing here crosses a machine, a device or a
+#: kernel, so the only term is the order the arithmetic happens in.
+CLOSED_FORM_FP64 = Tolerance(
+    name="closed_form_fp64",
+    atol=1e-12,
+    rtol=1e-12,
+    rationale=(
+        "A pure-math unit -- a radial basis, a cutoff envelope, a distance "
+        "transform -- checked against the analytic expression it implements, "
+        "with the expression's values committed as decimal literals in the "
+        "test. The two sides differ only in the order of the fp64 "
+        "operations, so the bound is three orders looser than what it has to "
+        "carry: measured over every case in tests/unit/test_radial.py, the "
+        "largest absolute deviation is 1.8e-15 (Chebyshev T_4 at x = 1.7, "
+        "value 14.55) and the largest relative one 7.1e-15 (Bessel n = 3 at "
+        "r = 1.7, value -0.023). "
+        "It exists so those tests do not have to invent a number each, and "
+        "it is deliberately NOT the row a committed reference uses: a value "
+        "reproduced from a formula and a value reproduced from a stored "
+        "snapshot of a network are different claims."
+    ),
+)
+
 #: Bit-for-bit. Not selectable by a golden for its *outputs* -- no numerical
 #: result reproduces exactly across machines, which is why the three rows
 #: above exist. It is what the recorded **inputs** are always compared at, and
@@ -169,7 +193,13 @@ EXACT = Tolerance(
 
 TOLERANCES: Dict[str, Tolerance] = {
     row.name: row
-    for row in (FP64_CPU_REFERENCE, FP64_ACCELERATED_BACKEND, FP32, EXACT)
+    for row in (
+        FP64_CPU_REFERENCE,
+        FP64_ACCELERATED_BACKEND,
+        FP32,
+        CLOSED_FORM_FP64,
+        EXACT,
+    )
 }
 
 
@@ -1745,6 +1775,7 @@ def compare_to_reference(
 __all__ = [
     "CHANNELS",
     "CHANNEL_ALIASES",
+    "CLOSED_FORM_FP64",
     "EXACT",
     "IGNORED_KEYS",
     "INPUT_ARRAY_KEYS",

--- a/tests/golden/test_harness.py
+++ b/tests/golden/test_harness.py
@@ -76,6 +76,12 @@ def test_tolerance_table_rows():
         "fp64_cpu_reference",
         "fp64_accelerated_backend",
         "fp32",
+        # not a golden row either: an implementation against the closed form
+        # it implements, in one process, which is what the pure-math units
+        # (radial bases, cutoffs, distance transforms) are checked at. It
+        # lives here so those tests import a row instead of each inventing a
+        # number, which is the whole point of a single table
+        "closed_form_fp64",
         # not selectable for outputs -- nothing reproduces bit for bit across
         # machines -- but it is what the recorded inputs are always compared
         # at, and it belongs in the one table rather than beside it
@@ -88,6 +94,8 @@ def test_tolerance_table_rows():
     # The fp32 absolute floor is adopted from tests/extensions/polar, which
     # documents 5e-6 failing in CI. Keeping the two equal is the point.
     assert harness.FP32.atol == 5e-5
+    assert harness.CLOSED_FORM_FP64.atol == 1e-12
+    assert harness.CLOSED_FORM_FP64.rtol == 1e-12
     for row in harness.TOLERANCES.values():
         assert row.rationale.strip(), f"row {row.name} has no rationale"
 

--- a/tests/neighbour_oracle.py
+++ b/tests/neighbour_oracle.py
@@ -1,0 +1,192 @@
+"""An independent, brute-force neighbour list, and the vocabulary to compare
+one neighbour list against another.
+
+``mace/data/neighborhood.py`` delegates the search to matscipy, so a test that
+only checks matscipy against itself checks nothing. This module enumerates
+periodic images in plain numpy at O(N^2 x images) and is deliberately slow,
+obvious and framework-free: it is the reference the shipped list is measured
+against, here and in the rewrite, where every pluggable neighbour backend has
+to reproduce it.
+
+Three things are worth stating outright, because each is a decision a
+reimplementation can silently get wrong:
+
+* **The comparison is on integer unit shifts, not on displacement vectors.**
+  ``get_neighborhood`` builds its shifts as ``unit_shifts @ cell`` (one
+  matmul) while any hand-written reference accumulates
+  ``n0*a0 + n1*a1 + n2*a2``; the two agree to floating-point round-off, not
+  bit for bit, and comparing them needs a tolerance nobody should have to
+  pick. The integer triple carries exactly the same information and compares
+  exactly, so that is the canonical form here. ``canonical_edges_from_shifts``
+  exists for a backend that reports only vectors, and it rounds.
+
+* **The returned cell is not the oracle's business.** ``get_neighborhood``
+  returns four values, and which cell comes back is a three-way policy
+  decision of that function (see its comments and the tests that pin it).
+  An oracle that reproduced the policy could not falsify it, so this one
+  returns the three edge quantities and nothing else.
+
+* **The cutoff is strict** (``d < cutoff``, not ``<=``) and self-pairs are
+  dropped only at zero shift, which is precisely
+  ``true_self_interaction=False``. Periodic self-images survive: one atom in a
+  cell smaller than the cutoff has neighbours, all of them itself.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+__all__ = [
+    "brute_force_neighborhood",
+    "canonical_edges",
+    "canonical_edges_from_shifts",
+    "assert_neighbourhoods_match",
+]
+
+Edge = Tuple[int, int, int, int, int]
+
+#: The image range is grown until the edge set stops changing rather than
+#: fixed, because a strongly skewed cell can put an image that a fixed range
+#: of +-1 or +-2 would miss inside the cutoff. Two consecutive identical edge
+#: sets end the search; the ceiling only exists so a mistake fails loudly
+#: instead of looping forever.
+_MAX_IMAGE_RADIUS = 12
+
+
+def brute_force_neighborhood(
+    positions: np.ndarray,
+    cutoff: float,
+    pbc: Optional[Sequence[bool]] = None,
+    cell: Optional[np.ndarray] = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Enumerate every pair within ``cutoff``, images included.
+
+    Args:
+        positions: ``[n_atoms, 3]`` Cartesian coordinates.
+        cutoff: strict distance bound, in the same units as ``positions``.
+        pbc: per-axis periodicity; defaults to fully aperiodic.
+        cell: ``[3, 3]`` row-vector lattice. Only rows whose axis is periodic
+            are ever used, so an aperiodic call may pass ``None``.
+
+    Returns:
+        ``(edge_index, shifts, unit_shifts)`` with the same layout
+        ``get_neighborhood`` uses: ``edge_index`` is ``[2, n_edges]`` as
+        ``(sender, receiver)``, ``shifts`` is ``[n_edges, 3]`` in Angstrom and
+        ``unit_shifts`` is the integer ``[n_edges, 3]`` such that
+        ``positions[j] - positions[i] + shift`` is the edge vector.
+    """
+    positions = np.asarray(positions, dtype=float)
+    if pbc is None:
+        pbc = (False, False, False)
+    if cell is None:
+        cell = np.zeros((3, 3), dtype=float)
+    cell = np.asarray(cell, dtype=float)
+    if any(pbc) and not cell.any():
+        raise ValueError("a periodic axis needs a non-zero cell")
+
+    previous: Optional[List[Edge]] = None
+    radius = 1
+    while radius <= _MAX_IMAGE_RADIUS:
+        found = _pairs_within(positions, cutoff, pbc, cell, radius)
+        if found == previous:
+            break
+        previous, radius = found, radius + 1
+    else:
+        raise RuntimeError(
+            f"the brute-force edge set was still growing at image radius "
+            f"{_MAX_IMAGE_RADIUS}; the cutoff ({cutoff}) is large compared to "
+            f"the cell and this reference would be incomplete"
+        )
+
+    edges = previous or []
+    unit_shifts = np.array([edge[2:] for edge in edges], dtype=float).reshape(-1, 3)
+    edge_index = np.array([[e[0] for e in edges], [e[1] for e in edges]], dtype=int)
+    edge_index = edge_index.reshape(2, -1)
+    shifts = unit_shifts @ cell
+    return edge_index, shifts, unit_shifts
+
+
+def _pairs_within(
+    positions: np.ndarray,
+    cutoff: float,
+    pbc: Sequence[bool],
+    cell: np.ndarray,
+    radius: int,
+) -> List[Edge]:
+    ranges = [range(-radius, radius + 1) if pbc[d] else range(1) for d in range(3)]
+    found: List[Edge] = []
+    for i in range(len(positions)):
+        for j in range(len(positions)):
+            for n_0 in ranges[0]:
+                for n_1 in ranges[1]:
+                    for n_2 in ranges[2]:
+                        if i == j and n_0 == 0 and n_1 == 0 and n_2 == 0:
+                            continue  # the only self-pair that is dropped
+                        shift = n_0 * cell[0] + n_1 * cell[1] + n_2 * cell[2]
+                        delta = positions[j] + shift - positions[i]
+                        if float(np.linalg.norm(delta)) < cutoff:
+                            found.append((i, j, n_0, n_1, n_2))
+    return sorted(found)
+
+
+def canonical_edges(edge_index: np.ndarray, unit_shifts: np.ndarray) -> List[Edge]:
+    """A neighbour list as a sorted list of ``(i, j, n0, n1, n2)`` integers.
+
+    Exact by construction: no rounding, no tolerance. Two lists that describe
+    the same edges compare equal whatever order they were produced in.
+    """
+    edge_index = np.asarray(edge_index).reshape(2, -1)
+    unit_shifts = np.asarray(unit_shifts).reshape(-1, 3)
+    if edge_index.shape[1] != unit_shifts.shape[0]:
+        raise ValueError(
+            f"{edge_index.shape[1]} edges but {unit_shifts.shape[0]} unit shifts"
+        )
+    integral = np.rint(unit_shifts)
+    if not np.array_equal(integral, unit_shifts):
+        raise ValueError(
+            "unit shifts must be integers; got non-integral values, which "
+            "means these are displacement vectors -- use "
+            "canonical_edges_from_shifts for those"
+        )
+    return sorted(
+        (int(i), int(j), int(n_0), int(n_1), int(n_2))
+        for (i, j), (n_0, n_1, n_2) in zip(edge_index.T, integral)
+    )
+
+
+def canonical_edges_from_shifts(
+    edge_index: np.ndarray, shifts: np.ndarray, decimals: int = 6
+) -> List[Tuple[int, int, float, float, float]]:
+    """The same, for a source that reports displacement vectors only.
+
+    Rounds, because two implementations sum the lattice vectors in different
+    orders. Prefer :func:`canonical_edges` whenever integer shifts exist.
+    """
+    edge_index = np.asarray(edge_index).reshape(2, -1)
+    shifts = np.asarray(shifts, dtype=float).reshape(-1, 3)
+    return sorted(
+        (int(i), int(j)) + tuple(round(float(v), decimals) for v in shift)
+        for (i, j), shift in zip(edge_index.T, shifts)
+    )
+
+
+def assert_neighbourhoods_match(
+    got: Iterable, expected: Iterable, context: str = ""
+) -> None:
+    """Compare two canonical edge lists and report the difference, not just
+    that there is one -- an edge count mismatch on its own says nothing about
+    which images went missing."""
+    got, expected = list(got), list(expected)
+    if got == expected:
+        return
+    missing = [edge for edge in expected if edge not in got]
+    extra = [edge for edge in got if edge not in expected]
+    where = f" ({context})" if context else ""
+    raise AssertionError(
+        f"neighbour lists differ{where}: {len(got)} edges against "
+        f"{len(expected)} in the reference; "
+        f"missing {missing[:8]}{' ...' if len(missing) > 8 else ''}, "
+        f"unexpected {extra[:8]}{' ...' if len(extra) > 8 else ''}"
+    )

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 from pathlib import Path
 
@@ -7,6 +8,12 @@ import numpy as np
 import pytest
 
 from tests.helpers import REPO_ROOT
+from tests.neighbour_oracle import (
+    assert_neighbourhoods_match,
+    brute_force_neighborhood,
+    canonical_edges,
+    canonical_edges_from_shifts,
+)
 import torch
 
 from mace.data import (
@@ -254,49 +261,6 @@ def test_nonperiodic_cell_is_extent_based():
     assert np.allclose(np.diag(cell_near), extent + 2 * cutoff + 1)
 
 
-def _edge_multiset(idx_pairs, shift_vecs):
-    return sorted(
-        (
-            int(i),
-            int(j),
-            round(float(s[0]), 4),
-            round(float(s[1]), 4),
-            round(float(s[2]), 4),
-        )
-        for (i, j), s in zip(idx_pairs, shift_vecs)
-    )
-
-
-def _bruteforce_neighbours(positions, cell, pbc, cutoff):
-    # Reference neighbour list: enumerate periodic images along the periodic axes
-    # (none along non-periodic ones) and keep pairs within cutoff. The image range
-    # is grown until the edge set stops changing, so the reference is complete no
-    # matter how skewed the cell is (a fixed range could miss images for a very
-    # non-orthogonal cell).
-    prev, radius = None, 2
-    while True:
-        ranges = [range(-radius, radius + 1) if pbc[d] else range(1) for d in range(3)]
-        pairs, shift_vecs = [], []
-        for i in range(len(positions)):
-            for j in range(len(positions)):
-                for n0 in ranges[0]:
-                    for n1 in ranges[1]:
-                        for n2 in ranges[2]:
-                            if i == j and n0 == 0 and n1 == 0 and n2 == 0:
-                                continue
-                            shift = n0 * cell[0] + n1 * cell[1] + n2 * cell[2]
-                            if (
-                                np.linalg.norm(positions[j] + shift - positions[i])
-                                < cutoff
-                            ):
-                                pairs.append((i, j))
-                                shift_vecs.append(shift)
-        edges = _edge_multiset(pairs, shift_vecs)
-        if edges == prev:
-            return edges
-        prev, radius = edges, radius + 1
-
-
 _NONORTHO_CELLS = {
     # in-plane periodic vectors are non-orthogonal; vacuum along the 3rd axis
     "hexagonal": np.array([[3.0, 0.0, 0.0], [1.5, 2.598, 0.0], [0.0, 0.0, 0.0]]),
@@ -324,9 +288,557 @@ def test_partial_pbc_neighbours_match_bruteforce_nonorthogonal(cell_name, cutoff
     positions = rng.uniform(0.0, 1.0, size=(6, 2)) @ cell[:2]  # in the periodic plane
     positions[:, 2] += rng.uniform(-0.3, 0.3, size=6)  # small slab thickness
 
-    edge_index, shifts, _, _ = get_neighborhood(
+    edge_index, _, unit_shifts, _ = get_neighborhood(
         positions, cutoff=cutoff, pbc=pbc, cell=cell
     )
-    got = _edge_multiset(edge_index.T, shifts)
-    ref = _bruteforce_neighbours(positions, cell, pbc, cutoff)
-    assert got == ref
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(
+        positions, cutoff, pbc, cell
+    )
+    assert_neighbourhoods_match(
+        canonical_edges(edge_index, unit_shifts),
+        canonical_edges(ref_index, ref_unit_shifts),
+        context=f"{cell_name}, cutoff {cutoff}, seed {seed}",
+    )
+
+
+# ===========================================================================
+# get_neighborhood: the contract is the edge set AND the returned cell
+#
+# The four returned values are (edge_index, shifts, unit_shifts, cell), and
+# the last one is not a detail: AtomicData stores it, the stress divides by
+# its determinant and the long-range models use it as their k-space box. It
+# is *not* always the cell that was passed in, and it is *not* always the
+# blown-up cell the search ran with either -- there are three regimes, pinned
+# one test each below, because "return the physical cell" and "return the
+# search cell" are each a plausible-looking simplification that breaks one of
+# them.
+# ===========================================================================
+
+
+def _cluster_positions(n_atoms=8, spread=1.8, seed=20260810):
+    return np.random.default_rng(seed).uniform(0.0, spread, size=(n_atoms, 3))
+
+
+# --- the oracle itself has to be falsifiable -------------------------------
+#
+# Every case below is "matscipy agrees with the oracle". That is worth
+# nothing if the oracle agrees with everything, so it is first checked
+# against two counts known from crystallography and then shown to reject a
+# list that is wrong by exactly one edge.
+
+
+@pytest.mark.parametrize(
+    "cell,expected_neighbours",
+    [
+        (np.eye(3) * 2.5, 6),  # simple cubic: 6 nearest neighbours
+        (np.array([[0.0, 2.0, 2.0], [2.0, 0.0, 2.0], [2.0, 2.0, 0.0]]), 12),  # fcc
+    ],
+)
+def test_the_oracle_reproduces_known_coordination_numbers(cell, expected_neighbours):
+    edge_index, _, _ = brute_force_neighborhood(
+        np.zeros((1, 3)), cutoff=1.01 * np.linalg.norm(cell[0]), pbc=(True,) * 3, cell=cell
+    )
+    assert edge_index.shape[1] == expected_neighbours
+
+
+def test_the_oracle_rejects_a_list_that_is_wrong_by_one_edge():
+    positions = _cluster_positions(n_atoms=4)
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(positions, 3.0)
+    reference = canonical_edges(ref_index, ref_unit_shifts)
+    assert_neighbourhoods_match(reference, reference)  # identical: silent
+    with pytest.raises(AssertionError, match="missing"):
+        assert_neighbourhoods_match(reference[:-1], reference)
+    with pytest.raises(AssertionError, match="unexpected"):
+        assert_neighbourhoods_match(reference + [(0, 0, 3, 3, 3)], reference)
+
+
+def test_the_oracle_refuses_a_periodic_request_without_a_cell():
+    with pytest.raises(ValueError, match="non-zero cell"):
+        brute_force_neighborhood(np.zeros((1, 3)), 3.0, pbc=(True, False, False))
+
+
+def test_canonical_edges_refuses_displacement_vectors():
+    """The integer form and the vector form are different comparisons and
+    mixing them silently would compare rounded floats against integers."""
+    edge_index = np.array([[0], [0]])
+    with pytest.raises(ValueError, match="must be integers"):
+        canonical_edges(edge_index, np.array([[0.5, 0.0, 0.0]]))
+    with pytest.raises(ValueError, match="unit shifts"):
+        canonical_edges(np.array([[0, 1], [1, 0]]), np.zeros((1, 3)))
+
+
+def test_full_directed_edge_set_against_the_oracle():
+    """Every pair inside the cutoff appears twice, once in each direction."""
+    positions = _cluster_positions()
+    cutoff = 3.0
+    # every pair of these 8 atoms is inside the cutoff, so the directed list
+    # is the complete digraph: 8 * 7 = 56 edges
+    assert (
+        np.linalg.norm(positions[:, None, :] - positions[None, :, :], axis=-1).max()
+        < cutoff
+    )
+    edge_index, _, unit_shifts, _ = get_neighborhood(positions, cutoff=cutoff)
+    assert edge_index.shape == (2, 56)
+
+    pairs = {(int(i), int(j)) for i, j in edge_index.T}
+    assert all((j, i) in pairs for i, j in pairs), "an edge is missing its mirror"
+    assert not any(i == j for i, j in pairs)
+
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(positions, cutoff)
+    assert_neighbourhoods_match(
+        canonical_edges(edge_index, unit_shifts),
+        canonical_edges(ref_index, ref_unit_shifts),
+    )
+
+
+def test_periodic_self_images_survive_the_self_edge_filter():
+    """Self-edges are dropped only at zero shift, so one atom in a cell
+    smaller than the cutoff is its own neighbour in every image."""
+    positions = np.zeros((1, 3))
+    cell = np.eye(3) * 2.0
+    pbc = (True, True, True)
+    edge_index, _, unit_shifts, _ = get_neighborhood(
+        positions, cutoff=3.0, pbc=pbc, cell=cell
+    )
+    # |n| * 2 Ang < 3 Ang for the 6 face and 12 edge images, not the 8 corners
+    assert edge_index.shape == (2, 18)
+    assert (edge_index[0] == edge_index[1]).all()
+    assert not (np.abs(unit_shifts).sum(axis=1) == 0).any()
+
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(
+        positions, 3.0, pbc, cell
+    )
+    assert_neighbourhoods_match(
+        canonical_edges(edge_index, unit_shifts),
+        canonical_edges(ref_index, ref_unit_shifts),
+    )
+
+
+@pytest.mark.parametrize(
+    "pbc,cell", [((False, False, False), None), ((True, True, True), np.eye(3) * 2.0)]
+)
+def test_true_self_interaction_is_dead(pbc, cell):
+    """Characterization of a parameter that does nothing.
+
+    `true_self_interaction=True` reads like "keep the zero-shift self edge",
+    and it does skip the filter that removes it -- but the matscipy call is
+    made without `self_interaction=True` (the argument is commented out at
+    `neighborhood.py:66-68`), so that edge is never produced and there is
+    nothing to filter. Both settings return the identical list. A port that
+    implements the flag as its name suggests would change every edge count
+    that goes through it, which is why the dead behaviour is pinned rather
+    than assumed.
+    """
+    positions = np.zeros((1, 3))
+    off = get_neighborhood(positions, cutoff=3.0, pbc=pbc, cell=cell)
+    on = get_neighborhood(
+        positions, cutoff=3.0, pbc=pbc, cell=cell, true_self_interaction=True
+    )
+    for a, b in zip(off, on):
+        assert np.array_equal(a, b)
+    # and in neither case is there a zero-shift self edge
+    assert not (np.abs(on[2]).sum(axis=1) == 0).any()
+
+
+def test_zero_edge_systems_are_legal():
+    """An isolated pair beyond the cutoff returns empty arrays of the right
+    shape rather than raising -- the padded-batch machinery depends on it."""
+    positions = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    edge_index, shifts, unit_shifts, _ = get_neighborhood(positions, cutoff=2.0)
+    assert edge_index.shape == (2, 0)
+    assert shifts.shape == (0, 3)
+    assert unit_shifts.shape == (0, 3)
+
+
+def test_missing_or_all_zero_cell_becomes_the_identity_before_extension():
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    _, _, _, from_none = get_neighborhood(positions, cutoff=2.0, cell=None)
+    _, _, _, from_zeros = get_neighborhood(
+        positions, cutoff=2.0, cell=np.zeros((3, 3))
+    )
+    assert np.array_equal(from_none, from_zeros)
+    # identity rows, each then blown up along its own axis: extent + 2*cutoff + 1
+    assert np.allclose(np.diag(from_none), [1.0 + 5.0, 0.0 + 5.0, 0.0 + 5.0])
+    assert np.allclose(from_none - np.diag(np.diag(from_none)), 0.0)
+
+
+# --- the three returned-cell regimes ---------------------------------------
+
+
+def test_returned_cell_regime_aperiodic_is_the_extended_search_cell():
+    """Fully aperiodic: the extended cell comes back, deliberately. Stress is
+    meaningless without periodicity and the electrostatic models need a
+    non-degenerate k-space box, so suppressing this in a port is a bug."""
+    positions = _cluster_positions()
+    cutoff = 3.0
+    _, _, _, cell = get_neighborhood(positions, cutoff=cutoff)
+    extent = positions.max(axis=0) - positions.min(axis=0)
+    assert np.allclose(np.diag(cell), extent + 2 * cutoff + 1)
+    assert np.allclose(cell - np.diag(np.diag(cell)), 0.0)
+    assert not np.isclose(np.linalg.det(cell), 0.0)
+
+
+def test_returned_cell_regime_periodic_is_the_physical_cell():
+    """Any periodic axis: the physical cell comes back untouched, including
+    the vacuum row. Returning the search cell here would rescale every slab
+    stress by a fabricated volume."""
+    physical = np.diag([4.0, 4.0, 12.0])
+    positions = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [0.0, 0.0, 1.5]])
+    _, _, _, cell = get_neighborhood(
+        positions, cutoff=3.0, pbc=(True, True, False), cell=physical
+    )
+    assert np.array_equal(cell, physical)
+
+
+def test_returned_cell_regime_periodic_with_a_zero_row_is_patched():
+    """The one case where a row of the physical cell is replaced: an all-zero
+    non-periodic row would make det(cell) zero, which NaNs the stress and
+    blows up the reciprocal cell."""
+    degenerate = np.diag([4.0, 4.0, 0.0])
+    positions = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [0.0, 0.0, 1.5]])
+    cutoff = 3.0
+    _, _, _, cell = get_neighborhood(
+        positions, cutoff=cutoff, pbc=(True, True, False), cell=degenerate
+    )
+    # the periodic rows are the physical ones ...
+    assert np.array_equal(cell[:2], degenerate[:2])
+    # ... and only the zero row is taken from the search cell
+    extent_z = positions[:, 2].max() - positions[:, 2].min()
+    assert np.allclose(cell[2], [0.0, 0.0, extent_z + 2 * cutoff + 1])
+    assert not np.isclose(np.linalg.det(cell), 0.0)
+
+
+def test_the_three_returned_cell_regimes_are_actually_three():
+    """A port that collapsed any two of them would still pass every test
+    above that it happened to keep. Assert the regimes differ from each
+    other on the same geometry."""
+    positions = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [0.0, 0.0, 1.5]])
+    physical = np.diag([4.0, 4.0, 12.0])
+    _, _, _, aperiodic = get_neighborhood(positions, cutoff=3.0, cell=physical)
+    _, _, _, periodic = get_neighborhood(
+        positions, cutoff=3.0, pbc=(True, True, False), cell=physical
+    )
+    _, _, _, patched = get_neighborhood(
+        positions, cutoff=3.0, pbc=(True, True, False), cell=np.diag([4.0, 4.0, 0.0])
+    )
+    assert not np.allclose(aperiodic, periodic)
+    assert not np.allclose(periodic, patched)
+    assert not np.allclose(aperiodic, patched)
+
+
+def test_shifts_are_unit_shifts_times_the_returned_cell():
+    """The identity every consumer relies on, in the regime where the search
+    cell and the returned cell differ. It holds because matscipy emits no
+    shift along a non-periodic axis."""
+    positions = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [0.0, 0.0, 1.5]])
+    _, shifts, unit_shifts, cell = get_neighborhood(
+        positions, cutoff=3.0, pbc=(True, True, False), cell=np.diag([4.0, 4.0, 0.0])
+    )
+    assert np.array_equal(shifts, unit_shifts @ cell)
+    # nothing shifted along the aperiodic axis, which is what makes the
+    # patched row harmless
+    assert np.array_equal(unit_shifts[:, 2], np.zeros(unit_shifts.shape[0]))
+
+
+@pytest.mark.parametrize(
+    "pbc", [(True, False, False), (False, True, False), (False, False, True)]
+)
+def test_mixed_pbc_is_passed_through_per_axis(pbc):
+    positions = np.array([[0.5, 0.5, 0.5], [1.0, 1.0, 1.0]])
+    cell = np.diag([2.0, 2.5, 3.0])
+    edge_index, _, unit_shifts, _ = get_neighborhood(
+        positions, cutoff=3.5, pbc=pbc, cell=cell
+    )
+    for dim, periodic in enumerate(pbc):
+        if not periodic:
+            assert np.array_equal(unit_shifts[:, dim], np.zeros(len(unit_shifts[:, dim])))
+        else:
+            assert np.abs(unit_shifts[:, dim]).sum() > 0
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(positions, 3.5, pbc, cell)
+    assert_neighbourhoods_match(
+        canonical_edges(edge_index, unit_shifts),
+        canonical_edges(ref_index, ref_unit_shifts),
+        context=str(pbc),
+    )
+
+
+@pytest.mark.parametrize(
+    "pbc,cell",
+    [
+        ((False, False, False), np.diag([4.0, 4.0, 4.0])),
+        ((True, True, True), np.diag([4.0, 4.0, 4.0])),
+        ((True, True, False), np.diag([4.0, 4.0, 12.0])),
+        ((True, True, False), np.diag([4.0, 4.0, 0.0])),
+    ],
+)
+def test_get_neighborhood_does_not_mutate_its_arguments(pbc, cell):
+    """Purity is a property of the port, not an accident of the caller:
+    AtomicData.from_config deep-copies before calling, so a mutation here
+    would be invisible there and would surface only in a caller that does
+    not. Every regime is checked, because the periodic branch and the
+    aperiodic branch build their cell differently."""
+    positions = np.array([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0], [0.0, 0.0, 1.5]])
+    cell_before, positions_before = cell.copy(), positions.copy()
+    _, _, _, returned = get_neighborhood(positions, cutoff=3.0, pbc=pbc, cell=cell)
+    assert np.array_equal(cell, cell_before)
+    assert np.array_equal(positions, positions_before)
+    # and the returned cell is a distinct object, so mutating it downstream
+    # cannot reach back into the caller's array
+    returned += 1.0
+    assert np.array_equal(cell, cell_before)
+
+
+# --- the same three regimes, on the committed golden fixtures --------------
+#
+# tests/golden/fixtures exists to reach exactly these regimes (its manifest
+# names the regime each structure was built for), and the anchors' stresses
+# depend on the cell that comes back. Reading the regime out of the manifest
+# rather than restating it here is what keeps the two suites pinning the same
+# thing: a fixture retagged there fails here.
+
+
+def _golden_fixtures():
+    from tests.golden import harness  # noqa: PLC0415  (optional, tests-only)
+
+    manifest = harness.load_manifest()
+    with open(harness.MANIFEST_PATH, encoding="utf-8") as handle:
+        r_max = json.load(handle)["r_max_hint"]
+    return harness.load_fixtures(), manifest, r_max
+
+
+#: Which returned-cell regime each committed fixture reaches. Written out
+#: rather than derived, because deriving it from the same rule the function
+#: uses would make the assertion circular.
+_FIXTURE_REGIME = {
+    "dimer_short": "extended",
+    "isolated_atom": "extended",
+    "water_cluster": "extended",
+    "slab_vacuum": "physical",
+    "triclinic_bulk": "physical",
+    "slab_zero_vacuum": "patched",
+    # The magnetic group, committed by the magnetic goldens. All five are
+    # aperiodic clusters, so all five reach the extended-search-cell
+    # regime; they are listed here rather than left out because the point
+    # of the table is that no committed fixture reaches a regime nobody
+    # wrote down.
+    "mag_fe_atom": "extended",
+    "mag_fe_dimer_fm": "extended",
+    "mag_fe_dimer_afm": "extended",
+    "mag_fe3_canted": "extended",
+    "mag_feo_cluster": "extended",
+}
+
+
+def _tabled_fixtures():
+    """The table entries this checkout actually has files for.
+
+    The table names every fixture any golden family commits, but a given
+    branch holds only its own: naming a fixture that is not here yet is a
+    row waiting for it, not a failure. The assertion that matters is the
+    other direction -- a fixture in the manifest with no row -- and that
+    is checked below.
+    """
+    from tests.golden import harness  # noqa: PLC0415  (optional, tests-only)
+
+    return sorted(set(_FIXTURE_REGIME) & set(harness.load_manifest()))
+
+
+def test_the_fixture_regime_table_agrees_with_the_golden_manifest():
+    """The manifest's `regime` field is prose for a human; this table is what
+    the assertions below use. Where the prose names a cell regime, the two
+    must say the same thing -- otherwise one suite is pinning a structure the
+    other has since repurposed."""
+    _, manifest, _ = _golden_fixtures()
+    # Manifest-subset, not equality: see _tabled_fixtures. A fixture with
+    # no row still fails here, which is the direction that matters.
+    missing = set(manifest) - set(_FIXTURE_REGIME)
+    assert not missing, (
+        f"{sorted(missing)} are committed fixtures with no regime row. Add "
+        "one: the table is what the neighbourhood oracle below is driven "
+        "from, so a fixture missing from it is never checked at all."
+    )
+    for name in _tabled_fixtures():
+        regime = _FIXTURE_REGIME[name]
+        prose = manifest[name]["regime"]
+        if "cell" not in prose:
+            continue  # e.g. "short-range repulsion envelope": not a cell claim
+        expected = {
+            "extended": "extended search cell",
+            "physical": "physical cell",
+            "patched": "patched",
+        }[regime]
+        assert expected in prose, (name, prose)
+
+
+@pytest.mark.parametrize("name", _tabled_fixtures())
+def test_golden_fixture_neighbourhood_matches_the_oracle(name):
+    fixtures, _, r_max = _golden_fixtures()
+    atoms = fixtures[name]
+    positions = atoms.get_positions()
+    pbc = tuple(bool(p) for p in atoms.get_pbc())
+    cell = np.array(atoms.get_cell())
+
+    edge_index, shifts, unit_shifts, returned = get_neighborhood(
+        positions, cutoff=r_max, pbc=pbc, cell=cell
+    )
+    ref_index, _, ref_unit_shifts = brute_force_neighborhood(
+        positions, r_max, pbc, cell
+    )
+    assert_neighbourhoods_match(
+        canonical_edges(edge_index, unit_shifts),
+        canonical_edges(ref_index, ref_unit_shifts),
+        context=name,
+    )
+    assert np.array_equal(shifts, unit_shifts @ returned)
+
+    regime = _FIXTURE_REGIME[name]
+    if regime == "extended":
+        assert not any(pbc)
+        extent = positions.max(axis=0) - positions.min(axis=0)
+        assert np.allclose(np.diag(returned), extent + 2 * r_max + 1)
+    elif regime == "physical":
+        assert np.array_equal(returned, cell)
+    else:
+        assert np.array_equal(returned[:2], cell[:2])  # the periodic rows
+        assert not cell[2].any() and returned[2].any()  # the patched one
+    assert not np.isclose(np.linalg.det(returned), 0.0)
+
+
+def test_oracle_and_matscipy_agree_on_displacement_vectors_too():
+    """The integer comparison everywhere else would not catch a cell whose
+    rows were permuted, since the unit shifts would permute with it. Compare
+    the vectors once, on the triclinic fixture."""
+    fixtures, _, r_max = _golden_fixtures()
+    atoms = fixtures["triclinic_bulk"]
+    positions, cell = atoms.get_positions(), np.array(atoms.get_cell())
+    pbc = tuple(bool(p) for p in atoms.get_pbc())
+    edge_index, shifts, _, _ = get_neighborhood(
+        positions, cutoff=r_max, pbc=pbc, cell=cell
+    )
+    ref_index, ref_shifts, _ = brute_force_neighborhood(positions, r_max, pbc, cell)
+    assert canonical_edges_from_shifts(
+        edge_index, shifts
+    ) == canonical_edges_from_shifts(ref_index, ref_shifts)
+
+
+# ===========================================================================
+# AtomicData: one-hot, shifts, Voigt expansion, and collation
+# ===========================================================================
+
+
+class TestAtomicDataContract:
+    z_table = AtomicNumberTable([1, 6, 8])
+
+    @staticmethod
+    def water(cell_length=6.0, **overrides):
+        properties = {
+            "energy": -1.5,
+            "forces": np.arange(9.0).reshape(3, 3),
+        }
+        properties.update(overrides)
+        return Configuration(
+            atomic_numbers=np.array([8, 1, 1]),
+            positions=np.array([[0.0, 0.0, 0.0], [0.95, 0.0, 0.0], [0.0, 0.95, 0.0]]),
+            properties=properties,
+            property_weights={"energy": 1.0, "forces": 1.0},
+            cell=np.diag([cell_length] * 3),
+            pbc=(True, True, True),
+        )
+
+    def test_one_hot_follows_the_z_table_not_the_atomic_number(self):
+        data = AtomicData.from_config(self.water(), z_table=self.z_table, cutoff=3.0)
+        # z_table is [1, 6, 8]; O is index 2, H is index 0
+        assert data.node_attrs.shape == (3, 3)
+        assert torch.equal(
+            data.node_attrs,
+            torch.tensor([[0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        )
+        assert torch.equal(data.atomic_numbers, torch.tensor([8, 1, 1]))
+        # one-hot rows are exactly one hot
+        assert torch.equal(data.node_attrs.sum(dim=1), torch.ones(3))
+
+    def test_shifts_are_unit_shifts_times_the_stored_cell(self):
+        # a cell smaller than the cutoff, so the identity is not vacuous
+        data = AtomicData.from_config(
+            self.water(cell_length=3.0), z_table=self.z_table, cutoff=4.0
+        )
+        assert data.cell.shape == (3, 3)
+        assert data.unit_shifts.abs().sum() > 0
+        assert torch.allclose(data.shifts, data.unit_shifts @ data.cell)
+
+    def test_voigt_stress_and_virials_expand_at_parse_time(self):
+        config = self.water(
+            stress=np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            virials=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        )
+        data = AtomicData.from_config(config, z_table=self.z_table, cutoff=3.0)
+        # Voigt order is (xx, yy, zz, yz, xz, xy) and the result is symmetric
+        assert torch.equal(
+            data.stress,
+            torch.tensor([[[1.0, 6.0, 5.0], [6.0, 2.0, 4.0], [5.0, 4.0, 3.0]]]),
+        )
+        assert torch.allclose(
+            data.virials,
+            torch.tensor([[[0.1, 0.6, 0.5], [0.6, 0.2, 0.4], [0.5, 0.4, 0.3]]]),
+        )
+        assert data.stress.shape == (1, 3, 3)
+
+    def test_graph_level_inputs_reach_the_graph(self):
+        config = self.water(total_charge=1.0, total_spin=2.0, elec_temp=300.0)
+        data = AtomicData.from_config(config, z_table=self.z_table, cutoff=3.0)
+        assert data.total_charge.item() == 1.0
+        assert data.total_spin.item() == 2.0
+        assert data.elec_temp.item() == 300.0
+        # the defaults are not all zero: an unspecified spin is 1.0
+        plain = AtomicData.from_config(self.water(), z_table=self.z_table, cutoff=3.0)
+        assert plain.total_charge.item() == 0.0
+        assert plain.total_spin.item() == 1.0
+        assert plain.elec_temp.item() == 0.0
+
+    def test_collating_two_graphs_offsets_the_edge_index(self):
+        first = AtomicData.from_config(self.water(), z_table=self.z_table, cutoff=4.0)
+        second_config = Configuration(
+            atomic_numbers=np.array([1, 1]),
+            positions=np.array([[0.0, 0.0, 0.0], [0.9, 0.0, 0.0]]),
+            properties={"energy": -0.5},
+            property_weights={"energy": 1.0},
+            cell=np.diag([5.0, 5.0, 5.0]),
+            pbc=(True, True, True),
+        )
+        second = AtomicData.from_config(
+            second_config, z_table=self.z_table, cutoff=4.0
+        )
+        batch = torch_geometric.batch.Batch.from_data_list([first, second])
+
+        n_first = first.num_nodes
+        assert batch.num_graphs == 2
+        assert torch.equal(
+            batch.batch, torch.tensor([0] * n_first + [1] * second.num_nodes)
+        )
+        assert torch.equal(
+            batch.ptr, torch.tensor([0, n_first, n_first + second.num_nodes])
+        )
+        # the second graph's edges are the same edges, shifted by n_first
+        assert torch.equal(
+            batch.edge_index,
+            torch.cat([first.edge_index, second.edge_index + n_first], dim=1),
+        )
+        # per-edge data concatenates in the same order
+        assert torch.equal(
+            batch.shifts, torch.cat([first.shifts, second.shifts], dim=0)
+        )
+        assert torch.equal(batch.energy, torch.stack([first.energy, second.energy]))
+
+    def test_the_collated_cell_is_stacked_rows_and_views_back(self):
+        """Characterization, not endorsement: a per-config cell is stored
+        [3, 3] and collates by concatenation into [3 * n_graphs, 3], which
+        every consumer un-flattens with .view(-1, 3, 3). The rewrite stores
+        [n_graphs, 3, 3] instead -- value-identical modulo this reshape, which
+        is why the values are pinned here and the storage accident is not."""
+        first = AtomicData.from_config(self.water(), z_table=self.z_table, cutoff=3.0)
+        second = AtomicData.from_config(self.water(), z_table=self.z_table, cutoff=3.0)
+        batch = torch_geometric.batch.Batch.from_data_list([first, second])
+        assert batch.cell.shape == (6, 3)
+        assert torch.equal(
+            batch.cell.view(-1, 3, 3), torch.stack([first.cell, second.cell])
+        )

--- a/tests/unit/test_data_utils.py
+++ b/tests/unit/test_data_utils.py
@@ -23,7 +23,7 @@ from mace.data.utils import (
     random_train_valid_split,
     update_keyspec_from_kwargs,
 )
-from mace.tools import AtomicNumberTable
+from mace.tools import AtomicNumberTable, DefaultKeys
 from tests.helpers import make_fitting_configs
 
 
@@ -373,3 +373,388 @@ def test_random_train_valid_split_writes_indices_file(tmp_path):
     assert index_file.exists()
     saved = [int(line) for line in index_file.read_text().split()]
     assert sorted(saved) == sorted(items.index(v) for v in valid)
+
+
+# ---------------------------------------------------------------------------
+# The default property keys are a data contract
+#
+# Every labelled dataset on disk is written against these names, so a rename
+# is not a refactor -- it silently stops reading somebody's forces. The names
+# are therefore asserted one at a time, spelled out, rather than compared
+# against DefaultKeys (which would pass whatever DefaultKeys said today).
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_KEY_NAMES = {
+    "ENERGY": "REF_energy",
+    "FORCES": "REF_forces",
+    "STRESS": "REF_stress",
+    "VIRIALS": "REF_virials",
+    "DIPOLE": "dipole",
+    "POLARIZABILITY": "polarizability",
+    "HEAD": "head",
+    "CHARGES": "REF_charges",
+    "TOTAL_CHARGE": "total_charge",
+    "TOTAL_SPIN": "total_spin",
+    "ELEC_TEMP": "elec_temp",
+    "MAGMOM": "REF_magmom",
+    "MAGFORCES": "REF_magforces",
+}
+
+
+def test_default_keys_are_exactly_these_thirteen():
+    assert {member.name: member.value for member in DefaultKeys} == DEFAULT_KEY_NAMES
+    # spelled out again, so a bulk edit of the dict above still fails
+    assert DefaultKeys.ENERGY.value == "REF_energy"
+    assert DefaultKeys.FORCES.value == "REF_forces"
+    assert DefaultKeys.STRESS.value == "REF_stress"
+    assert DefaultKeys.VIRIALS.value == "REF_virials"
+    assert DefaultKeys.DIPOLE.value == "dipole"
+    assert DefaultKeys.POLARIZABILITY.value == "polarizability"
+    assert DefaultKeys.HEAD.value == "head"
+    assert DefaultKeys.CHARGES.value == "REF_charges"
+    assert DefaultKeys.TOTAL_CHARGE.value == "total_charge"
+    assert DefaultKeys.TOTAL_SPIN.value == "total_spin"
+    assert DefaultKeys.ELEC_TEMP.value == "elec_temp"
+    assert DefaultKeys.MAGMOM.value == "REF_magmom"
+    assert DefaultKeys.MAGFORCES.value == "REF_magforces"
+
+
+def test_keydict_derives_one_cli_argument_per_member():
+    keydict = DefaultKeys.keydict()
+    assert keydict == {
+        f"{name.lower()}_key": value for name, value in DEFAULT_KEY_NAMES.items()
+    }
+    # the derivation is `<member name lowercased>_key`, which is exactly the
+    # --energy_key / --magforces_key spelling the CLI exposes
+    assert keydict["energy_key"] == "REF_energy"
+    assert keydict["magforces_key"] == "REF_magforces"
+
+
+def test_every_default_key_reaches_the_keyspec():
+    """`update_keyspec_from_kwargs` routes each `<name>_key` into info_keys or
+    arrays_keys from two hardcoded lists. A member missing from both is
+    silently dropped -- the property is then never parsed and no error says
+    so -- so assert the partition covers all thirteen."""
+    keyspec = KeySpecification.from_defaults()
+    routed = set(keyspec.info_keys) | set(keyspec.arrays_keys)
+    assert routed == {member.name.lower() for member in DefaultKeys}
+    assert not set(keyspec.info_keys) & set(keyspec.arrays_keys)
+    # per-atom quantities are arrays, per-graph ones are info
+    assert set(keyspec.arrays_keys) == {"forces", "charges", "magmom", "magforces"}
+    assert keyspec.info_keys["elec_temp"] == "elec_temp"
+    assert keyspec.info_keys["total_spin"] == "total_spin"
+    assert keyspec.info_keys["total_charge"] == "total_charge"
+    assert keyspec.info_keys["polarizability"] == "polarizability"
+
+
+# ---------------------------------------------------------------------------
+# Round-tripping every default key through a real extxyz file
+# ---------------------------------------------------------------------------
+
+
+def labelled_water():
+    """A water molecule carrying a value under all thirteen default keys."""
+    atoms = make_water()
+    atoms.info["REF_energy"] = -14.5
+    atoms.info["REF_stress"] = np.linspace(0.1, 0.6, 6)
+    atoms.info["REF_virials"] = np.linspace(-0.3, 0.3, 6)
+    atoms.info["dipole"] = np.array([0.1, -0.2, 0.3])
+    atoms.info["polarizability"] = np.arange(9.0).reshape(3, 3)
+    atoms.info["total_charge"] = -1.0
+    atoms.info["total_spin"] = 2.0
+    atoms.info["elec_temp"] = 300.0
+    atoms.new_array("REF_forces", np.arange(9.0).reshape(3, 3) / 10.0)
+    atoms.new_array("REF_charges", np.array([-0.8, 0.4, 0.4]))
+    atoms.new_array("REF_magmom", np.array([[0.0, 0.0, 2.2]] * 3))
+    atoms.new_array("REF_magforces", np.array([[0.1, 0.2, 0.3]] * 3))
+    return atoms
+
+
+def test_all_default_keys_survive_a_write_read_roundtrip(tmp_path):
+    written = labelled_water()
+    path = tmp_path / "labelled.xyz"
+    ase.io.write(path, [written])
+
+    _, configs = load_from_xyz(
+        str(path), key_specification=KeySpecification.from_defaults()
+    )
+    (config,) = configs
+    properties = config.properties
+
+    assert properties["energy"] == pytest.approx(-14.5)
+    assert np.allclose(properties["forces"], written.arrays["REF_forces"])
+    assert np.allclose(properties["stress"], written.info["REF_stress"])
+    assert np.allclose(properties["virials"], written.info["REF_virials"])
+    assert np.allclose(
+        np.reshape(properties["polarizability"], (3, 3)), np.arange(9.0).reshape(3, 3)
+    )
+    assert np.allclose(properties["charges"], [-0.8, 0.4, 0.4])
+    # the graph-level model inputs
+    assert properties["total_charge"] == pytest.approx(-1.0)
+    assert properties["total_spin"] == pytest.approx(2.0)
+    assert properties["elec_temp"] == pytest.approx(300.0)
+    # the two magnetic per-atom arrays
+    assert np.allclose(properties["magmom"], [[0.0, 0.0, 2.2]] * 3)
+    assert np.allclose(properties["magforces"], [[0.1, 0.2, 0.3]] * 3)
+    # head is written by load_from_xyz itself, not read from the file
+    assert config.head == "Default"
+    # twelve of the thirteen came back; `dipole` is the exception, below
+    assert set(config.property_weights) == set(properties)
+    assert {
+        name for name, weight in config.property_weights.items() if weight == 1.0
+    } == {name.lower() for name in DEFAULT_KEY_NAMES} - {"dipole"}
+
+
+def test_the_default_dipole_key_does_not_survive_extxyz(tmp_path):
+    """The one default key that cannot be read back from a file.
+
+    ase reserves `dipole` as a per-config *calculator* property
+    (`ase.io.extxyz.per_config_properties`, ase 3.29), so a value written into
+    `atoms.info["dipole"]` is read back into `atoms.calc.results` and never
+    reaches `atoms.info` -- where `config_from_atoms` is the only place that
+    looks. The property silently becomes None with weight 0, i.e. a dipole
+    dataset labelled with the documented default trains on nothing.
+
+    `load_from_xyz` already rewrites the other three unsafe spellings
+    ('energy', 'forces', 'stress') onto their REF_ equivalents; `dipole` has
+    no such branch, which is why every dipole workflow in this repository
+    passes `--dipole_key REF_dipole`. Pinned as the current behaviour, not
+    endorsed: if the port fixes it, this test is what says the fix changed
+    something.
+    """
+    atoms = make_water(REF_energy=0.0)
+    atoms.new_array("REF_forces", np.zeros((3, 3)))
+    atoms.info["dipole"] = np.array([0.1, -0.2, 0.3])
+    atoms.info["REF_dipole"] = np.array([0.1, -0.2, 0.3])
+    path = tmp_path / "dipole.xyz"
+    ase.io.write(path, [atoms])
+
+    reread = ase.io.read(path, index=0)
+    assert "dipole" not in reread.info
+    assert np.allclose(reread.calc.results["dipole"], [0.1, -0.2, 0.3])
+
+    _, configs = load_from_xyz(
+        str(path), key_specification=KeySpecification.from_defaults()
+    )
+    assert configs[0].properties["dipole"] is None
+    assert configs[0].property_weights["dipole"] == 0.0
+
+    # the same value under a non-reserved name reads fine, which is what the
+    # dipole/polarizability workflows actually do
+    keyspec = KeySpecification.from_defaults()
+    update_keyspec_from_kwargs(keyspec, {"dipole_key": "REF_dipole"})
+    _, renamed = load_from_xyz(str(path), key_specification=keyspec)
+    assert np.allclose(renamed[0].properties["dipole"], [0.1, -0.2, 0.3])
+
+
+@pytest.mark.parametrize(
+    "name,cli_argument,custom,store",
+    [
+        ("energy", "energy_key", "pbe_energy", "info"),
+        ("forces", "forces_key", "pbe_forces", "arrays"),
+        ("stress", "stress_key", "pbe_stress", "info"),
+        ("total_charge", "total_charge_key", "qtot", "info"),
+        ("total_spin", "total_spin_key", "multiplicity", "info"),
+        ("elec_temp", "elec_temp_key", "smearing_T", "info"),
+        ("magmom", "magmom_key", "spins", "arrays"),
+        ("magforces", "magforces_key", "spin_forces", "arrays"),
+    ],
+)
+def test_custom_property_keys_round_trip(tmp_path, name, cli_argument, custom, store):
+    """The `--<name>_key custom_name` path, end to end: a file labelled with a
+    non-default name is read only when the keyspec is told about it, and the
+    default name then reads nothing."""
+    atoms = make_water(REF_energy=0.0)
+    atoms.new_array("REF_forces", np.zeros((3, 3)))
+    value = (
+        np.arange(9.0).reshape(3, 3) if store == "arrays" else np.float64(7.5)
+    )
+    if store == "info":
+        atoms.info[custom] = value
+    else:
+        atoms.new_array(custom, value)
+    path = tmp_path / "custom.xyz"
+    ase.io.write(path, [atoms])
+
+    keyspec = KeySpecification.from_defaults()
+    update_keyspec_from_kwargs(keyspec, {cli_argument: custom})
+    _, configs = load_from_xyz(str(path), key_specification=keyspec)
+    got = configs[0].properties[name]
+    assert np.allclose(got, value)
+    assert configs[0].property_weights[name] == 1.0
+
+    # the same file read with the default keys finds nothing under that name,
+    # and says so through a zero weight rather than by raising
+    _, defaults = load_from_xyz(
+        str(path), key_specification=KeySpecification.from_defaults()
+    )
+    if name not in ("energy", "forces"):  # those two are present as defaults
+        assert defaults[0].properties[name] is None
+        assert defaults[0].property_weights[name] == 0.0
+
+
+def test_config_type_and_per_property_weights_round_trip(tmp_path):
+    atoms = labelled_water()
+    atoms.info["config_type"] = "slab"
+    atoms.info["config_weight"] = 2.0
+    atoms.info["config_energy_weight"] = 5.0
+    atoms.info["config_forces_weight"] = 0.25
+    atoms.info["config_magmom_weight"] = 3.0
+    path = tmp_path / "weighted.xyz"
+    ase.io.write(path, [atoms])
+
+    _, configs = load_from_xyz(
+        str(path),
+        key_specification=KeySpecification.from_defaults(),
+        config_type_weights={"slab": 3.0},
+    )
+    (config,) = configs
+    assert config.config_type == "slab"
+    assert config.weight == pytest.approx(6.0)  # config_weight * type weight
+    assert config.property_weights["energy"] == pytest.approx(5.0)
+    assert config.property_weights["forces"] == pytest.approx(0.25)
+    assert config.property_weights["magmom"] == pytest.approx(3.0)
+    # an unweighted property keeps 1.0
+    assert config.property_weights["stress"] == pytest.approx(1.0)
+    # an unknown config_type falls back to weight 1.0, it is not an error
+    _, unknown = load_from_xyz(
+        str(path),
+        key_specification=KeySpecification.from_defaults(),
+        config_type_weights={"bulk": 9.0},
+    )
+    assert unknown[0].weight == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Isolated-atom detection (the behaviour behind --keep_isolated_atoms)
+# ---------------------------------------------------------------------------
+
+
+def isolated_atom(number, energy=None, config_type="IsolatedAtom"):
+    atoms = Atoms(numbers=[number], positions=[[0.0, 0.0, 0.0]])
+    atoms.info["config_type"] = config_type
+    if energy is not None:
+        atoms.info["REF_energy"] = energy
+    return atoms
+
+
+def test_isolated_atom_detection_needs_both_one_atom_and_the_config_type(tmp_path):
+    """Both conditions, because the test is `len(atoms) == 1 and
+    config_type == "IsolatedAtom"`: a two-atom config labelled IsolatedAtom is
+    training data, and a lone atom without the label is too."""
+    two_atoms = Atoms(numbers=[8, 8], positions=[[0.0] * 3, [1.2, 0.0, 0.0]])
+    two_atoms.info.update({"config_type": "IsolatedAtom", "REF_energy": -7.0})
+    lone_unlabelled = isolated_atom(1, energy=-0.5, config_type="Default")
+    path = tmp_path / "iso.xyz"
+    ase.io.write(path, [isolated_atom(8, -3.0), two_atoms, lone_unlabelled])
+
+    e0s, configs = load_from_xyz(
+        str(path),
+        key_specification=KeySpecification.from_defaults(),
+        extract_atomic_energies=True,
+    )
+    assert e0s == {8: -3.0}
+    assert len(configs) == 2  # only the real isolated atom was removed
+
+
+def test_isolated_atom_without_an_energy_contributes_zero(tmp_path, caplog):
+    path = tmp_path / "iso_noenergy.xyz"
+    ase.io.write(path, [isolated_atom(8, -3.0), isolated_atom(1, None)])
+    with caplog.at_level("WARNING"):
+        e0s, configs = load_from_xyz(
+            str(path),
+            key_specification=KeySpecification.from_defaults(),
+            extract_atomic_energies=True,
+            no_data_ok=True,
+        )
+    assert e0s == {8: -3.0, 1: 0.0}
+    assert "Zero energy will be used" in caplog.text
+    assert configs == []
+
+
+def test_keep_isolated_atoms_keeps_them_and_still_extracts(tmp_path):
+    water = make_water(REF_energy=-14.0)
+    water.new_array("REF_forces", np.zeros((3, 3)))
+    path = tmp_path / "iso_keep.xyz"
+    ase.io.write(path, [isolated_atom(8, -3.0), water])
+
+    keyspec = KeySpecification.from_defaults()
+    e0s, kept = load_from_xyz(
+        str(path),
+        key_specification=keyspec,
+        extract_atomic_energies=True,
+        keep_isolated_atoms=True,
+    )
+    assert e0s == {8: -3.0}
+    assert [c.config_type for c in kept] == ["IsolatedAtom", "Default"]
+    _, dropped = load_from_xyz(
+        str(path),
+        key_specification=KeySpecification.from_defaults(),
+        extract_atomic_energies=True,
+    )
+    assert [c.config_type for c in dropped] == ["Default"]
+
+
+# ---------------------------------------------------------------------------
+# The remaining parsing-layer surface: prefixed split files, a headless
+# config, and the two HDF5 writers that mace.data exports and nothing in the
+# suite had ever called.
+# ---------------------------------------------------------------------------
+
+
+def test_random_train_valid_split_prefixes_the_indices_file(tmp_path):
+    train, valid = random_train_valid_split(
+        list(range(100)),
+        valid_fraction=0.2,
+        seed=3,
+        work_dir=str(tmp_path),
+        prefix="run7",
+    )
+    assert len(train) == 80 and len(valid) == 20
+    assert (tmp_path / "run7_valid_indices_3.txt").exists()
+    assert not (tmp_path / "valid_indices_3.txt").exists()
+
+
+def test_config_types_treats_a_missing_head_as_the_empty_string():
+    config = make_config([1], 0.0)
+    config.config_type = "bulk"
+    config.head = None
+    (name, group), = data_utils.test_config_types([config])
+    assert name == "bulk_"
+    assert group == [config]
+    assert config.head == ""  # normalised in place
+
+
+def test_save_dataset_as_hdf5_writes_one_group_per_graph(tmp_path):
+    """`save_dataset_as_HDF5` / `save_AtomicData_to_HDF5` are exported from
+    `mace.data` and were reached by nothing in the suite. They write built
+    graphs (not configurations), one group per graph, so the on-disk layout
+    they define is pinned here before DATA-2 has to reproduce or replace it.
+    """
+    import h5py  # noqa: PLC0415  (only this test needs it)
+
+    from mace.data import AtomicData, save_dataset_as_HDF5
+
+    z_table = AtomicNumberTable([1, 8])
+    configs = [
+        config_from_atoms(make_water(REF_energy=float(i)), key_specification=ref_keyspec())
+        for i in range(2)
+    ]
+    graphs = [
+        AtomicData.from_config(config, z_table=z_table, cutoff=3.0)
+        for config in configs
+    ]
+    path = tmp_path / "graphs.h5"
+    save_dataset_as_HDF5(graphs, str(path))
+
+    with h5py.File(path, "r") as handle:
+        assert sorted(handle) == ["config_0", "config_1"]
+        group = handle["config_0"]
+        assert group["num_nodes"][()] == 3
+        assert group["positions"].shape == (3, 3)
+        assert group["edge_index"].shape == graphs[0].edge_index.shape
+        assert np.allclose(group["cell"][()], graphs[0].cell.numpy())
+        assert np.allclose(group["node_attrs"][()], graphs[0].node_attrs.numpy())
+        assert group["energy"][()] == pytest.approx(0.0)
+        assert handle["config_1"]["energy"][()] == pytest.approx(1.0)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 import torch.nn.functional
 from ase import build
@@ -7,6 +8,7 @@ from e3nn.util import jit
 from scipy.spatial.transform import Rotation as R
 
 from mace import data, modules, tools
+from mace.tools import scripts_utils  # noqa: F401  (tools.scripts_utils)
 from mace.tools import torch_geometric
 
 torch.set_default_dtype(torch.float64)
@@ -523,3 +525,157 @@ def test_stress_partial_pbc():
         f"sigma_yy finite difference {finite_diff} does not match "
         f"analytic stress {stress[1, 1]}"
     )
+
+
+# ===========================================================================
+# Two model-construction knobs no published checkpoint stores, and which
+# therefore have no golden: --use_edge_irreps_first and a non-linear first
+# interaction block. Both are KEEP for the rewrite, so each needs a case that
+# says what it does rather than only that it parses.
+# ===========================================================================
+
+
+def _energy_model_config(**overrides):
+    config_dict = dict(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=6,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o"),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=atomic_energies,
+        avg_num_neighbors=8,
+        atomic_numbers=table.zs,
+        correlation=3,
+        atomic_inter_scale=1.0,
+        atomic_inter_shift=0.0,
+    )
+    config_dict.update(overrides)
+    return config_dict
+
+
+def test_use_edge_irreps_first_narrows_the_first_interaction_block():
+    """`--use_edge_irreps_first` replaces the first layer's edge irreps with
+    the *scalar* part of `--edge_irreps` (`models.py:175-176`). Later layers
+    are untouched, and with `--edge_irreps` unset the flag does nothing.
+
+    The multiplicities here differ on purpose: 8 scalars on the edges against
+    16 in the hidden irreps. With the usual 128/128 setting the derived
+    `128x0e` equals the first layer's node features exactly and the flag is
+    unobservable -- a test at those numbers would pass whatever the flag did.
+    """
+    edge_irreps = o3.Irreps("8x0e + 8x1o")
+    off = modules.ScaleShiftMACE(
+        **_energy_model_config(edge_irreps=edge_irreps, use_edge_irreps_first=False)
+    )
+    on = modules.ScaleShiftMACE(
+        **_energy_model_config(edge_irreps=edge_irreps, use_edge_irreps_first=True)
+    )
+
+    # off: the block falls back to the node features, 16 scalars after the
+    # element embedding. on: the 0e count of edge_irreps.
+    assert off.interactions[0].edge_irreps == o3.Irreps("16x0e")
+    assert on.interactions[0].edge_irreps == o3.Irreps("8x0e")
+    # the first layer only -- later layers use edge_irreps in full either way
+    assert off.interactions[1].edge_irreps == edge_irreps
+    assert on.interactions[1].edge_irreps == edge_irreps
+    # and the narrower first layer really is a smaller model
+    assert sum(p.numel() for p in on.parameters()) < sum(
+        p.numel() for p in off.parameters()
+    )
+
+    # without edge_irreps there is nothing to derive from, so it is a no-op
+    plain_on = modules.ScaleShiftMACE(
+        **_energy_model_config(use_edge_irreps_first=True)
+    )
+    plain_off = modules.ScaleShiftMACE(
+        **_energy_model_config(use_edge_irreps_first=False)
+    )
+    assert (
+        plain_on.interactions[0].edge_irreps == plain_off.interactions[0].edge_irreps
+    )
+
+
+def test_use_edge_irreps_first_survives_the_checkpoint_config_round_trip():
+    """The flag is stored on the model and re-emitted by
+    `extract_config_mace_model`, which is what every conversion CLI rebuilds
+    from. If it were dropped there, a converted model would silently get a
+    wider first layer and the weights would not fit."""
+    model = modules.ScaleShiftMACE(
+        **_energy_model_config(
+            edge_irreps=o3.Irreps("8x0e + 8x1o"), use_edge_irreps_first=True
+        )
+    )
+    assert model.use_edge_irreps_first is True
+    extracted = tools.scripts_utils.extract_config_mace_model(model)
+    assert extracted["use_edge_irreps_first"] is True
+    rebuilt = modules.ScaleShiftMACE(**extracted)
+    assert rebuilt.interactions[0].edge_irreps == o3.Irreps("8x0e")
+    assert sum(p.numel() for p in rebuilt.parameters()) == sum(
+        p.numel() for p in model.parameters()
+    )
+
+
+def test_non_linear_first_interaction_block_runs_and_is_equivariant():
+    """`--interaction_first RealAgnosticResidualNonLinearInteractionBlock`:
+    a gated non-linearity inside the first layer only."""
+    model = modules.ScaleShiftMACE(
+        **_energy_model_config(
+            interaction_cls_first=modules.interaction_classes[
+                "RealAgnosticResidualNonLinearInteractionBlock"
+            ]
+        )
+    )
+    assert hasattr(model.interactions[0], "equivariant_nonlin")
+    assert not hasattr(model.interactions[1], "equivariant_nonlin")
+
+    atomic_data = data.AtomicData.from_config(config, z_table=table, cutoff=3.0)
+    rotated = data.AtomicData.from_config(config_rotated, z_table=table, cutoff=3.0)
+    batch = next(
+        iter(
+            torch_geometric.dataloader.DataLoader(
+                dataset=[atomic_data, rotated], batch_size=2, shuffle=False
+            )
+        )
+    )
+    output = model(batch.to_dict(), training=True)
+    assert output["energy"].shape == (2,)
+    assert torch.allclose(output["energy"][0], output["energy"][1])
+    assert output["forces"].shape == (6, 3)
+
+    extracted = tools.scripts_utils.extract_config_mace_model(model)
+    assert (
+        extracted["interaction_cls_first"]
+        is modules.interaction_classes["RealAgnosticResidualNonLinearInteractionBlock"]
+    )
+
+
+def test_non_linear_first_interaction_block_cannot_be_torchscripted():
+    """Characterization of a real limitation, not a wish: TorchScript cannot
+    resolve the `-> o3.Irreps` annotation on `GatedEquivariantBlock.irreps_in`
+    (`mace/modules/gate.py:205`), so a model with this block compiles nowhere
+    -- which rules out the LAMMPS export path, whose whole artifact is a
+    scripted module. Every other interaction block scripts fine, so this is
+    the block's property and not the model's.
+    """
+    model = modules.ScaleShiftMACE(
+        **_energy_model_config(
+            interaction_cls_first=modules.interaction_classes[
+                "RealAgnosticResidualNonLinearInteractionBlock"
+            ]
+        )
+    )
+    with pytest.raises(RuntimeError, match="o3.Irreps"):
+        jit.compile(model)
+
+    # the same model with the default first block scripts without complaint
+    assert jit.compile(modules.ScaleShiftMACE(**_energy_model_config())) is not None

--- a/tests/unit/test_radial.py
+++ b/tests/unit/test_radial.py
@@ -1,94 +1,772 @@
+"""Characterization of `mace/modules/radial.py` and the radial-embedding
+assembly in `mace/modules/blocks.py`.
+
+Everything in this file is pure mathematics: a distance in, a number out, no
+learned parameters and no graph beyond the element pair an edge connects. It
+ports into the rewrite nearly verbatim, so these values are the spec the port
+is checked against rather than a snapshot of what the code happens to do.
+
+Two conventions, both deliberate:
+
+* **Reference values are committed as decimal literals AND re-derived from
+  the closed form.** The literals are what a port is measured against; the
+  derivation is what says the literals are the formula rather than a
+  photograph of the implementation. A change to either side alone fails.
+* **Tolerances are imported, never written here.** The one table lives in
+  `tests/golden/harness.py`; the row these tests use is `closed_form_fp64`,
+  which is not a golden row -- nothing here crosses a machine or a device,
+  only the order of the fp64 arithmetic differs.
+
+Where the behaviour is exactly representable -- a cutoff that returns zero, a
+repulsion that switches off past the covalent radii -- the assertion is exact
+equality with no row at all. That is not pedantry: `build_fake_padding_graph`
+(`mace/data/padding_tools.py:81-106`) gives every padding edge a self-loop
+with a shift of `2 * r_max` precisely so the envelope annihilates it, and
+"very small" would not do.
+"""
+
+import ase.data
+import numpy as np
 import pytest
 import torch
 
-from mace.modules.radial import AgnesiTransform, ZBLBasis
+from mace.modules.blocks import RadialEmbeddingBlock
+from mace.modules.radial import (
+    AgnesiTransform,
+    BesselBasis,
+    ChebychevBasis,
+    GaussianBasis,
+    PolynomialCutoff,
+    RadialMLP,
+    SoftTransform,
+    ZBLBasis,
+)
+from tests.golden.harness import tolerance
+
+CLOSED_FORM = tolerance("closed_form_fp64")
 
 
-@pytest.fixture
-def zbl_basis():
-    return ZBLBasis(p=6, trainable=False)
+@pytest.fixture(name="fp64")
+def fixture_fp64():
+    """These modules read `torch.get_default_dtype()` at construction, and the
+    suite runs in float32. Nothing below is a float32 claim."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous)
 
 
-def test_zbl_basis_initialization(zbl_basis):
-    assert zbl_basis.p == torch.tensor(6.0)
-    assert torch.allclose(zbl_basis.c, torch.tensor([0.1818, 0.5099, 0.2802, 0.02817]))
-
-    assert zbl_basis.a_exp == torch.tensor(0.300)
-    assert zbl_basis.a_prefactor == torch.tensor(0.4543)
-    assert not zbl_basis.a_exp.requires_grad
-    assert not zbl_basis.a_prefactor.requires_grad
-
-
-def test_trainable_zbl_basis_initialization(zbl_basis):
-    zbl_basis = ZBLBasis(p=6, trainable=True)
-    assert zbl_basis.p == torch.tensor(6.0)
-    assert torch.allclose(zbl_basis.c, torch.tensor([0.1818, 0.5099, 0.2802, 0.02817]))
-
-    assert zbl_basis.a_exp == torch.tensor(0.300)
-    assert zbl_basis.a_prefactor == torch.tensor(0.4543)
-    assert zbl_basis.a_exp.requires_grad
-    assert zbl_basis.a_prefactor.requires_grad
-
-
-def test_forward(zbl_basis):
-    x = torch.tensor([1.0, 1.0, 2.0]).unsqueeze(-1)  # [n_edges]
-    node_attrs = torch.tensor(
-        [[1, 0], [0, 1]]
-    )  # [n_nodes, n_node_features] - one_hot encoding of atomic numbers
-    edge_index = torch.tensor([[0, 1, 1], [1, 0, 1]])  # [2, n_edges]
-    atomic_numbers = torch.tensor([1, 6])  # [n_nodes]
-    output = zbl_basis(x, node_attrs, edge_index, atomic_numbers)
-
-    assert output.shape == torch.Size([node_attrs.shape[0]])
-    assert torch.is_tensor(output)
-    assert torch.allclose(
-        output,
-        torch.tensor([0.0031, 0.0031], dtype=torch.get_default_dtype()),
-        rtol=1e-2,
+def assert_close(actual, expected, what=""):
+    """The one comparison used for a closed-form check, at the imported row."""
+    actual = np.asarray(
+        actual.detach().numpy() if torch.is_tensor(actual) else actual, dtype=float
+    )
+    expected = np.asarray(expected, dtype=float)
+    assert actual.shape == expected.shape, f"{what}: {actual.shape} vs {expected.shape}"
+    deviation = np.abs(actual - expected)
+    bound = CLOSED_FORM.atol + CLOSED_FORM.rtol * np.abs(expected)
+    worst = int(np.argmax(deviation - bound)) if deviation.size else 0
+    assert np.all(deviation <= bound), (
+        f"{what}: worst deviation {deviation.ravel()[worst]:.3e} at index "
+        f"{worst} exceeds the '{CLOSED_FORM.name}' row"
     )
 
 
-@pytest.fixture
-def agnesi():
-    return AgnesiTransform(trainable=False)
+# ===========================================================================
+# BesselBasis -- f_n(r) = sqrt(2/r_max) * sin(n*pi*r/r_max) / r
+# ===========================================================================
+
+BESSEL_R_MAX, BESSEL_N = 5.0, 4
+
+#: r -> the four basis values, sqrt(2/5) * sin(n*pi*r/5) / r for n = 1..4.
+BESSEL_REFERENCE = {
+    0.9: [
+        0.37654068966260074,
+        0.6358476387398435,
+        0.6971871458425328,
+        0.5414615143319496,
+    ],
+    1.7: [
+        0.3260147103245917,
+        0.314117569020157,
+        -0.02336012437387206,
+        -0.33662522050932886,
+    ],
+    3.0: [
+        0.20050031833584858,
+        -0.12391601148672815,
+        -0.1239160114867282,
+        0.20050031833584855,
+    ],
+}
 
 
-def test_agnesi_transform_initialization(agnesi: AgnesiTransform):
-    assert agnesi.q.item() == pytest.approx(0.9183, rel=1e-4)
-    assert agnesi.p.item() == pytest.approx(4.5791, rel=1e-4)
-    assert agnesi.a.item() == pytest.approx(1.0805, rel=1e-4)
-    assert not agnesi.a.requires_grad
-    assert not agnesi.q.requires_grad
-    assert not agnesi.p.requires_grad
+def test_bessel_reference_values_are_the_closed_form():
+    n = np.arange(1, BESSEL_N + 1)
+    for distance, expected in BESSEL_REFERENCE.items():
+        closed_form = (
+            np.sqrt(2.0 / BESSEL_R_MAX)
+            * np.sin(n * np.pi * distance / BESSEL_R_MAX)
+            / distance
+        )
+        assert_close(closed_form, expected, f"bessel closed form at r={distance}")
 
 
-def test_trainable_agnesi_transform_initialization():
+def test_bessel_basis_values(fp64):  # pylint: disable=unused-argument
+    basis = BesselBasis(r_max=BESSEL_R_MAX, num_basis=BESSEL_N)
+    distances = torch.tensor([[r] for r in BESSEL_REFERENCE])
+    assert_close(
+        basis(distances),
+        list(BESSEL_REFERENCE.values()),
+        "bessel",
+    )
+
+
+def test_bessel_buffers_and_trainability(fp64):  # pylint: disable=unused-argument
+    basis = BesselBasis(r_max=BESSEL_R_MAX, num_basis=BESSEL_N)
+    assert_close(
+        basis.bessel_weights,
+        np.pi / BESSEL_R_MAX * np.arange(1, BESSEL_N + 1),
+        "bessel weights",
+    )
+    assert_close(basis.prefactor, np.sqrt(2.0 / BESSEL_R_MAX), "prefactor")
+    assert not basis.bessel_weights.requires_grad
+    assert BesselBasis(r_max=BESSEL_R_MAX, trainable=True).bessel_weights.requires_grad
+    assert "trainable=False" in repr(basis)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("n_edges", [0, 1, 7])
+def test_bessel_shape_and_dtype_contract(dtype, n_edges):
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        basis = BesselBasis(r_max=BESSEL_R_MAX, num_basis=BESSEL_N)
+        out = basis(torch.full((n_edges, 1), 1.3, dtype=dtype))
+        assert out.shape == (n_edges, BESSEL_N)
+        assert out.dtype == dtype
+    finally:
+        torch.set_default_dtype(previous)
+
+
+# ===========================================================================
+# ChebychevBasis -- T_n(x), and it does NOT rescale by r_max
+# ===========================================================================
+
+#: x -> T_1..T_4 evaluated by the standard recurrence.
+CHEBYCHEV_REFERENCE = {
+    0.3: [0.3, -0.8200000000000001, -0.7919999999999999, 0.3448],
+    -0.5: [-0.5, -0.5, 1.0, -0.5],
+    0.9: [0.9, 0.6200000000000001, 0.2160000000000002, -0.2312000000000003],
+}
+
+
+def test_chebychev_reference_values_are_the_recurrence():
+    for x, expected in CHEBYCHEV_REFERENCE.items():
+        closed_form = [x, 2 * x**2 - 1, 4 * x**3 - 3 * x, 8 * x**4 - 8 * x**2 + 1]
+        assert_close(closed_form, expected, f"chebychev closed form at x={x}")
+
+
+def test_chebychev_basis_values(fp64):  # pylint: disable=unused-argument
+    basis = ChebychevBasis(r_max=BESSEL_R_MAX, num_basis=4)
+    x = torch.tensor([[v] for v in CHEBYCHEV_REFERENCE])
+    assert_close(basis(x), list(CHEBYCHEV_REFERENCE.values()), "chebychev")
+
+
+def test_chebychev_ignores_r_max_and_diverges_outside_the_unit_interval(
+    fp64,
+):  # pylint: disable=unused-argument
+    """Characterization, not endorsement. `r_max` is stored and never used:
+    the polynomials are evaluated on the raw distance, so at r > 1 they take
+    the cosh branch and grow without bound instead of oscillating. Two bases
+    built with different `r_max` return the same numbers. A port that
+    "fixed" this by mapping r into [-1, 1] would silently change every model
+    trained with `--radial_type chebyshev`.
+    """
+    near = ChebychevBasis(r_max=3.0, num_basis=3)
+    far = ChebychevBasis(r_max=30.0, num_basis=3)
+    distances = torch.tensor([[1.7]])
+    assert torch.equal(near(distances), far(distances))
+    # T_n(1.7): 1.7, 2*1.7^2-1 = 4.78, 4*1.7^3-3*1.7 = 14.552
+    assert_close(near(distances), [[1.7, 4.78, 14.552]], "chebychev beyond 1")
+
+
+# ===========================================================================
+# GaussianBasis -- exp(-0.5 * ((r - c_k) / w)^2), c_k linspace(0, r_max)
+# ===========================================================================
+
+GAUSSIAN_R_MAX, GAUSSIAN_N = 5.0, 6
+
+GAUSSIAN_REFERENCE = {
+    0.9: [
+        0.6669768108584744,
+        0.9950124791926823,
+        0.5460744266397094,
+        0.11025052530448522,
+        0.008188701014374074,
+        0.00022374579372062055,
+    ],
+    3.0: [
+        0.011108996538242306,
+        0.1353352832366127,
+        0.6065306597126334,
+        1.0,
+        0.6065306597126334,
+        0.1353352832366127,
+    ],
+}
+
+
+def test_gaussian_reference_values_are_the_closed_form():
+    centres = np.linspace(0.0, GAUSSIAN_R_MAX, GAUSSIAN_N)
+    width = GAUSSIAN_R_MAX / (GAUSSIAN_N - 1)
+    for distance, expected in GAUSSIAN_REFERENCE.items():
+        closed_form = np.exp(-0.5 * ((distance - centres) / width) ** 2)
+        assert_close(closed_form, expected, f"gaussian closed form at r={distance}")
+
+
+def test_gaussian_basis_values(fp64):  # pylint: disable=unused-argument
+    basis = GaussianBasis(r_max=GAUSSIAN_R_MAX, num_basis=GAUSSIAN_N)
+    distances = torch.tensor([[r] for r in GAUSSIAN_REFERENCE])
+    assert_close(basis(distances), list(GAUSSIAN_REFERENCE.values()), "gaussian")
+    # the width is folded into a single coefficient at construction
+    assert_close(
+        basis.coeff, -0.5 / (GAUSSIAN_R_MAX / (GAUSSIAN_N - 1)) ** 2, "gaussian coeff"
+    )
+    assert not basis.gaussian_weights.requires_grad
+    assert GaussianBasis(
+        r_max=GAUSSIAN_R_MAX, trainable=True
+    ).gaussian_weights.requires_grad
+
+
+def test_gaussian_basis_is_not_zero_beyond_r_max(fp64):  # pylint: disable=unused-argument
+    """Unlike the cutoff, a Gaussian never reaches zero. Only the envelope
+    makes a long edge contribute nothing, which is why the padding trick
+    depends on `PolynomialCutoff` and not on the basis."""
+    basis = GaussianBasis(r_max=GAUSSIAN_R_MAX, num_basis=GAUSSIAN_N)
+    assert (basis(torch.tensor([[2 * GAUSSIAN_R_MAX]])) > 0.0).all()
+
+
+# ===========================================================================
+# PolynomialCutoff
+# ===========================================================================
+
+CUTOFF_R_MAX, CUTOFF_P = 3.0, 6
+
+CUTOFF_REFERENCE = {
+    0.0: 1.0,
+    1.0: 0.9803383630544124,
+    1.5: 0.85546875,
+    2.0: 0.5317786922725198,
+    2.9: 0.001828263342478209,
+}
+
+
+def _envelope(distance, r_max=CUTOFF_R_MAX, p=CUTOFF_P):
+    u = distance / r_max
+    return (
+        1.0
+        - ((p + 1.0) * (p + 2.0) / 2.0) * u**p
+        + p * (p + 2.0) * u ** (p + 1)
+        - (p * (p + 1.0) / 2.0) * u ** (p + 2)
+    )
+
+
+def test_cutoff_reference_values_are_the_closed_form():
+    for distance, expected in CUTOFF_REFERENCE.items():
+        assert_close(_envelope(distance), expected, f"cutoff closed form at {distance}")
+
+
+def test_polynomial_cutoff_values(fp64):  # pylint: disable=unused-argument
+    cutoff = PolynomialCutoff(r_max=CUTOFF_R_MAX, p=CUTOFF_P)
+    distances = torch.tensor([[r] for r in CUTOFF_REFERENCE])
+    assert_close(
+        cutoff(distances), [[v] for v in CUTOFF_REFERENCE.values()], "cutoff"
+    )
+    assert cutoff.p.dtype == torch.int32
+    assert f"p={cutoff.p}" in repr(cutoff)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_polynomial_cutoff_is_exactly_zero_at_and_beyond_r_max(dtype):
+    """Exact equality, in both dtypes, at both distances the padded-batch
+    contract relies on. At 2*r_max the polynomial evaluates to a negative
+    number and the `(x < r_max)` mask produces -0.0, which compares equal to
+    0.0 -- assert the comparison, never the repr."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        cutoff = PolynomialCutoff(r_max=CUTOFF_R_MAX, p=CUTOFF_P)
+        for distance in (CUTOFF_R_MAX, 2 * CUTOFF_R_MAX, 100 * CUTOFF_R_MAX):
+            value = cutoff(torch.tensor(distance, dtype=dtype))
+            assert value.item() == 0.0, (distance, value.item())
+        # ... and it is not zero just inside
+        inside = cutoff(torch.tensor(CUTOFF_R_MAX * 0.999, dtype=dtype))
+        assert inside.item() > 0.0
+    finally:
+        torch.set_default_dtype(previous)
+
+
+def test_polynomial_cutoff_derivative_vanishes_at_and_beyond_r_max(
+    fp64,
+):  # pylint: disable=unused-argument
+    cutoff = PolynomialCutoff(r_max=CUTOFF_R_MAX, p=CUTOFF_P)
+    distances = torch.tensor(
+        [CUTOFF_R_MAX, CUTOFF_R_MAX + 0.5, 2 * CUTOFF_R_MAX], requires_grad=True
+    )
+    (gradient,) = torch.autograd.grad(cutoff(distances).sum(), distances)
+    assert torch.equal(gradient, torch.zeros_like(gradient))
+
+
+def test_polynomial_cutoff_meets_r_max_with_a_vanishing_slope(
+    fp64,
+):  # pylint: disable=unused-argument
+    """Continuity across the cutoff, measured rather than asserted: the
+    envelope has a triple root at r_max, so its finite-difference slope just
+    inside must fall off like h^2 as the offset h halves. A first-order kink
+    would halve instead, and a discontinuity would not shrink at all."""
+    cutoff = PolynomialCutoff(r_max=CUTOFF_R_MAX, p=CUTOFF_P)
+
+    def central_difference(distance, step=1e-7):
+        left = cutoff(torch.tensor(distance - step))
+        right = cutoff(torch.tensor(distance + step))
+        return abs(float(right - left) / (2 * step))
+
+    # offsets small enough to be in the asymptotic regime: at h = 0.4 (13% of
+    # r_max) the higher-order terms still dominate and the observed ratio is
+    # only 2.76, which is a property of the sampling, not of the envelope
+    offsets = (0.05, 0.025, 0.0125, 0.00625)
+    slopes = [central_difference(CUTOFF_R_MAX - h) for h in offsets]
+    for coarse, fine in zip(slopes, slopes[1:]):
+        ratio = coarse / fine
+        assert 3.5 < ratio < 4.5, f"observed order {np.log2(ratio):.2f}, expected 2"
+    # and the last one is already tiny compared with the slope mid-range
+    assert slopes[-1] < 0.01 * central_difference(CUTOFF_R_MAX / 2)
+
+
+@pytest.mark.parametrize("p", [2, 5, 6, 8])
+def test_polynomial_cutoff_is_one_at_zero_for_every_p(p, fp64):  # pylint: disable=unused-argument
+    cutoff = PolynomialCutoff(r_max=CUTOFF_R_MAX, p=p)
+    assert cutoff(torch.tensor(0.0)).item() == 1.0
+    assert cutoff(torch.tensor(CUTOFF_R_MAX)).item() == 0.0
+    # monotone decreasing in between, for every p the CLI accepts
+    sampled = cutoff(torch.linspace(0.0, CUTOFF_R_MAX, 200))
+    assert bool((torch.diff(sampled) <= 0).all())
+
+
+# ===========================================================================
+# ZBLBasis -- the published Ziegler-Biersack-Littmark screened Coulomb pair
+# ===========================================================================
+#
+#   V(r) = (1/2) * (14.3996 * Z_u * Z_v / r) * phi(r/a) * envelope(r)
+#   a    = 0.4543 * 0.529 / (Z_u^0.3 + Z_v^0.3)
+#   phi(x) = 0.1818 e^{-3.2x} + 0.5099 e^{-0.9423x}
+#          + 0.2802 e^{-0.4028x} + 0.02817 e^{-0.2016x}
+#
+# The envelope is a PolynomialCutoff whose r_max is the *pair's* covalent
+# radii sum, not the model cutoff -- so the term switches off at 1.07 Ang for
+# H-C and at 1.32 Ang for O-O. The 1/2 is because the sum below runs over
+# directed edges, i.e. every pair twice.
+
+
+def zbl_pair_energy(z_u, z_v, distance, p=6):
+    """The formula above, written out independently of the implementation."""
+    a = 0.4543 * 0.529 / (z_u**0.300 + z_v**0.300)
+    x = distance / a
+    phi = (
+        0.1818 * np.exp(-3.2 * x)
+        + 0.5099 * np.exp(-0.9423 * x)
+        + 0.2802 * np.exp(-0.4028 * x)
+        + 0.02817 * np.exp(-0.2016 * x)
+    )
+    pair_r_max = ase.data.covalent_radii[z_u] + ase.data.covalent_radii[z_v]
+    envelope = _envelope(distance, r_max=pair_r_max, p=p) * (distance < pair_r_max)
+    return 0.5 * (14.3996 * z_u * z_v) / distance * phi * envelope
+
+
+#: (Z_u, Z_v, r) -> per-node energy, hand-evaluated from the formula above.
+#: H-C at 0.9 Ang: a = 0.4543*0.529/(1 + 6^0.3) = 0.09147 Ang, x = 9.839,
+#: phi = 6.148e-5, prefactor 14.3996*6/0.9 = 95.997 eV, envelope 0.1300.
+ZBL_REFERENCE = {
+    (1, 6, 0.9): 0.04838438085989024,
+    (8, 8, 1.2): 0.00924872728685459,
+}
+
+
+def test_zbl_reference_values_are_the_published_formula():
+    for (z_u, z_v, distance), expected in ZBL_REFERENCE.items():
+        assert_close(
+            zbl_pair_energy(z_u, z_v, distance), expected, f"zbl {z_u}-{z_v}"
+        )
+
+
+@pytest.mark.parametrize("pair", sorted(ZBL_REFERENCE))
+def test_zbl_matches_the_published_formula(pair, fp64):  # pylint: disable=unused-argument
+    z_u, z_v, distance = pair
+    zbl = ZBLBasis(p=6)
+    species = sorted({z_u, z_v})
+    node_attrs = torch.eye(len(species))[
+        [species.index(z_u), species.index(z_v)]
+    ].to(torch.get_default_dtype())
+    lengths = torch.tensor([[distance], [distance]])
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    energies = zbl(
+        lengths, node_attrs, edge_index, torch.tensor(species, dtype=torch.long)
+    )
+    # one directed edge lands on each node, each carrying half the pair energy
+    assert energies.shape == (2,)
+    assert_close(energies, [ZBL_REFERENCE[pair]] * 2, f"zbl {pair}")
+    assert_close(
+        energies.sum(), 2 * ZBL_REFERENCE[pair], "zbl total"
+    )
+
+
+def test_zbl_is_exactly_zero_beyond_the_pair_covalent_radii(
+    fp64,
+):  # pylint: disable=unused-argument
+    """The envelope's r_max is the pair's covalent radii sum (1.07 Ang for
+    H-C), not the model cutoff -- so a perfectly ordinary bond length gets
+    exactly no repulsion."""
+    zbl = ZBLBasis(p=6)
+    node_attrs = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    atomic_numbers = torch.tensor([1, 6])
+    pair_r_max = ase.data.covalent_radii[1] + ase.data.covalent_radii[6]
+    assert pair_r_max == pytest.approx(1.07)
+    for distance in (pair_r_max, 1.2, 3.0):
+        energies = zbl(
+            torch.tensor([[distance], [distance]]),
+            node_attrs,
+            edge_index,
+            atomic_numbers,
+        )
+        assert torch.equal(energies, torch.zeros(2)), distance
+    # ... and it is not zero just inside
+    inside = zbl(
+        torch.tensor([[pair_r_max * 0.99], [pair_r_max * 0.99]]),
+        node_attrs,
+        edge_index,
+        atomic_numbers,
+    )
+    assert (inside > 0.0).all()
+
+
+def test_zbl_energy_is_scattered_onto_the_receiver(fp64):  # pylint: disable=unused-argument
+    """Per-node, not per-edge: the return is indexed by receiver, so a node
+    with two neighbours carries both halves."""
+    zbl = ZBLBasis(p=6)
+    # three H atoms, all edges pointing at node 0
+    node_attrs = torch.ones(3, 1)
+    edge_index = torch.tensor([[1, 2], [0, 0]])
+    lengths = torch.tensor([[0.6], [0.6]])
+    energies = zbl(lengths, node_attrs, edge_index, torch.tensor([1]))
+    assert energies.shape == (3,)
+    assert_close(energies[0], 2 * zbl_pair_energy(1, 1, 0.6), "receiver sum")
+    assert torch.equal(energies[1:], torch.zeros(2))
+
+
+def test_zbl_buffers_and_trainability(fp64):  # pylint: disable=unused-argument
+    zbl = ZBLBasis(p=6)
+    assert_close(zbl.c, [0.1818, 0.5099, 0.2802, 0.02817], "zbl c")
+    assert zbl.a_exp.item() == pytest.approx(0.300)
+    assert zbl.a_prefactor.item() == pytest.approx(0.4543)
+    assert not zbl.a_exp.requires_grad and not zbl.a_prefactor.requires_grad
+    trainable = ZBLBasis(p=6, trainable=True)
+    assert trainable.a_exp.requires_grad and trainable.a_prefactor.requires_grad
+
+
+def test_zbl_accepts_and_ignores_r_max(fp64, caplog):  # pylint: disable=unused-argument
+    """`r_max` is a deprecated argument kept for old checkpoints: it warns and
+    changes nothing, because the envelope's cutoff comes from the covalent
+    radii of each pair."""
+    with caplog.at_level("WARNING"):
+        deprecated = ZBLBasis(p=6, r_max=5.0)
+    assert "r_max is deprecated" in caplog.text
+    node_attrs = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    edge_index = torch.tensor([[0, 1], [1, 0]])
+    lengths = torch.tensor([[0.9], [0.9]])
+    atomic_numbers = torch.tensor([1, 6])
+    assert torch.equal(
+        deprecated(lengths, node_attrs, edge_index, atomic_numbers),
+        ZBLBasis(p=6)(lengths, node_attrs, edge_index, atomic_numbers),
+    )
+
+
+# ===========================================================================
+# Distance transforms
+# ===========================================================================
+
+#: r -> transformed r, for an H-C edge (r_0 = 0.535 Ang = half the radii sum).
+#: T(r) = 1 / (1 + a * (r/r_0)^q / (1 + (r/r_0)^(q-p)))
+AGNESI_REFERENCE = {0.9: 0.3974261261086945, 1.7: 0.2451457879436009}
+
+#: The same edge through the tanh clamp, whose r_0 is the *full* radii sum
+#: (1.07 Ang), giving p_0 = 0.8025 and p_1 = 1.4267.
+SOFT_REFERENCE = {0.9: 0.8083566107332905, 1.7: 1.699505533439394}
+
+
+def _hc_edge(distances):
+    lengths = torch.tensor([[float(d)] for d in distances])
+    node_attrs = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    edge_index = torch.stack(
+        [
+            torch.zeros(len(distances), dtype=torch.long),
+            torch.ones(len(distances), dtype=torch.long),
+        ]
+    )
+    return lengths, node_attrs, edge_index, torch.tensor([1, 6])
+
+
+def test_agnesi_reference_values_are_the_closed_form():
+    q, p, a = 0.9183, 4.5791, 1.0805
+    r_0 = 0.5 * (ase.data.covalent_radii[1] + ase.data.covalent_radii[6])
+    for distance, expected in AGNESI_REFERENCE.items():
+        y = distance / r_0
+        assert_close(1.0 / (1 + a * y**q / (1 + y ** (q - p))), expected, "agnesi")
+
+
+def test_agnesi_transform_values(fp64):  # pylint: disable=unused-argument
+    transform = AgnesiTransform()
+    out = transform(*_hc_edge(AGNESI_REFERENCE))
+    assert_close(out, [[v] for v in AGNESI_REFERENCE.values()], "agnesi")
+
+
+def test_agnesi_transform_is_monotone_decreasing(fp64):  # pylint: disable=unused-argument
+    """It compresses distance: larger r maps to smaller transformed r, over
+    the whole range a cutoff can span."""
+    distances = np.linspace(0.2, 6.0, 200)
+    out = AgnesiTransform()(*_hc_edge(distances)).squeeze(-1)
+    assert bool((torch.diff(out) < 0).all())
+    assert float(out[0]) < 1.0
+
+
+def test_soft_reference_values_are_the_closed_form():
+    r_0 = ase.data.covalent_radii[1] + ase.data.covalent_radii[6]
+    p_0, p_1 = 0.75 * r_0, (4.0 / 3.0) * r_0
+    midpoint, alpha = 0.5 * (p_0 + p_1), 4.0 / (p_1 - p_0)
+    for distance, expected in SOFT_REFERENCE.items():
+        switch = 0.5 * (1.0 + np.tanh(alpha * (distance - midpoint)))
+        assert_close(p_0 + (distance - p_0) * switch, expected, "soft")
+
+
+def test_soft_transform_values(fp64):  # pylint: disable=unused-argument
+    out = SoftTransform()(*_hc_edge(SOFT_REFERENCE))
+    assert_close(out, [[v] for v in SOFT_REFERENCE.values()], "soft")
+
+
+def test_soft_transform_clamps_below_p0_and_is_the_identity_above(
+    fp64,
+):  # pylint: disable=unused-argument
+    """It flattens short distances onto p_0 = 0.75 * r_0 and leaves long ones
+    alone. Note the docstring on the class says it clamps at `p1`; the code
+    clamps at `p_0`, and the code is what is pinned here."""
+    transform = SoftTransform()
+    r_0 = ase.data.covalent_radii[1] + ase.data.covalent_radii[6]
+    p_0 = 0.75 * r_0
+    short, long = 0.15, 4.0
+    out = transform(*_hc_edge([short, long])).squeeze(-1)
+    assert float(out[0]) == pytest.approx(p_0, abs=1e-3)
+    assert float(out[1]) == pytest.approx(long, abs=1e-6)
+
+
+def test_soft_transform_is_monotone_only_above_the_clamp(
+    fp64,
+):  # pylint: disable=unused-argument
+    """Characterization of a real wrinkle: T is *not* globally monotone. Below
+    p_0 the (x - p_0) factor is negative while the switch is still opening, so
+    T dips about 5e-4 below p_0 near r = 0.74 Ang before recovering. Harmless
+    -- nothing is that short in practice -- but a port that asserts global
+    monotonicity would be asserting something false."""
+    transform = SoftTransform()
+    r_0 = ase.data.covalent_radii[1] + ase.data.covalent_radii[6]
+    p_0 = 0.75 * r_0
+
+    above = np.linspace(p_0, 6.0, 200)
+    assert bool((torch.diff(transform(*_hc_edge(above)).squeeze(-1)) > 0).all())
+
+    below = np.linspace(0.05, p_0, 200)
+    values = transform(*_hc_edge(below)).squeeze(-1)
+    assert not bool((torch.diff(values) > 0).all())
+    assert float(values.min()) < p_0
+
+
+def test_transforms_are_trainable_on_request(fp64):  # pylint: disable=unused-argument
     agnesi = AgnesiTransform(trainable=True)
-
-    assert agnesi.q.item() == pytest.approx(0.9183, rel=1e-4)
-    assert agnesi.p.item() == pytest.approx(4.5791, rel=1e-4)
-    assert agnesi.a.item() == pytest.approx(1.0805, rel=1e-4)
-    assert agnesi.a.requires_grad
-    assert agnesi.q.requires_grad
-    assert agnesi.p.requires_grad
+    assert agnesi.a.requires_grad and agnesi.q.requires_grad and agnesi.p.requires_grad
+    assert SoftTransform(trainable=True).alpha.requires_grad
+    assert not SoftTransform().alpha.requires_grad
 
 
-def test_agnesi_transform_forward():
-    agnesi = AgnesiTransform()
-    x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.get_default_dtype()).unsqueeze(-1)
-    node_attrs = torch.tensor([[0, 1], [1, 0], [0, 1]], dtype=torch.get_default_dtype())
-    edge_index = torch.tensor([[0, 1, 2], [1, 2, 0]])
-    atomic_numbers = torch.tensor([1, 6, 8])
-    output = agnesi(x, node_attrs, edge_index, atomic_numbers)
-    assert output.shape == x.shape
-    assert torch.is_tensor(output)
-    assert torch.allclose(
-        output,
-        torch.tensor(
-            [0.3646, 0.2175, 0.2089], dtype=torch.get_default_dtype()
-        ).unsqueeze(-1),
-        rtol=1e-2,
+# ===========================================================================
+# RadialMLP
+# ===========================================================================
+
+
+def test_every_module_has_a_repr_naming_its_parameters(fp64):  # pylint: disable=unused-argument
+    """A printed model is how a user checks which radial setup a checkpoint
+    was built with, so the reprs are part of the surface."""
+    assert "num_basis=4" in repr(BesselBasis(r_max=5.0, num_basis=4))
+    assert "num_basis=4" in repr(ChebychevBasis(r_max=5.0, num_basis=4))
+    assert "r_max=3.0" in repr(PolynomialCutoff(r_max=3.0)).replace("tensor(", "")
+    assert "0.1818" in repr(ZBLBasis(p=6))
+    assert "a=1.0805" in repr(AgnesiTransform())
+    assert "alpha=4.0000" in repr(SoftTransform())
+
+
+def test_radial_mlp_structure_and_shapes(fp64):  # pylint: disable=unused-argument
+    mlp = RadialMLP([8, 16, 4])
+    kinds = [type(module).__name__ for module in mlp.net]
+    # Linear -> LayerNorm -> SiLU -> Linear: no normalisation or activation
+    # after the last layer, so the output is unbounded
+    assert kinds == ["Linear", "LayerNorm", "SiLU", "Linear"]
+    assert mlp.hs == [8, 16, 4]
+    out = mlp(torch.zeros(5, 8))
+    assert out.shape == (5, 4)
+    assert out.dtype == torch.float64
+
+
+def test_radial_mlp_single_layer_has_no_activation(fp64):  # pylint: disable=unused-argument
+    mlp = RadialMLP([3, 2])
+    assert [type(module).__name__ for module in mlp.net] == ["Linear"]
+    assert mlp(torch.ones(1, 3)).shape == (1, 2)
+
+
+# ===========================================================================
+# RadialEmbeddingBlock: --apply_cutoff and the order of the three steps
+# ===========================================================================
+#
+# forward() computes the cutoff from the RAW edge lengths, then applies the
+# distance transform, then the basis. Both facts are load-bearing and neither
+# is visible from the outside unless it is asserted: with `--distance_transform
+# Agnesi` an envelope computed from the transformed lengths differs by 0.87 at
+# r = 0.9 Ang, i.e. it is not a rounding-level difference but a different
+# model.
+
+EMBEDDING_R_MAX = 3.0
+
+
+def _embedding_inputs():
+    lengths = torch.tensor([[0.9], [1.7], [2.5]])
+    node_attrs = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    edge_index = torch.tensor([[0, 1, 0], [1, 0, 1]])
+    return lengths, node_attrs, edge_index, torch.tensor([1, 6])
+
+
+@pytest.mark.parametrize("radial_type", ["bessel", "gaussian", "chebyshev"])
+@pytest.mark.parametrize("distance_transform", ["None", "Agnesi", "Soft"])
+def test_apply_cutoff_true_returns_the_product_and_no_envelope(
+    radial_type, distance_transform, fp64
+):  # pylint: disable=unused-argument
+    block = RadialEmbeddingBlock(
+        r_max=EMBEDDING_R_MAX,
+        num_bessel=4,
+        num_polynomial_cutoff=6,
+        radial_type=radial_type,
+        distance_transform=distance_transform,
     )
+    assert block.apply_cutoff is True  # the CLI default
+    radial, envelope = block(*_embedding_inputs())
+    assert envelope is None
+    assert radial.shape == (3, 4)
+    assert block.out_dim == 4
+
+
+@pytest.mark.parametrize("radial_type", ["bessel", "gaussian", "chebyshev"])
+@pytest.mark.parametrize("distance_transform", ["None", "Agnesi", "Soft"])
+def test_apply_cutoff_false_defers_the_envelope_to_the_consumer(
+    radial_type, distance_transform, fp64
+):  # pylint: disable=unused-argument
+    """`--apply_cutoff False` returns the bare basis and the envelope beside
+    it, un-multiplied. The product of the two is bit-for-bit the default
+    branch's output -- that identity is the whole contract, since the
+    consumer applies the envelope later."""
+    common = dict(
+        r_max=EMBEDDING_R_MAX,
+        num_bessel=4,
+        num_polynomial_cutoff=6,
+        radial_type=radial_type,
+        distance_transform=distance_transform,
+    )
+    applied, _ = RadialEmbeddingBlock(**common, apply_cutoff=True)(
+        *_embedding_inputs()
+    )
+    deferred, envelope = RadialEmbeddingBlock(**common, apply_cutoff=False)(
+        *_embedding_inputs()
+    )
+    assert envelope is not None
+    assert envelope.shape == (3, 1)
+    assert torch.equal(applied, deferred * envelope)
+    assert not torch.equal(applied, deferred)  # the envelope is not all ones
+
+
+@pytest.mark.parametrize("distance_transform", ["Agnesi", "Soft"])
+def test_the_cutoff_is_computed_before_the_distance_transform(
+    distance_transform, fp64
+):  # pylint: disable=unused-argument
+    """Ordering, pinned discriminatingly: the returned envelope is the one
+    computed from the raw lengths, and it is *not* the one the transformed
+    lengths would give."""
+    lengths, node_attrs, edge_index, atomic_numbers = _embedding_inputs()
+    block = RadialEmbeddingBlock(
+        r_max=EMBEDDING_R_MAX,
+        num_bessel=4,
+        num_polynomial_cutoff=6,
+        distance_transform=distance_transform,
+        apply_cutoff=False,
+    )
+    _, envelope = block(lengths, node_attrs, edge_index, atomic_numbers)
+
+    cutoff = PolynomialCutoff(r_max=EMBEDDING_R_MAX, p=6)
+    transform = {"Agnesi": AgnesiTransform, "Soft": SoftTransform}[
+        distance_transform
+    ]()
+    transformed = transform(lengths, node_attrs, edge_index, atomic_numbers)
+
+    assert torch.equal(envelope, cutoff(lengths))
+    assert not torch.allclose(envelope, cutoff(transformed))
+
+
+def test_the_basis_sees_the_transformed_lengths(fp64):  # pylint: disable=unused-argument
+    lengths, node_attrs, edge_index, atomic_numbers = _embedding_inputs()
+    block = RadialEmbeddingBlock(
+        r_max=EMBEDDING_R_MAX,
+        num_bessel=4,
+        num_polynomial_cutoff=6,
+        distance_transform="Agnesi",
+        apply_cutoff=False,
+    )
+    radial, _ = block(lengths, node_attrs, edge_index, atomic_numbers)
+    transformed = AgnesiTransform()(lengths, node_attrs, edge_index, atomic_numbers)
+    reference = BesselBasis(r_max=EMBEDDING_R_MAX, num_basis=4)
+    assert torch.equal(radial, reference(transformed))
+    assert not torch.allclose(radial, reference(lengths))
+
+
+def test_a_padding_edge_contributes_exactly_nothing(fp64):  # pylint: disable=unused-argument
+    """The property `build_fake_padding_graph` depends on: a self-loop edge
+    with a shift of 2*r_max has length 2*r_max, and the embedded value there
+    is exactly zero -- in the default branch by multiplication, and in the
+    deferred branch through an envelope that is exactly zero."""
+    block = RadialEmbeddingBlock(
+        r_max=EMBEDDING_R_MAX, num_bessel=4, num_polynomial_cutoff=6
+    )
+    padded = torch.tensor([[2 * EMBEDDING_R_MAX]])
+    node_attrs = torch.tensor([[1.0, 0.0]])
+    edge_index = torch.tensor([[0], [0]])
+    atomic_numbers = torch.tensor([1, 6])
+    radial, _ = block(padded, node_attrs, edge_index, atomic_numbers)
+    assert torch.equal(radial, torch.zeros_like(radial))
+
+    deferred = RadialEmbeddingBlock(
+        r_max=EMBEDDING_R_MAX,
+        num_bessel=4,
+        num_polynomial_cutoff=6,
+        apply_cutoff=False,
+    )
+    _, envelope = deferred(padded, node_attrs, edge_index, atomic_numbers)
+    assert torch.equal(envelope, torch.zeros_like(envelope))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The radial bases, key parsing, neighbour lists and batching are pure functions that port into a rewrite almost unchanged. What protects them is having their numbers written down, and mostly they did not. The radial module had three tests at `rtol=1e-2` and nothing for the Chebyshev basis, the Gaussian basis or the polynomial cutoff. The brute force neighbour reference was a private closure in one test file. The returned cell, which is what a stress gets divided by, was checked in one of its three regimes.

What this adds:

* Radial bases, cutoffs and distance transforms checked against the published formulas, in float64.
* The neighbour oracle moves to `tests/neighbour_oracle.py` so other backends can use the same reference. It compares integer unit shifts, so there is no tolerance to pick.
* A test for each of the three returned cell regimes, plus one that they really are three. Collapsing two of them silently rescales every slab stress.
* A tolerance row for closed form checks, set at 1e-12. The worst deviation measured is 1.8e-15.

Three superseded radial tests are deleted rather than kept beside the new ones. Each is covered at a real tolerance now, against a formula instead of a remembered output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 574d85c2027f504fef1be1e84581a7fdedd5891d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->