### PR TITLE
Remove the L-BFGS reload that cannot run

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -905,7 +905,6 @@ def run(args) -> None:
     )
 
     start_epoch = 0
-    restart_lbfgs = False
     opt_start_epoch = None
     if args.restart_latest:
         try:
@@ -921,8 +920,14 @@ def run(args) -> None:
                     swa=False,
                     device=device,
                 )
-            except Exception: # pylint: disable=W0703
-                restart_lbfgs = True
+            except Exception:  # pylint: disable=W0703
+                # Both attempts raising used to set a flag for the reload below,
+                # so a run that asked to resume and could not started from
+                # scratch without saying so.
+                logging.warning(
+                    "--restart_latest was requested but no checkpoint could be "
+                    "loaded; training starts from scratch"
+                )
         if opt_start_epoch is not None:
             start_epoch = opt_start_epoch
 
@@ -936,14 +941,6 @@ def run(args) -> None:
                           history_size=200,
                           max_iter=20,
                           line_search_fn="strong_wolfe")
-        if restart_lbfgs:
-            opt_start_epoch = checkpoint_handler.load_latest(
-                state=tools.CheckpointState(model, optimizer, lr_scheduler),
-                swa=False,
-                device=device,
-            )
-            if opt_start_epoch is not None:
-                start_epoch = opt_start_epoch
 
     if args.wandb:
         setup_wandb(args)


### PR DESCRIPTION
`run_train` carries a second checkpoint load for L-BFGS resumes, placed after the optimiser swap and guarded by a flag set only when *both* earlier `load_latest` calls raise. They cannot both raise, so the block never runs.

The intended trigger is knowable: a checkpoint whose L-BFGS optimiser state the freshly built Adam cannot accept. That raises a `ValueError`, and the checkpoint loader catches it and downgrades it to a warning, so the load returns normally and the `except` never fires. Absence of a checkpoint cannot trigger it either, because `load_latest` returns `None` in that case rather than raising, so the second call is not even attempted.

Measured rather than argued: instrumenting both points and running three resume scenarios, including `--restart_latest --lbfgs` after a stage two run that left both a stage one and a stage two checkpoint, the flag was never set once.

Deleting it changes nothing a user sees. The same scenario before and after produces byte identical logs, resuming from the stage two checkpoint at the recorded epoch with a fresh L-BFGS optimiser.

One line is added rather than only removed. The flag was doing something incidental and harmful: without `--lbfgs`, both loads failing left a run that had asked to resume starting from scratch in silence, because the flag it set was only ever read inside the `--lbfgs` branch. That case now warns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0001a83e4a642fbfc0b4f906ba3616066339281a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->