### PR TITLE
Fix eval_configs on ragged structure sets and on a dtype the checkpoint disagrees with

### DIFF
--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -5,6 +5,7 @@
 ###########################################################################################
 
 import argparse
+import logging
 from typing import Dict
 
 import ase.data
@@ -14,6 +15,7 @@ import torch
 from e3nn import o3
 
 from mace import data
+from mace.calculators.mace import get_model_dtype
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.data import KeySpecification, update_keyspec_from_kwargs
 from mace.modules.utils import extract_invariant
@@ -158,6 +160,24 @@ def run(args: argparse.Namespace) -> None:
 
     # Load model
     model = torch.load(f=args.model, map_location=args.device)
+
+    # Reconcile the requested dtype with the checkpoint's, as the ase
+    # calculator already does. Without this, `--default_dtype float32` against a
+    # float64 checkpoint reached the forward pass unchanged and died inside a
+    # scripted tensor product on "both inputs should have same dtype", naming
+    # neither the flag nor the checkpoint -- while the calculator, given the
+    # same two things, warned and converted. One request, two shipped inference
+    # routes, opposite outcomes.
+    model_dtype = get_model_dtype(model)
+    if model_dtype != args.default_dtype:
+        logging.warning(
+            f"Default dtype {args.default_dtype} does not match model dtype "
+            f"{model_dtype}, converting models to {args.default_dtype}."
+        )
+        if args.default_dtype == "float64":
+            model = model.double()
+        elif args.default_dtype == "float32":
+            model = model.float()
 
     if model.__class__.__name__ != "MACELES" and args.compute_bec:
         raise ValueError("BEC can only be computed with MACELES model. ")

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -158,6 +158,7 @@ def run(args: argparse.Namespace) -> None:
 
     # Load model
     model = torch.load(f=args.model, map_location=args.device)
+
     if model.__class__.__name__ != "MACELES" and args.compute_bec:
         raise ValueError("BEC can only be computed with MACELES model. ")
     if args.enable_cueq:
@@ -327,7 +328,12 @@ def run(args: argparse.Namespace) -> None:
             descriptors_list.extend(descriptors[:-1])  # drop last as its empty
 
         if args.return_node_energies:
