### PR TITLE
Fix committee variance scaling under unit conversions

### DIFF
--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -768,19 +768,24 @@ class MACECalculator(Calculator):
                 self.results[results_key] = data * unit_conv
 
                 if self.num_models > 1 and results_key in results_store_ensemble:
-                    data = ret_tensors[results_key].cpu().numpy()
-                    data *= unit_conv
-                    self.results[results_key + "_comm"] = data
+                    ensemble = ret_tensors[results_key]
+                    # Scale a copy. `.numpy()` shares storage with a cpu tensor,
+                    # so multiplying in place rescaled `ensemble` itself, and the
+                    # variance below was then taken over already-converted values.
+                    self.results[results_key + "_comm"] = (
+                        ensemble.cpu().numpy() * unit_conv
+                    )
 
-                    data = torch.var(
-                        ret_tensors[results_key], dim=0, unbiased=False
-                    ).cpu()
+                    spread = torch.var(ensemble, dim=0, unbiased=False).cpu()
                     if ret_key in scalar_tensors:
-                        data = data.item()
+                        spread = spread.item()
                     else:
-                        data = data.numpy()
-                    data *= unit_conv
-                    self.results[results_key + "_var"] = data
+                        spread = spread.numpy()
+                    # A variance carries the square of whatever scales the values.
+                    # With the aliasing above it came out at unit_conv**3, so an
+                    # ensemble spread was wrong by that factor for any caller who
+                    # set a unit conversion -- silently, since the default is 1.
+                    self.results[results_key + "_var"] = spread * unit_conv**2
 
         # special cases
         if self.results.get("energy") is not None:
@@ -1420,7 +1425,8 @@ class MagneticMACECalculator(Calculator):
                     torch.var(ret_tensors["energies"], dim=0, unbiased=False)
                     .cpu()
                     .item()
