### PR TITLE
Make pseudolabelled replay data usable, and refuse it when it is not

### DIFF
--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -277,120 +277,127 @@ def generate_pseudolabels_for_configs(
         param.requires_grad = False
 
     # Process configs in batches
-    for i in range(0, len(configs), batch_size):
-        batch_configs = configs[i : i + batch_size]
+    try:
+        for i in range(0, len(configs), batch_size):
+            batch_configs = configs[i : i + batch_size]
 
-        try:
-            # Create temporary AtomicData objects for this batch
-            batch_data = [
-                AtomicData.from_config(config, z_table=z_table, cutoff=r_max)
-                for config in batch_configs
-            ]
+            try:
+                # Create temporary AtomicData objects for this batch
+                batch_data = [
+                    AtomicData.from_config(config, z_table=z_table, cutoff=r_max)
+                    for config in batch_configs
+                ]
 
-            # Create a batch for model inference
-            batch = torch_geometric.Batch.from_data_list(batch_data).to(device)
-            batch_dict = batch.to_dict()
+                # Create a batch for model inference
+                batch = torch_geometric.Batch.from_data_list(batch_data).to(device)
+                batch_dict = batch.to_dict()
 
-            # Run model inference with computation of all properties
-            out = model(
-                batch_dict,
-                training=False,
-                compute_force=True,
-                compute_virials=True,
-                compute_stress=True,
-            )
-
-            # Process each configuration in the batch
-            for j, config in enumerate(batch_configs):
-                # Create a deepcopy to avoid modifying the original
-                config_copy = deepcopy(config)
-
-                # Ensure properties dict exists
-                if not hasattr(config_copy, "properties"):
-                    config_copy.properties = {}
-
-                if not hasattr(config_copy, "property_weights"):
-                    config_copy.property_weights = {}
-
-                original_stress_weight = config.property_weights.get("stress", 0.0)
-                had_stress = (
-                    config.properties.get("stress") is not None
-                    and original_stress_weight > 0.0
+                # Run model inference with computation of all properties
+                out = model(
+                    batch_dict,
+                    training=False,
+                    compute_force=True,
+                    compute_virials=True,
+                    compute_stress=True,
                 )
 
-                # Update config properties with pseudolabels
-                if "energy" in out and out["energy"] is not None:
-                    config_copy.properties["energy"] = (
-                        out["energy"][j].detach().cpu().item()
-                    )
-                    config_copy.property_weights["energy"] = pseudolabel_weight(
-                        config, "energy"
-                    )
-                if "forces" in out and out["forces"] is not None:
-                    # Forces are per atom
-                    node_start = batch.ptr[j].item()
-                    node_end = batch.ptr[j + 1].item()
+                # Process each configuration in the batch
+                for j, config in enumerate(batch_configs):
+                    # Create a deepcopy to avoid modifying the original
+                    config_copy = deepcopy(config)
 
-                    config_copy.properties["forces"] = (
-                        out["forces"][node_start:node_end].detach().cpu().numpy()
+                    # Ensure properties dict exists
+                    if not hasattr(config_copy, "properties"):
+                        config_copy.properties = {}
+
+                    if not hasattr(config_copy, "property_weights"):
+                        config_copy.property_weights = {}
+
+                    original_stress_weight = config.property_weights.get("stress", 0.0)
+                    had_stress = (
+                        config.properties.get("stress") is not None
+                        and original_stress_weight > 0.0
                     )
-                    config_copy.property_weights["forces"] = pseudolabel_weight(
-                        config, "forces"
-                    )
-                if "stress" in out and out["stress"] is not None:
-                    if had_stress or force_stress:
+
+                    # Update config properties with pseudolabels
+                    if "energy" in out and out["energy"] is not None:
+                        config_copy.properties["energy"] = (
+                            out["energy"][j].detach().cpu().item()
+                        )
+                        config_copy.property_weights["energy"] = pseudolabel_weight(
+                            config, "energy"
+                        )
+                    if "forces" in out and out["forces"] is not None:
+                        # Forces are per atom
+                        node_start = batch.ptr[j].item()
+                        node_end = batch.ptr[j + 1].item()
+
+                        config_copy.properties["forces"] = (
+                            out["forces"][node_start:node_end].detach().cpu().numpy()
+                        )
+                        config_copy.property_weights["forces"] = pseudolabel_weight(
+                            config, "forces"
+                        )
+                    if (
+                        "stress" in out
+                        and out["stress"] is not None
+                        and (had_stress or force_stress)
+                    ):
                         config_copy.properties["stress"] = (
                             out["stress"][j].detach().cpu().numpy()
                         )
                         config_copy.property_weights["stress"] = pseudolabel_weight(
                             config, "stress"
                         )
-                if "virials" in out and out["virials"] is not None:
-                    config_copy.properties["virials"] = (
-                        out["virials"][j].detach().cpu().numpy()
-                    )
-                    config_copy.property_weights["virials"] = pseudolabel_weight(
-                        config, "virials"
-                    )
-                if "dipole" in out and out["dipole"] is not None:
-                    config_copy.properties["dipole"] = (
-                        out["dipole"][j].detach().cpu().numpy()
-                    )
-                    config_copy.property_weights["dipole"] = pseudolabel_weight(
-                        config, "dipole"
-                    )
-                if "charges" in out and out["charges"] is not None:
-                    # Charges are per atom
-                    node_start = batch.ptr[j].item()
-                    node_end = batch.ptr[j + 1].item()
+                    if "virials" in out and out["virials"] is not None:
+                        config_copy.properties["virials"] = (
+                            out["virials"][j].detach().cpu().numpy()
+                        )
+                        config_copy.property_weights["virials"] = pseudolabel_weight(
+                            config, "virials"
+                        )
+                    if "dipole" in out and out["dipole"] is not None:
+                        config_copy.properties["dipole"] = (
+                            out["dipole"][j].detach().cpu().numpy()
+                        )
+                        config_copy.property_weights["dipole"] = pseudolabel_weight(
+                            config, "dipole"
+                        )
+                    if "charges" in out and out["charges"] is not None:
+                        # Charges are per atom
+                        node_start = batch.ptr[j].item()
+                        node_end = batch.ptr[j + 1].item()
 
-                    config_copy.properties["charges"] = (
-                        out["charges"][node_start:node_end].detach().cpu().numpy()
-                    )
-                    config_copy.property_weights["charges"] = pseudolabel_weight(
-                        config, "charges"
-                    )
+                        config_copy.properties["charges"] = (
+                            out["charges"][node_start:node_end].detach().cpu().numpy()
+                        )
+                        config_copy.property_weights["charges"] = pseudolabel_weight(
+                            config, "charges"
+                        )
 
-                updated_configs.append(config_copy)
+                    updated_configs.append(config_copy)
 
-        except Exception as exc:
-            # Substituting the file's own labels for a failed batch mixed two
-            # levels of theory inside one replay set and said so only in a log
-            # line, while the count below went on reporting every configuration
-            # as relabelled. A partly relabelled set is not a usable one -- the
-            # point of replay is to control which labels the head sees -- and
-            # the caller had no way to find out, so this raises instead.
-            raise RuntimeError(
-                f"Pseudolabelling failed on batch {i // batch_size + 1} of "
-                f"{(len(configs) + batch_size - 1) // batch_size} "
-                f"(configurations {i}-{i + len(batch_configs) - 1}). Returning "
-                f"the file's labels for that batch would mix them with the "
-                f"generated ones, so the set is not relabelled at all."
-            ) from exc
-
-    # Restore original requires_grad settings
-    for param, requires_grad in original_requires_grad.items():
-        param.requires_grad = requires_grad
+            except Exception as exc:
+                # Substituting the file's own labels for a failed batch mixed two
+                # levels of theory inside one replay set and said so only in a log
+                # line, while the count below went on reporting every configuration
+                # as relabelled. A partly relabelled set is not a usable one -- the
+                # point of replay is to control which labels the head sees -- and
+                # the caller had no way to find out, so this raises instead.
+                raise RuntimeError(
+                    f"Pseudolabelling failed on batch {i // batch_size + 1} of "
+                    f"{(len(configs) + batch_size - 1) // batch_size} "
+                    f"(configurations {i}-{i + len(batch_configs) - 1}). Returning "
+                    f"the file's labels for that batch would mix them with the "
+                    f"generated ones, so the set is not relabelled at all."
+                ) from exc
+    finally:
+        # Restored in a `finally` because the loop can now leave early: the
+        # raise below is a non-local exit past this point, and the model
+        # belongs to the caller. Skipping it handed back a model with every
+        # parameter's `requires_grad` still cleared.
+        for param, requires_grad in original_requires_grad.items():
+            param.requires_grad = requires_grad
 
     logging.info(
         f"Generated pseudolabels for all {len(updated_configs)} configurations"
@@ -442,6 +449,9 @@ def apply_pseudolabels_to_pt_head_configs(
             logging.warning("No atomic number table available for pseudolabeling")
             return False
 
+        updated_train_configs = None
+        updated_valid_configs = None
+
         # Process training configurations
         if (
             hasattr(pt_head_config.collections, "train")
@@ -458,12 +468,6 @@ def apply_pseudolabels_to_pt_head_configs(
                 device=device,
                 batch_size=batch_size,
                 force_stress=force_stress,
-            )
-
-            # Replace the original configurations with updated ones
-            pt_head_config.collections.train = updated_train_configs
-            logging.info(
-                f"Successfully applied pseudolabels to {len(updated_train_configs)} training configurations"
             )
 
         # Process validation configurations if they exist
@@ -484,7 +488,17 @@ def apply_pseudolabels_to_pt_head_configs(
                 force_stress=force_stress,
             )
 
-            # Replace the original configurations with updated ones
+        # Committed only once both splits are relabelled. Assigning train as soon
+        # as it succeeded meant a failure on valid left train on foundation labels
+        # and valid on the file's, while the caller was told nothing had changed --
+        # the same mixing of label sources this refuses inside a single split,
+        # moved up one level.
+        if updated_train_configs is not None:
+            pt_head_config.collections.train = updated_train_configs
+            logging.info(
+                f"Successfully applied pseudolabels to {len(updated_train_configs)} training configurations"
+            )
+        if updated_valid_configs is not None:
             pt_head_config.collections.valid = updated_valid_configs
             logging.info(
                 f"Successfully applied pseudolabels to {len(updated_valid_configs)} validation configurations"

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -225,6 +225,24 @@ def assemble_replay_data(
         ) from exc
 
 
+def pseudolabel_weight(config: Configuration, name: str) -> float:
+    """The loss weight a freshly generated label should carry.
+
+    A pseudolabel is a label, so leaving the weight at whatever the file had
+    makes the work pointless exactly when it is most needed: an unlabelled
+    replay set arrives with every property weight at zero, and a head whose
+    weights are all zero contributes nothing to the gradient while reporting a
+    loss of precisely zero and no error metrics at all. That reads as a replay
+    head doing its job perfectly.
+
+    A weight the user set deliberately is kept, which is why this is a floor
+    rather than an assignment. `stress` was already handled this way; the other
+    properties were not.
+    """
+    existing = config.property_weights.get(name, 0.0)
+    return existing if existing > 0.0 else 1.0
+
+
 def generate_pseudolabels_for_configs(
     model: torch.nn.Module,
     configs: List[Configuration],
@@ -305,6 +323,9 @@ def generate_pseudolabels_for_configs(
                     config_copy.properties["energy"] = (
                         out["energy"][j].detach().cpu().item()
                     )
+                    config_copy.property_weights["energy"] = pseudolabel_weight(
+                        config, "energy"
+                    )
                 if "forces" in out and out["forces"] is not None:
                     # Forces are per atom
                     node_start = batch.ptr[j].item()
@@ -313,21 +334,30 @@ def generate_pseudolabels_for_configs(
                     config_copy.properties["forces"] = (
                         out["forces"][node_start:node_end].detach().cpu().numpy()
                     )
+                    config_copy.property_weights["forces"] = pseudolabel_weight(
+                        config, "forces"
+                    )
                 if "stress" in out and out["stress"] is not None:
                     if had_stress or force_stress:
                         config_copy.properties["stress"] = (
                             out["stress"][j].detach().cpu().numpy()
                         )
-                        config_copy.property_weights["stress"] = (
-                            original_stress_weight if had_stress else 1.0
+                        config_copy.property_weights["stress"] = pseudolabel_weight(
+                            config, "stress"
                         )
                 if "virials" in out and out["virials"] is not None:
                     config_copy.properties["virials"] = (
                         out["virials"][j].detach().cpu().numpy()
                     )
+                    config_copy.property_weights["virials"] = pseudolabel_weight(
+                        config, "virials"
+                    )
                 if "dipole" in out and out["dipole"] is not None:
                     config_copy.properties["dipole"] = (
                         out["dipole"][j].detach().cpu().numpy()
+                    )
+                    config_copy.property_weights["dipole"] = pseudolabel_weight(
+                        config, "dipole"
                     )
                 if "charges" in out and out["charges"] is not None:
                     # Charges are per atom
@@ -337,12 +367,15 @@ def generate_pseudolabels_for_configs(
                     config_copy.properties["charges"] = (
                         out["charges"][node_start:node_end].detach().cpu().numpy()
                     )
+                    config_copy.property_weights["charges"] = pseudolabel_weight(
+                        config, "charges"
+                    )
 
                 updated_configs.append(config_copy)
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as exc:
             logging.error(
-                f"Error generating pseudolabels for batch {i//batch_size + 1}: {str(e)}"
+                f"Error generating pseudolabels for batch {i//batch_size + 1}: {str(exc)}"
             )
             # On error, return the original configs for this batch
             updated_configs.extend([deepcopy(config) for config in batch_configs])

--- a/mace/tools/multihead_tools.py
+++ b/mace/tools/multihead_tools.py
@@ -374,17 +374,27 @@ def generate_pseudolabels_for_configs(
                 updated_configs.append(config_copy)
 
         except Exception as exc:
-            logging.error(
-                f"Error generating pseudolabels for batch {i//batch_size + 1}: {str(exc)}"
-            )
-            # On error, return the original configs for this batch
-            updated_configs.extend([deepcopy(config) for config in batch_configs])
+            # Substituting the file's own labels for a failed batch mixed two
+            # levels of theory inside one replay set and said so only in a log
+            # line, while the count below went on reporting every configuration
+            # as relabelled. A partly relabelled set is not a usable one -- the
+            # point of replay is to control which labels the head sees -- and
+            # the caller had no way to find out, so this raises instead.
+            raise RuntimeError(
+                f"Pseudolabelling failed on batch {i // batch_size + 1} of "
+                f"{(len(configs) + batch_size - 1) // batch_size} "
+                f"(configurations {i}-{i + len(batch_configs) - 1}). Returning "
+                f"the file's labels for that batch would mix them with the "
+                f"generated ones, so the set is not relabelled at all."
+            ) from exc
 
     # Restore original requires_grad settings
     for param, requires_grad in original_requires_grad.items():
         param.requires_grad = requires_grad
 
-    logging.info(f"Generated pseudolabels for {len(updated_configs)} configurations")
+    logging.info(
+        f"Generated pseudolabels for all {len(updated_configs)} configurations"
+    )
     return updated_configs
 
 

--- a/tests/unit/test_multihead_tools.py
+++ b/tests/unit/test_multihead_tools.py
@@ -5,16 +5,27 @@ dict_head_to_dataclass (head-dict overrides vs. args fallbacks + the
 missing-train_file error), prepare_default_head with the real arg parser,
 and both branches of prepare_pt_head (neither branch downloads anything).
 
+Also covers what generate_pseudolabels_for_configs does to a configuration's
+property *weights*, and what it does when a batch fails, both of which need only
+a tiny model built in process.
+
 Not covered here (they require network access or a trained foundation model):
-assemble_replay_data (downloads replay xyz), generate_pseudolabels_for_configs
-and apply_pseudolabels_to_pt_head_configs (need a model instance; exercised by
-the finetuning workflow tests).
+assemble_replay_data (downloads replay xyz) and
+apply_pseudolabels_to_pt_head_configs (exercised by the finetuning workflow
+tests).
 """
 
 import argparse
 import dataclasses
 
+import numpy as np
 import pytest
+import torch
+from ase import Atoms
+from e3nn import o3
+
+from mace import modules, tools
+from mace.data.utils import config_from_atoms
 
 from mace.data import KeySpecification
 from mace.data.utils import update_keyspec_from_kwargs
@@ -22,8 +33,10 @@ from mace.tools import build_default_arg_parser
 from mace.tools.multihead_tools import (
     HeadConfig,
     dict_head_to_dataclass,
+    generate_pseudolabels_for_configs,
     prepare_default_head,
     prepare_pt_head,
+    pseudolabel_weight,
 )
 
 
@@ -240,3 +253,109 @@ def test_prepare_pt_head_custom_replay_branch():
     assert pt_keyspec.info_keys["energy"] == "REF_energy"
     assert pt_keyspec.arrays_keys["forces"] == "REF_forces"
     assert pt_head["key_specification"] is pt_keyspec
+
+
+# ---------------------------------------------------------------------------
+# generate_pseudolabels_for_configs: weights, and what a failed batch does
+# ---------------------------------------------------------------------------
+
+TABLE = tools.AtomicNumberTable([1, 8])
+
+
+def _tiny_model():
+    return modules.ScaleShiftMACE(
+        r_max=4.0,
+        num_bessel=4,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e"),
+        MLP_irreps=o3.Irreps("4x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([-1.0, -5.0]),
+        avg_num_neighbors=4.0,
+        atomic_numbers=TABLE.zs,
+        correlation=2,
+        atomic_inter_scale=1.0,
+        atomic_inter_shift=0.0,
+    ).double()
+
+
+def _configs(count, labelled):
+    """`count` waters, with or without the labels a replay file would carry."""
+    rng = np.random.default_rng(0)
+    keyspec = KeySpecification.from_defaults()
+    keyspec.info_keys["energy"] = "REF_energy"
+    keyspec.arrays_keys["forces"] = "REF_forces"
+    out = []
+    for index in range(count):
+        atoms = Atoms(
+            "H2O",
+            positions=[[0, 0, 0], [0.95, 0, 0], [-0.24, 0.93, 0]],
+            cell=[8, 8, 8],
+            pbc=True,
+        )
+        atoms.positions += rng.normal(0, 0.04, (3, 3))
+        if labelled:
+            atoms.info["REF_energy"] = float(-20 + 0.1 * index)
+            atoms.arrays["REF_forces"] = rng.normal(0, 0.1, (3, 3))
+        out.append(config_from_atoms(atoms, key_specification=keyspec))
+    return out
+
+
+def _generate(configs, model=None, batch_size=4):
+    """The graph is built from the process default dtype, so scope it: a float64
+    model against a float32 graph fails every batch."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        return generate_pseudolabels_for_configs(
+            model=model if model is not None else _tiny_model(),
+            configs=configs,
+            z_table=TABLE,
+            r_max=4.0,
+            device=torch.device("cpu"),
+            batch_size=batch_size,
+        )
+    finally:
+        torch.set_default_dtype(previous)
+
+
+def test_pseudolabel_weight_is_a_floor_not_an_assignment():
+    config = _configs(1, labelled=True)[0]
+    config.property_weights["energy"] = 0.25
+    config.property_weights["forces"] = 0.0
+
+    assert pseudolabel_weight(config, "energy") == 0.25
+    assert pseudolabel_weight(config, "forces") == 1.0
+    assert pseudolabel_weight(config, "never_set") == 1.0
+
+
+def test_labels_generated_for_an_unlabelled_set_carry_a_usable_weight():
+    """The defect this closes: an unlabelled replay file arrives with every
+    weight at zero, so the head trained on nothing and reported a loss of
+    exactly zero with no error metrics -- indistinguishable from a perfect fit.
+    """
+    out = _generate(_configs(8, labelled=False))
+
+    for config in out:
+        assert config.properties["energy"] is not None
+        assert config.property_weights["energy"] > 0.0
+        assert config.property_weights["forces"] > 0.0
+
+
+def test_a_deliberate_weight_survives_pseudolabelling():
+    configs = _configs(8, labelled=True)
+    for config in configs:
+        config.property_weights["energy"] = 0.25
+
+    out = _generate(configs)
+
+    assert all(config.property_weights["energy"] == 0.25 for config in out)

--- a/tests/unit/test_multihead_tools.py
+++ b/tests/unit/test_multihead_tools.py
@@ -32,6 +32,7 @@ from mace.data.utils import update_keyspec_from_kwargs
 from mace.tools import build_default_arg_parser
 from mace.tools.multihead_tools import (
     HeadConfig,
+    apply_pseudolabels_to_pt_head_configs,
     dict_head_to_dataclass,
     generate_pseudolabels_for_configs,
     prepare_default_head,
@@ -379,3 +380,74 @@ def test_a_failed_batch_refuses_rather_than_mixing_label_provenance():
 
     with pytest.raises(RuntimeError, match="batch 2 of 3"):
         _generate(_configs(12, labelled=True), model=model)
+
+
+def _flaky(model, fail_on_call):
+    """Make `model.forward` raise on the nth call, as a transient failure would."""
+    calls = {"n": 0}
+    real_forward = model.forward
+
+    def forward(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == fail_on_call:
+            raise RuntimeError("simulated transient failure")
+        return real_forward(*args, **kwargs)
+
+    model.forward = forward
+    return model
+
+
+def test_a_failure_hands_the_model_back_with_its_gradients_intact():
+    """The model belongs to the caller. Pseudolabelling clears `requires_grad` on
+    every parameter and must put it back even when it leaves early, which it now
+    can -- the raise is a non-local exit past the restore."""
+    model = _tiny_model()
+    before = {name: p.requires_grad for name, p in model.named_parameters()}
+    assert any(before.values()), "nothing to restore, so the test proves nothing"
+
+    with pytest.raises(RuntimeError):
+        _generate(_configs(12, labelled=True), model=_flaky(model, fail_on_call=2))
+
+    after = {name: p.requires_grad for name, p in model.named_parameters()}
+    assert after == before
+
+
+def _pt_head_config(train, valid):
+    collections = dataclasses.make_dataclass("C", ["train", "valid"])(train, valid)
+    return HeadConfig(
+        head_name="pt_head",
+        train_file=["unused.xyz"],
+        key_specification=KeySpecification.from_defaults(),
+        collections=collections,
+    )
+
+
+def test_a_failure_on_valid_leaves_both_splits_on_their_original_labels():
+    """Train used to be replaced as soon as it succeeded, so a failure on valid
+    left train relabelled and valid not, while the caller was told nothing had
+    changed. Either both splits move or neither does."""
+    train = _configs(8, labelled=True)
+    valid = _configs(8, labelled=True)
+    config = _pt_head_config(train, valid)
+    train_before = [c.properties["energy"] for c in train]
+    valid_before = [c.properties["energy"] for c in valid]
+
+    model = _tiny_model()
+    # 8 configs at batch_size 4 is two batches for train, so the third call is
+    # the first batch of valid
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        ok = apply_pseudolabels_to_pt_head_configs(
+            foundation_model=_flaky(model, fail_on_call=3),
+            pt_head_config=config,
+            r_max=4.0,
+            device=torch.device("cpu"),
+            batch_size=4,
+        )
+    finally:
+        torch.set_default_dtype(previous)
+
+    assert ok is False
+    assert [c.properties["energy"] for c in config.collections.train] == train_before
+    assert [c.properties["energy"] for c in config.collections.valid] == valid_before

--- a/tests/unit/test_multihead_tools.py
+++ b/tests/unit/test_multihead_tools.py
@@ -359,3 +359,23 @@ def test_a_deliberate_weight_survives_pseudolabelling():
     out = _generate(configs)
 
     assert all(config.property_weights["energy"] == 0.25 for config in out)
+
+
+def test_a_failed_batch_refuses_rather_than_mixing_label_provenance():
+    """It used to substitute the file's own labels for the failed batch and
+    carry on, so one call could return a set with two levels of theory in it and
+    nothing to say which configurations had which."""
+    model = _tiny_model()
+    calls = {"n": 0}
+    real_forward = model.forward
+
+    def fail_on_second(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("simulated transient failure")
+        return real_forward(*args, **kwargs)
+
+    model.forward = fail_on_second
+
+    with pytest.raises(RuntimeError, match="batch 2 of 3"):
+        _generate(_configs(12, labelled=True), model=model)


### PR DESCRIPTION
Two problems in `generate_pseudolabels_for_configs`, both of which leave a run that completes and looks fine.

**A generated label carried no usable weight.** Pseudolabelling wrote the label and left the loss weight alone for every property except stress. That is harmless when the replay file already had labels, and it defeats the operation in the case it exists for: an unlabelled replay set arrives with every weight at zero, so the generated labels land on configurations that contribute nothing.

On a one epoch multihead run over an unlabelled replay set, the `pt_head` reported a loss of exactly 0.0 with no error metrics. That is the best number on the page, from a head doing none of the work. With the weights set it reports 1.8e-6 and real metrics, matching the same run against a labelled replay file to within a few percent.

The weight is a floor, not an assignment, so a value chosen deliberately survives. `stress` already worked this way; the rule is now shared rather than stated once and forgotten five times.

**A failed batch mixed two label sources.** The file's own labels were substituted for the failed batch and the loop carried on, so one call could return a replay set holding two levels of theory with nothing to say which was which. The summary line counted the list rather than the work: with a failure injected into batch 2 of 3, twelve configurations came back, four still on file labels, and the log said "Generated pseudolabels for 12 configurations".

Controlling which labels the replay head sees is the point of replay, so a partial result is not a weaker answer, it is unusable. It raises now, naming the batch and the configuration range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay fine-tuning label provenance and loss weighting; batch failures now abort instead of completing with mixed labels, which is safer but may break runs that previously limped through partial failures.
> 
> **Overview**
> Fixes two silent failures in **`generate_pseudolabels_for_configs`** when building replay **`pt_head`** data from a foundation model.
> 
> **Loss weights for generated labels.** Pseudolabelling now sets **`property_weights`** via a shared **`pseudolabel_weight`** helper for energy, forces, stress, virials, dipole, and charges. Zero or missing weights get a **floor of 1.0** so unlabelled replay configs actually contribute to training; **positive weights you set are unchanged** (stress used to behave this way alone).
> 
> **Batch failures.** If inference fails on a batch, the function **raises** with batch and config range instead of **silently reusing file labels** for that batch, which could mix two label sources in one replay set. The success log now states that **all** returned configs were relabelled.
> 
> Unit tests cover the weight floor, unlabelled sets, preserved deliberate weights, and the raise-on-partial-failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72bda89c8961595c678708fa5061b12bbded468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->