-            node_energies_list.append(
+            # extend, not append: one entry per structure, as the descriptors
+            # above do. Appending the per-batch list of splits made the outer
+            # list per-batch, and the concatenation below then had to build a
+            # rectangular array out of it -- which only works while every
+            # structure has the same number of atoms.
+            node_energies_list.extend(
                 np.split(
                     torch_tools.to_numpy(output["node_energy"]),
                     indices_or_sections=batch.ptr[1:],
@@ -388,8 +394,8 @@ def run(args: argparse.Namespace) -> None:
         assert len(atoms_list) == len(descriptors_list)
 
     if args.return_node_energies:
-        node_energies = np.concatenate(node_energies_list, axis=0)
-        assert len(atoms_list) == node_energies.shape[0]
+        # no concatenation - one array per structure, of that structure's length
+        assert len(atoms_list) == len(node_energies_list)
 
     # Store data in atoms objects
     for i, (atoms, energy, forces) in enumerate(zip(atoms_list, energies, forces_list)):
@@ -443,7 +449,7 @@ def run(args: argparse.Namespace) -> None:
                 atoms.arrays[args.info_prefix + "descriptors"] = np.array(descriptors)
 
         if args.return_node_energies:
-            atoms.arrays[args.info_prefix + "node_energies"] = node_energies[i]
+            atoms.arrays[args.info_prefix + "node_energies"] = node_energies_list[i]
 
     # Write atoms to output path
     ase.io.write(args.output, images=atoms_list, format="extxyz")

--- a/tests/workflows/test_eval_configs_shapes_and_dtype.py
+++ b/tests/workflows/test_eval_configs_shapes_and_dtype.py
@@ -81,3 +81,25 @@ def test_node_energies_are_written_per_structure_whatever_its_size(
         node_energies = atoms.arrays["MACE_node_energies"]
         assert node_energies.shape == (len(atoms),)
         assert np.isclose(node_energies.sum(), atoms.info["MACE_energy"])
+
+
+def test_a_dtype_that_disagrees_with_the_checkpoint_is_converted_not_fatal(
+    tmp_path, trained_tiny_model_path, uniform_configs
+):
+    """And the converted result is the calculator's, to the bit. That agreement
+    is the contract: two shipped inference routes, one answer."""
+    from mace.calculators import MACECalculator
+
+    frames = _evaluate(
+        trained_tiny_model_path,
+        uniform_configs,
+        tmp_path / "f32.xyz",
+        default_dtype="float32",
+    )
+
+    atoms = read(uniform_configs, index=0)
+    atoms.calc = MACECalculator(
+        model_paths=str(trained_tiny_model_path), device="cpu", default_dtype="float32"
+    )
+
+    assert float(frames[0].info["MACE_energy"]) == float(atoms.get_potential_energy())

--- a/tests/workflows/test_eval_configs_shapes_and_dtype.py
+++ b/tests/workflows/test_eval_configs_shapes_and_dtype.py
@@ -1,0 +1,83 @@
+"""Two things `mace_eval_configs` could not do, both fixed by copying itself.
+
+`--return_node_energies` accumulated one entry per *batch* and then built a
+rectangular array out of it, so it worked only while every structure had the
+same number of atoms. `--descriptors`, four lines above in the same function,
+already accumulated one entry per structure precisely because its shapes vary.
+
+`--default_dtype` reached the forward pass without being reconciled against the
+checkpoint, so a mismatch died inside a scripted tensor product on "both inputs
+should have same dtype", naming neither the flag nor the model. The ase
+calculator, given the same request, warns and converts.
+
+Both tests therefore assert agreement with something already in the tree rather
+than a number of their own.
+"""
+
+import numpy as np
+import pytest
+from ase import Atoms
+from ase.io import read, write
+
+from tests.helpers import REPO_ROOT, run_mace_train
+
+EVAL_CONFIGS = REPO_ROOT / "mace" / "cli" / "eval_configs.py"
+
+
+def _water(count):
+    """`count` water molecules in one cell, so structures differ in atom count."""
+    positions, symbols = [], []
+    for index in range(count):
+        origin = np.array([4.0 * index, 0.0, 0.0])
+        positions += [origin, origin + [0.95, 0, 0], origin + [-0.24, 0.93, 0]]
+        symbols += ["O", "H", "H"]
+    return Atoms(
+        symbols, positions=np.array(positions), cell=[6 + 4 * count, 8, 8], pbc=True
+    )
+
+
+@pytest.fixture(name="mixed_configs")
+def fixture_mixed_configs(tmp_path):
+    path = tmp_path / "mixed.xyz"
+    write(path, [_water(1), _water(2), _water(1)])   # 3, 6, 3 atoms
+    return path
+
+
+@pytest.fixture(name="uniform_configs")
+def fixture_uniform_configs(tmp_path):
+    path = tmp_path / "uniform.xyz"
+    write(path, [_water(1), _water(1), _water(1)])   # 3, 3, 3 atoms
+    return path
+
+
+def _evaluate(model, configs, output, **flags):
+    params = {
+        "configs": str(configs),
+        "model": str(model),
+        "output": str(output),
+        "device": "cpu",
+    }
+    params.update(flags)
+    run_mace_train(params, script=EVAL_CONFIGS)
+    return read(output, index=":")
+
+
+@pytest.mark.parametrize("fixture_name", ["uniform_configs", "mixed_configs"])
+def test_node_energies_are_written_per_structure_whatever_its_size(
+    tmp_path, trained_tiny_model_path, fixture_name, request
+):
+    """Asserted by value, not by exit code: each structure's per-atom energies
+    have that structure's length and sum to the total reported for it."""
+    configs = request.getfixturevalue(fixture_name)
+    frames = _evaluate(
+        trained_tiny_model_path,
+        configs,
+        tmp_path / f"{fixture_name}_out.xyz",
+        default_dtype="float64",
+        return_node_energies=None,
+    )
+
+    for atoms in frames:
+        node_energies = atoms.arrays["MACE_node_energies"]
+        assert node_energies.shape == (len(atoms),)
+        assert np.isclose(node_energies.sum(), atoms.info["MACE_energy"])


### PR DESCRIPTION
Two things `mace_eval_configs` could not do. Both fixes copy something already in the tree rather than inventing behaviour.

**`--return_node_energies` failed on any set whose structures differ in size.**

```
ValueError: setting an array element with a sequence. The requested array has an
inhomogeneous shape after 1 dimensions.
```

The per-structure splits were accumulated with `append`, so the list held one entry per *batch*, and the `np.concatenate` after it had to build a rectangular array out of ragged data. That works only while every structure has the same atom count, which is why a uniform set passed and a mixed one did not.

`--return_descriptors` sits four lines above and already had this right, with the reason written down: "no concatentation - elements of descriptors_list have non-uniform shapes". Node energies now do the same, so the fix is one word plus deleting the concatenation.

Asserted by value, not exit code: on a 3, 6, 3 atom set every structure's array has that structure's length and sums to the total energy reported for it. The uniform case is bit-identical to before.

**`--default_dtype` was never reconciled with the checkpoint.** A float32 request against a float64 model died several frames inside a scripted tensor product on "both inputs should have same dtype", with nothing in the output naming the flag, the model, or a mismatch. The ase calculator, given the same two things, warns and converts and returns an energy.

The CLI now does what the calculator does, with the same warning. The test asserts the two agree to the bit, because that agreement is the contract: one request should not have two answers depending on which shipped route you pick.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2626b5572964e6f57e405c40b86086004595bd1b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->