-                    * self.energy_units_to_eV
+                    # squared: a variance carries the square of the conversion
+                    * self.energy_units_to_eV**2
                 )
                 self.results["forces_comm"] = (
                     ret_tensors["forces"].cpu().numpy()
@@ -1442,8 +1448,7 @@ class MagneticMACECalculator(Calculator):
                         torch.var(ret_tensors["stress"], dim=0, unbiased=False)
                         .cpu()
                         .numpy()
-                        * self.energy_units_to_eV
-                        / self.length_units_to_A**3
+                        * (self.energy_units_to_eV / self.length_units_to_A**3) ** 2
                     )
         if self.model_type in ["DipoleMACE", "EnergyDipoleMACE"]:
             self.results["dipole"] = (

--- a/tests/unit/test_calculator_units_and_spread.py
+++ b/tests/unit/test_calculator_units_and_spread.py
@@ -1,0 +1,197 @@
+"""The two calculator surfaces that scale or select, neither of them asserted.
+
+`energy_units_to_eV` and `length_units_to_A` multiply every energy, force and
+stress the calculator returns. Nothing exercised them, and a wrong factor is the
+quietest kind of wrong: the numbers stay plausible and a user comparing against
+a reference blames the model.
+
+The committee keys are the other half. `energy_comm` and `energy_var` are what an
+active-learning loop reads to decide which structures to label next, and only the
+energy mean and variance were ever asserted -- at the default conversion of 1.0,
+where a factor and its square are indistinguishable. They are not:
+
+    var(c * X) == c**2 * var(X)
+
+which is what these tests pin, and what the calculator got wrong in two separate
+ways. `MACECalculator` scaled the ensemble array in place, and `.numpy()` shares
+storage with a cpu tensor, so the variance was then taken over already-converted
+values and scaled again -- `unit_conv**3`. `MagneticMACECalculator` had the
+exponent alone. Both were invisible while the factors stayed at 1.
+"""
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from ase import Atoms
+from e3nn import o3
+
+from mace import modules
+from mace.calculators import MACECalculator
+from mace.tools import AtomicNumberTable
+
+TABLE = AtomicNumberTable([1, 8])
+
+#: not a round number, so a factor and its square cannot coincide, and neither
+#: can a factor and its reciprocal
+ENERGY_FACTOR = 2.5
+LENGTH_FACTOR = 1.25
+
+
+def _tiny_model(seed):
+    torch.manual_seed(seed)
+    return modules.ScaleShiftMACE(
+        r_max=4.0,
+        num_bessel=4,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e"),
+        MLP_irreps=o3.Irreps("4x0e"),
+        gate=F.silu,
+        atomic_energies=np.array([-1.0, -5.0]),
+        avg_num_neighbors=4.0,
+        atomic_numbers=TABLE.zs,
+        correlation=2,
+        atomic_inter_scale=1.0,
+        atomic_inter_shift=0.0,
+    ).double()
+
+
+@pytest.fixture(name="water")
+def fixture_water():
+    atoms = Atoms(
+        "H2O",
+        positions=[[0, 0, 0], [0.95, 0, 0], [-0.24, 0.93, 0]],
+        cell=[8, 8, 8],
+        pbc=True,
+    )
+    return atoms
+
+
+def _results(water, models, **kwargs):
+    """Evaluate in a float64 scope, since the graph reads the default dtype."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        atoms = water.copy()
+        atoms.calc = MACECalculator(
+            models=models, device="cpu", default_dtype="float64", **kwargs
+        )
+        atoms.get_potential_energy()
+        return dict(atoms.calc.results)
+    finally:
+        torch.set_default_dtype(previous)
+
+
+# ---------------------------------------------------------------------------
+# the unit conversions
+# ---------------------------------------------------------------------------
+
+
+def test_the_energy_conversion_scales_the_energy_and_the_forces(water):
+    """`energy_units_to_eV` is linear in the energy and in the force, since a
+    force is an energy over a length and only the energy is being converted."""
+    plain = _results(water, [_tiny_model(1)])
+    scaled = _results(water, [_tiny_model(1)], energy_units_to_eV=ENERGY_FACTOR)
+
+    assert scaled["energy"] == pytest.approx(plain["energy"] * ENERGY_FACTOR)
+    assert scaled["forces"] == pytest.approx(plain["forces"] * ENERGY_FACTOR)
+
+
+def test_the_length_conversion_divides_the_forces_and_cubes_for_the_stress(water):
+    """A force is an energy per length and a stress an energy per volume, so the
+    length factor enters once and three times respectively -- and inversely."""
+    plain = _results(water, [_tiny_model(1)])
+    scaled = _results(water, [_tiny_model(1)], length_units_to_A=LENGTH_FACTOR)
+
+    assert scaled["energy"] == pytest.approx(plain["energy"])
+    assert scaled["forces"] == pytest.approx(plain["forces"] / LENGTH_FACTOR)
+    assert scaled["stress"] == pytest.approx(plain["stress"] / LENGTH_FACTOR**3)
+
+
+def test_the_default_conversions_change_nothing(water):
+    """The identity case, so a test above cannot pass by the factors being
+    ignored altogether."""
+    plain = _results(water, [_tiny_model(1)])
+    explicit = _results(
+        water, [_tiny_model(1)], energy_units_to_eV=1.0, length_units_to_A=1.0
+    )
+
+    assert explicit["energy"] == pytest.approx(plain["energy"])
+    assert explicit["forces"] == pytest.approx(plain["forces"])
+
+
+# ---------------------------------------------------------------------------
+# the committee spread
+# ---------------------------------------------------------------------------
+
+
+def test_a_committee_reports_the_spread_of_the_members_it_averaged(water):
+    """The mean is the energy, and the variance is the variance of the members
+    the mean came from. Asserted for the arrays as well as the scalar: only the
+    energy pair was covered before."""
+    results = _results(water, [_tiny_model(1), _tiny_model(2)])
+
+    assert results["energy"] == pytest.approx(np.mean(results["energy_comm"]))
+    assert results["energy_var"] == pytest.approx(np.var(results["energy_comm"]))
+    assert results["forces"] == pytest.approx(np.mean(results["forces_comm"], axis=0))
+    assert results["forces_var"] == pytest.approx(
+        np.var(results["forces_comm"], axis=0)
+    )
+
+
+def test_the_spread_stays_the_spread_under_a_unit_conversion(water):
+    """The bug this closes. A variance carries the square of whatever scales the
+    values, and the calculator applied the factor once -- to data it had already
+    converted in place, reaching `unit_conv**3` for the energy.
+
+    Stated as an internal consistency rather than against a remembered number:
+    whatever the conversion, the reported variance is the variance of the
+    reported members.
+    """
+    scaled = _results(
+        water,
+        [_tiny_model(1), _tiny_model(2)],
+        energy_units_to_eV=ENERGY_FACTOR,
+    )
+
+    assert scaled["energy_var"] == pytest.approx(np.var(scaled["energy_comm"]))
+    assert scaled["forces_var"] == pytest.approx(
+        np.var(scaled["forces_comm"], axis=0)
+    )
+
+
+def test_the_variance_scales_as_the_square_and_the_members_linearly(water):
+    """The same claim from the outside, which is what a caller sees: converting
+    the units multiplies the members by the factor and the variance by its
+    square."""
+    plain = _results(water, [_tiny_model(1), _tiny_model(2)])
+    scaled = _results(
+        water,
+        [_tiny_model(1), _tiny_model(2)],
+        energy_units_to_eV=ENERGY_FACTOR,
+    )
+
+    assert scaled["energy_comm"] == pytest.approx(
+        plain["energy_comm"] * ENERGY_FACTOR
+    )
+    assert scaled["energy_var"] == pytest.approx(
+        plain["energy_var"] * ENERGY_FACTOR**2
+    )
+
+
+def test_a_single_model_reports_no_spread_at_all(water):
+    """The keys are a committee feature, so one model must not invent them."""
+    results = _results(water, [_tiny_model(1)])
+
+    assert "energy_comm" not in results
+    assert "energy_var" not in results
+    assert "forces_var" not in results


### PR DESCRIPTION
`energy_units_to_eV` and `length_units_to_A` multiply every energy, force and stress the calculator returns, and nothing exercised them. Closing that gap turned up a bug in the surface beside it.

A variance carries the square of whatever scales the values, `var(c * X) == c**2 * var(X)`. `MACECalculator` applied the factor once, and to data it had already converted: the ensemble array is scaled in place, `.numpy()` shares storage with a cpu tensor, so the variance was then taken over converted values and multiplied again. On a two member committee with a factor of 2, `energy_var` came out 8x rather than 4x, which is twice the variance of the `energy_comm` array it describes. `MagneticMACECalculator` has the exponent half of the same mistake, without the aliasing.

None of it shows at the default factor of 1.0, where a number, its square and its cube agree. That is why the existing committee test could assert `energy_var == var(energy_comm)` and pass throughout. `energy_var` is what an active learning loop reads to choose what to label next, so the spread was wrong by a constant while selecting badly and saying nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 90795e307dd414ec67db1422907c3312b7beb62f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->