### PR TITLE
Add backend parity goldens for the cueq and oeq kernels

### DIFF
--- a/.github/workflows/ci-extensions.yaml
+++ b/.github/workflows/ci-extensions.yaml
@@ -77,6 +77,11 @@ jobs:
               - *shared
               - 'mace/cli/convert_*.py'
               - 'tests/backends/**'
+              # The backend goldens live with the other goldens, not in
+              # tests/backends: they are cueq/oeq tests that happen to assert
+              # against a committed reference. Without this line a change to
+              # them is reviewed by no job that has cuequivariance installed.
+              - 'tests/golden/**'
 
   polar:
     needs: changes

--- a/tests/golden/backend_kernel_audit.py
+++ b/tests/golden/backend_kernel_audit.py
@@ -1,0 +1,363 @@
+"""Did the vendor kernel actually run?
+
+A backend golden compares numbers, and numbers alone cannot tell an
+accelerated kernel from the plain e3nn path that produced the reference in
+the first place -- the two are *supposed* to agree. So a value-only assertion
+is green in exactly the case the golden exists to catch: the conversion
+quietly produced something that is not accelerated at all. Two ways that
+happens here, both silent, both observed rather than imagined:
+
+* **cuEquivariance downgrades and only warns.** ``cuet.SegmentedPolynomial``
+  falls back to ``SegmentedPolynomialNaive`` when ``cuequivariance_ops_torch``
+  cannot be imported (an ops wheel whose CUDA major does not match torch's, or
+  a version pin below the one that carries the fused kernels). It sets
+  ``.method`` to ``"naive"``, logs a warning, and returns a module that
+  computes the right answer with no vendor kernel behind it.
+  ``CueqConvFusionWrapper`` refuses that today, but the refusal lives in the
+  code under test: a golden that relies on it is trusting the thing it is
+  supposed to be checking.
+* **The converter was handed the wrong device.** ``convert_e3nn_cueq.run``
+  sets ``conv_fusion=(device == "cuda")``. Converting on ``"cpu"`` and moving
+  the model afterwards yields a cueq model whose conv path is the *unfused*
+  ``ChannelWiseTensorProduct`` -- still cueq, still correct, and not the kernel
+  anybody meant to pin. Nothing in the outputs says so.
+
+This module answers the structural question ("is the accelerated
+implementation the one in place?") and the dynamic one ("did it execute?"),
+and it is written so both can be exercised without a GPU: everything is read
+off ordinary attributes, so a stand-in module tree reproduces either failure
+on a laptop. See ``tests/golden/test_backend_parity_golden.py``.
+
+Nothing here imports ``cuequivariance`` or ``openequivariance``. It must be
+importable on a host that has neither, because the test that proves the audit
+*rejects* an unaccelerated model is exactly the test that runs there.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Sequence
+
+CUEQ = "cueq"
+OEQ = "oeq"
+BACKENDS = (CUEQ, OEQ)
+
+#: Root packages a backend's modules must come from. cuEquivariance splits
+#: itself over two distributions (``cuequivariance`` for the descriptors,
+#: ``cuequivariance_torch`` for the modules), hence the prefix match.
+_PACKAGE_PREFIX = {CUEQ: "cuequivariance", OEQ: "openequivariance"}
+
+#: The method ``cuet.SegmentedPolynomial`` reports when the fused uniform_1d
+#: kernels are in use. Any other value means the fallback -- see the module
+#: docstring. This is the same attribute ``mace/modules/wrapper_ops.py`` reads
+#: to build its own guard, so the two cannot disagree about where to look.
+_CUEQ_FUSED_METHOD = "uniform_1d"
+
+
+@dataclass(frozen=True)
+class KernelSite:
+    """One place in the model where a vendor kernel is supposed to be.
+
+    ``module`` is the object whose ``__call__`` has to fire, which is not
+    always the object holding the implementation: MACE wraps the vendor's
+    module to adapt its calling convention, and the wrapper is what the
+    interaction block invokes.
+    """
+
+    path: str
+    role: str
+    module: Any
+    implementation: str
+    complaints: tuple = ()
+
+    @property
+    def healthy(self) -> bool:
+        return not self.complaints
+
+
+@dataclass
+class _SiteDraft:
+    path: str
+    role: str
+    module: Any
+    implementation: str = "<none>"
+    complaints: List[str] = field(default_factory=list)
+
+    def freeze(self) -> KernelSite:
+        return KernelSite(
+            path=self.path,
+            role=self.role,
+            module=self.module,
+            implementation=self.implementation,
+            complaints=tuple(self.complaints),
+        )
+
+
+def qualname(obj: Any) -> str:
+    """``module.QualName`` of an object's class, for messages and records."""
+    cls = type(obj)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _from_package(obj: Any, prefix: str) -> bool:
+    return type(obj).__module__.split(".")[0].startswith(prefix)
+
+
+def _cueq_conv_site(index: int, interaction: Any) -> _SiteDraft:
+    # Imported here rather than at module scope only to keep the import graph
+    # of this file to the standard library plus MACE's own wrapper types.
+    from mace.modules.wrapper_ops import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        CueqConvFusionWrapper,
+    )
+
+    conv = interaction.conv_tp
+    draft = _SiteDraft(
+        path=f"interactions.{index}.conv_tp",
+        role="channelwise tensor product (fused conv)",
+        module=conv,
+        implementation=qualname(conv),
+    )
+    if not hasattr(interaction, "conv_fusion"):
+        draft.complaints.append(
+            "the interaction block carries no `conv_fusion` attribute, so its "
+            "forward takes the unfused branch (blocks.py checks "
+            "`hasattr(self, 'conv_fusion')`). convert_e3nn_cueq sets "
+            "conv_fusion=(device == 'cuda'): converting on 'cpu' and moving "
+            "the model afterwards lands exactly here"
+        )
+    if not isinstance(conv, CueqConvFusionWrapper):
+        draft.complaints.append(
+            f"conv_tp is {qualname(conv)}, not the fused CueqConvFusionWrapper"
+            + (
+                ""
+                if _from_package(conv, _PACKAGE_PREFIX[CUEQ])
+                else " -- and it is not a cuEquivariance module at all, so this "
+                "model was never converted (or the conversion silently fell "
+                "back to e3nn)"
+            )
+        )
+        return draft
+    inner = conv.conv_tp
+    draft.implementation = qualname(inner)
+    method = getattr(inner, "method", None)
+    if method != _CUEQ_FUSED_METHOD:
+        draft.complaints.append(
+            f"cuequivariance selected method={method!r} instead of "
+            f"{_CUEQ_FUSED_METHOD!r}: the fused kernels are not in use"
+        )
+    implementation = getattr(inner, "m", None)
+    if implementation is None:
+        draft.complaints.append(
+            "the SegmentedPolynomial exposes no `.m`, so which implementation "
+            "cuequivariance selected cannot be read; treat this as a failure "
+            "rather than a pass -- an audit that cannot see the kernel is not "
+            "an audit"
+        )
+    else:
+        name = qualname(implementation)
+        draft.implementation = name
+        if "naive" in name.lower():
+            draft.complaints.append(
+                f"the implementation is {name}: cuequivariance downgraded to "
+                "its naive path, which it does with a warning and no error "
+                "when cuequivariance_ops_torch cannot be imported"
+            )
+    return draft
+
+
+def _cueq_symmetric_site(index: int, product: Any) -> _SiteDraft:
+    contraction = product.symmetric_contractions
+    draft = _SiteDraft(
+        path=f"products.{index}.symmetric_contractions",
+        role="symmetric contraction",
+        module=contraction,
+        implementation=qualname(contraction),
+    )
+    if not _from_package(contraction, _PACKAGE_PREFIX[CUEQ]):
+        draft.complaints.append(
+            f"the symmetric contraction is {qualname(contraction)}, which is "
+            "MACE's own e3nn implementation and not cuEquivariance's"
+        )
+        return draft
+    # Only checked when the attribute exists: unlike the conv path above,
+    # nothing in MACE reads a `method` off this module, so its absence is a
+    # fact about a cuequivariance version rather than evidence of a fallback.
+    method = getattr(contraction, "method", None)
+    if isinstance(method, str) and "naive" in method.lower():
+        draft.complaints.append(
+            f"the symmetric contraction reports method={method!r}: the fused "
+            "kernels are not in use"
+        )
+    return draft
+
+
+def _oeq_conv_site(index: int, interaction: Any) -> _SiteDraft:
+    conv = interaction.conv_tp
+    draft = _SiteDraft(
+        path=f"interactions.{index}.conv_tp",
+        role="channelwise tensor product (fused conv)",
+        module=conv,
+        implementation=qualname(conv),
+    )
+    if not _from_package(conv, _PACKAGE_PREFIX[OEQ]):
+        draft.complaints.append(
+            f"conv_tp is {qualname(conv)}, not an OpenEquivariance module: "
+            "this model was never converted, or the conversion fell back to "
+            "e3nn because openequivariance was not importable (OEQConfig "
+            "silently sets enabled=False in that case)"
+        )
+        return draft
+    if not hasattr(interaction, "conv_fusion"):
+        draft.complaints.append(
+            "the interaction block carries no `conv_fusion` attribute, so its "
+            "forward takes the unfused branch"
+        )
+    if not hasattr(conv, "original_forward"):
+        draft.complaints.append(
+            "the conv_tp was not wrapped by with_oeq_conv_fusion, so MACE's "
+            "calling convention was never adapted to the fused kernel"
+        )
+    return draft
+
+
+def kernel_sites(model: Any, backend: str) -> List[KernelSite]:
+    """Every place ``backend`` is supposed to have put a vendor kernel.
+
+    Sites are returned whether they are healthy or not; the complaints ride
+    along, so a caller can report all of them at once instead of failing on
+    the first layer.
+    """
+    if backend not in BACKENDS:
+        raise ValueError(f"unknown backend {backend!r}; the backends are {BACKENDS}")
+    interactions = getattr(model, "interactions", None)
+    if interactions is None:
+        raise TypeError(
+            f"{qualname(model)} has no `interactions`; this audit reads the "
+            f"MACE module tree and was handed something else"
+        )
+    drafts: List[_SiteDraft] = []
+    for index, interaction in enumerate(interactions):
+        if backend == CUEQ:
+            drafts.append(_cueq_conv_site(index, interaction))
+        else:
+            drafts.append(_oeq_conv_site(index, interaction))
+    if backend == CUEQ:
+        # The symmetric contraction is cuEquivariance's only under cueq: the
+        # oeq converter leaves it on MACE's own implementation (see
+        # SymmetricContractionWrapper, which takes an oeq_config and ignores
+        # it), so demanding a vendor module there would fail every oeq run.
+        for index, product in enumerate(getattr(model, "products", ()) or ()):
+            drafts.append(_cueq_symmetric_site(index, product))
+    for draft in drafts:
+        if not hasattr(draft.module, "register_forward_hook"):
+            draft.complaints.append(
+                f"{qualname(draft.module)} is not an nn.Module, so whether it "
+                f"ran cannot be observed"
+            )
+    return [draft.freeze() for draft in drafts]
+
+
+def environment_report(backend: str) -> str:
+    """What the host has, in the words a failure needs to be actionable.
+
+    Appended to every failure message rather than asserted on its own: the
+    module names below are cuEquivariance's business and could be renamed by
+    an upgrade, and a diagnostic that turns into a false failure is worse than
+    no diagnostic. The one thing it must never do is stay silent about the
+    root cause, which for the naive downgrade is an ops wheel that will not
+    import.
+    """
+    lines = []
+    try:
+        import torch  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+        lines.append(
+            f"torch {torch.__version__} (cuda={torch.version.cuda}, "
+            f"hip={torch.version.hip}, cuda.is_available="
+            f"{torch.cuda.is_available()})"
+        )
+    except Exception as error:  # pylint: disable=broad-except
+        lines.append(f"torch could not be inspected: {error!r}")
+    probes = {
+        CUEQ: ("cuequivariance", "cuequivariance_torch", "cuequivariance_ops_torch"),
+        OEQ: ("openequivariance",),
+    }[backend]
+    for name in probes:
+        try:
+            module = __import__(name)
+            lines.append(f"{name} {getattr(module, '__version__', '?')}")
+        except Exception as error:  # pylint: disable=broad-except
+            lines.append(f"{name} does NOT import: {error!r}")
+    return "\n    ".join(lines)
+
+
+def assert_vendor_kernels(model: Any, backend: str) -> List[KernelSite]:
+    """Assert the converted model is accelerated where it claims to be.
+
+    Returns the sites, so the caller can hand them straight to :func:`watch`
+    and then to :func:`assert_every_site_ran` -- the structural check and the
+    "it executed" check are two halves of one claim and share their subject.
+    """
+    sites = kernel_sites(model, backend)
+    if not sites:
+        raise AssertionError(
+            f"{qualname(model)} exposes no place a {backend} kernel could sit, "
+            f"so this golden would pin nothing about {backend}"
+        )
+    bad = [site for site in sites if not site.healthy]
+    if not bad:
+        return sites
+    detail = "\n".join(
+        f"  {site.path} ({site.role}) -> {site.implementation}\n"
+        + "\n".join(f"      - {complaint}" for complaint in site.complaints)
+        for site in bad
+    )
+    raise AssertionError(
+        f"the model does not run {backend} kernels at {len(bad)} of "
+        f"{len(sites)} site(s), so a value comparison here would pass without "
+        f"any vendor kernel having run:\n"
+        f"{detail}\n"
+        f"  environment:\n    {environment_report(backend)}"
+    )
+
+
+@contextlib.contextmanager
+def watch(sites: Sequence[KernelSite]) -> Iterator[Dict[str, int]]:
+    """Count how many times each site's module is called, inside the block."""
+    counts: Dict[str, int] = {site.path: 0 for site in sites}
+    handles = []
+
+    def make_hook(path: str):
+        def hook(module, args, output):  # pylint: disable=unused-argument
+            counts[path] += 1
+
+        return hook
+
+    for site in sites:
+        handles.append(site.module.register_forward_hook(make_hook(site.path)))
+    try:
+        yield counts
+    finally:
+        for handle in handles:
+            handle.remove()
+
+
+def assert_every_site_ran(
+    sites: Sequence[KernelSite], counts: Dict[str, int], backend: str
+) -> None:
+    """Assert every audited site was actually executed.
+
+    The structural check says the kernel is installed; this one says the
+    forward went through it. They are not the same claim -- an interaction
+    block that stopped calling its ``conv_tp`` (a refactor, a LAMMPS branch, a
+    compiled copy of the model that left the original untouched) would keep
+    the structure and lose the kernel.
+    """
+    silent = sorted(site.path for site in sites if counts.get(site.path, 0) == 0)
+    if silent:
+        raise AssertionError(
+            f"{len(silent)} {backend} site(s) were never called during the "
+            f"evaluation, so the numbers just compared did not come out of "
+            f"them: {silent}. Call counts: {dict(sorted(counts.items()))}"
+        )

--- a/tests/golden/docs/backends.md
+++ b/tests/golden/docs/backends.md
@@ -1,0 +1,69 @@
+# The accelerated-backend goldens
+
+No regeneration target: this family commits no reference of its own.
+
+`test_backend_parity_golden.py` converts the `ScaleShiftMACE` anchor (and
+MACE-MP-0 small, where a job allows downloads) to cueq and to oeq, evaluates
+it on an accelerator and asserts the committed CPU e3nn references at the
+`fp64_accelerated_backend` row. Nothing new is written: the whole point is
+that the accelerated numbers are held to the ones the plain CPU path
+produced.
+
+That creates a problem no value comparison can solve, and it is the reason
+`backend_kernel_audit.py` exists. **Matching the reference is not evidence
+that a vendor kernel ran** — the reference *came from* the unaccelerated
+path, so the unaccelerated path reproduces it perfectly. Two ways to end up
+there without noticing, both silent, both reproduced by CPU tests in that
+file:
+
+* `convert_e3nn_cueq.run` sets `conv_fusion=(device == "cuda")`, so
+  converting with the default `device="cpu"` and moving the model afterwards
+  yields a real cueq model whose conv path is the *unfused*
+  `ChannelWiseTensorProduct`. Measured on the anchor: it reproduces the
+  committed reference to **1.7e-16**, eleven orders of magnitude inside the
+  1e-5 row. No tolerance catches this.
+* `cuet.SegmentedPolynomial` falls back to `SegmentedPolynomialNaive` when
+  `cuequivariance_ops_torch` cannot be imported — an ops wheel whose CUDA
+  major does not match torch's, or a pin below the version that carries the
+  fused kernels. It warns, sets `.method = "naive"`, and returns a module
+  that computes the right answer with no kernel behind it.
+
+So every backend case audits the module tree (is the accelerated
+implementation in place, and is it the fused one?) and counts calls into it
+with forward hooks (did it execute?). MACE's own wrapper refuses the naive
+downgrade at construction time; the audit deliberately does not rely on that,
+because the guard is code under test.
+
+The audit is written so both halves can be exercised **without a GPU**, and
+they are: on a host with `[cueq]` but no ops wheel — which is what the
+`backends-cpu` CI job has — the degradation is real, not simulated. The
+failure it guards against is a *passing* test, which is precisely the failure
+that cannot be found by watching a GPU job stay green.
+
+Parity runs on the `ScaleShiftMACE` anchor because the plain-`MACE` one is not
+convertible; both converters are pinned to *stop* on the refusal payload
+rather than return a model.
+
+## Running
+
+The cases are marked so that each lands in the job that can honour it:
+
+| marks | where it runs |
+|---|---|
+| `gpu` + `cueq` | the Nvidia GPU job (`-m gpu`) |
+| `gpu` + `oeq` | both GPU jobs — AMD selects `gpu and not cueq` |
+| `gpu` + `cueq` + `network` | Nvidia only; it lists `network` in `MACE_REQUIRE_CAPS` |
+| `cueq` (no `gpu`) | the `backends-cpu` extension job (`cueq and not gpu`) |
+
+Under `MACE_REQUIRE_CAPS` a promised-but-missing capability fails instead of
+skipping, so a broken backend install cannot make a vendor job green. The
+`network` case is deliberately cueq-only: an oeq case carrying `network`
+would also be collected by the AMD job, which promises no network test.
+
+```bash
+python -m pytest tests/golden/test_backend_parity_golden.py -m "gpu and cueq"
+```
+
+oeq JIT-compiles its kernels, so the host needs a CUDA or HIP toolkit and a
+compiler new enough for `-std=c++20`; a stale default `c++` fails the build
+rather than the comparison.

--- a/tests/golden/test_backend_parity_golden.py
+++ b/tests/golden/test_backend_parity_golden.py
@@ -44,7 +44,6 @@ os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
 import pytest
 import torch
 
-from mace.tools import torch_tools
 from tests.golden import backend_kernel_audit as audit
 from tests.golden import harness
 
@@ -128,24 +127,24 @@ def _reference_for(name):
 def _convert(model, backend, device):
     """Convert through the shipped entry points, with the device declared.
 
-    The ``default_dtype`` scope is not decoration: ``run`` calls
-    ``torch.set_default_dtype`` from the source model's parameters and never
-    puts it back, and the accelerated modules read the process-wide default
-    at construction time. Leaving that to escape would silently re-dtype
-    every later test in the session.
+    No ``default_dtype`` scope around this. ``run`` sets the process default
+    from the source model's parameters, so the accelerated modules it builds
+    read the right dtype at construction, and it puts the caller's default back
+    on the way out, exception included (#1659). An outer scope here would be
+    overridden by that inner set and would only look like it was doing
+    something.
     """
-    with torch_tools.default_dtype("float64"):
-        if backend == audit.CUEQ:
-            from mace.cli.convert_e3nn_cueq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-                run as run_e3nn_to_cueq,
-            )
-
-            return run_e3nn_to_cueq(model, device=device)
-        from mace.cli.convert_e3nn_oeq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-            run as run_e3nn_to_oeq,
+    if backend == audit.CUEQ:
+        from mace.cli.convert_e3nn_cueq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            run as run_e3nn_to_cueq,
         )
 
-        return run_e3nn_to_oeq(model, device=device)
+        return run_e3nn_to_cueq(model, device=device)
+    from mace.cli.convert_e3nn_oeq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        run as run_e3nn_to_oeq,
+    )
+
+    return run_e3nn_to_oeq(model, device=device)
 
 
 def _calculator(model, device):

--- a/tests/golden/test_backend_parity_golden.py
+++ b/tests/golden/test_backend_parity_golden.py
@@ -1,0 +1,599 @@
+"""The accelerated backends reproduce the committed CPU e3nn references.
+
+`tests/backends/backend_parity.py` already checks that a freshly built model
+survives the round trip e3nn -> backend -> e3nn *in one process, on one
+machine, against a model built beside it*. That is a self-consistency check:
+if the e3nn side moved, both sides move together and the comparison still
+passes. What was missing is the cross-machine half -- the accelerated model
+evaluated on a GPU against numbers that were committed to this repository
+from a CPU e3nn run and cannot move without somebody rewriting a file.
+
+So the assertion path here is deliberately: committed checkpoint -> convert ->
+evaluate on the accelerator -> compare against the committed JSON. No e3nn
+model is built in this process, because a fresh one would re-derive the very
+oracle the comparison is supposed to be independent of.
+
+Three things about this file are not obvious and each was paid for once:
+
+* **The conversion must be told it is targeting a GPU.**
+  ``convert_e3nn_cueq.run`` sets ``conv_fusion=(device == "cuda")``, so
+  converting with the default ``device="cpu"`` and moving the model
+  afterwards produces a cueq model whose conv path is the *unfused*
+  ``ChannelWiseTensorProduct``. It still gives the right numbers, so a golden
+  taken that way passes for years while pinning a kernel nobody runs.
+* **Matching the reference is not evidence that a vendor kernel ran.** The
+  reference was produced by the plain e3nn path, so the plain e3nn path
+  reproduces it perfectly -- and cuEquivariance downgrades to
+  ``SegmentedPolynomialNaive`` with a warning and no error when its ops wheel
+  cannot be imported. Every case therefore audits the module tree and counts
+  the calls into it (``tests/golden/backend_kernel_audit.py``); the CPU tests
+  at the bottom of this file exercise both halves of that audit on a host
+  with no GPU, including against a real degraded cuEquivariance module.
+* **Parity runs on the ScaleShiftMACE anchor, not the plain-MACE one.** Both
+  converters route through ``extract_config_mace_model``, whose whitelist does
+  not include a plain ``MACE``; converting one tests the refusal, not the
+  kernels. The refusal is pinned as a contract instead.
+
+This file commits no new reference and regenerates none.
+"""
+# pylint: disable=wrong-import-position
+import os
+
+os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
+
+import pytest
+import torch
+
+from mace.tools import torch_tools
+from tests.golden import backend_kernel_audit as audit
+from tests.golden import harness
+
+ANCHOR_MODEL = harness.MODELS_DIR / "tiny_scaleshift.model"
+ANCHOR_REFERENCE = harness.REFERENCES_DIR / "tiny_scaleshift_e3nn_cpu_fp64.json"
+PLAIN_ANCHOR_MODEL = harness.MODELS_DIR / "tiny_mace.model"
+#: Committed by the foundation-model goldens, which are a separate change.
+#: Absent here means "not merged yet", not "not pinned": see _reference_for.
+MP_SMALL_REFERENCE = harness.REFERENCES_DIR / "mp_small_e3nn_cpu_fp64.json"
+
+#: Tests never encode a vendor. "cuda" is what a ROCm build answers to as
+#: well, and which vendor a job is on is decided by its marker expression.
+DEVICE = "cuda"
+
+
+# ---------------------------------------------------------------------------
+# The models under test and how each is reached
+# ---------------------------------------------------------------------------
+
+
+def _load_anchor(path=ANCHOR_MODEL, device="cpu"):
+    return torch.load(path, weights_only=False, map_location=device).to(torch.float64)
+
+
+def _load_mp_small(device):
+    """MACE-MP-0 small, as the foundation-model golden loads it.
+
+    Same loader and same dtype; only the device differs, and it has to --
+    the reference is the CPU evaluation this run is being compared against.
+    """
+    from mace.calculators.foundations_models import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        mace_mp,
+    )
+
+    calc = mace_mp(model="small", default_dtype="float64", device=device)
+    models = getattr(calc, "models", None)
+    if not models:
+        raise AssertionError(
+            f"mace_mp returned a {type(calc).__name__} with no `models`; the "
+            f"loader used to hand back a plain MACECalculator and this golden "
+            f"converts the module it holds"
+        )
+    return models[0].to(torch.float64)
+
+
+MODELS = {
+    "tiny_scaleshift": {
+        "load": lambda device: _load_anchor(ANCHOR_MODEL, device),
+        "reference": ANCHOR_REFERENCE,
+        "provided_by": "",
+    },
+    "mp_small": {
+        "load": _load_mp_small,
+        "reference": MP_SMALL_REFERENCE,
+        "provided_by": "the foundation-model goldens",
+    },
+}
+
+
+def _reference_for(name):
+    """The committed reference, or a skip that says who owns the missing file.
+
+    A capability that is promised and absent must fail rather than skip, which
+    is what ``MACE_REQUIRE_CAPS`` is for. This is not that case: the file
+    below is another change's artifact, so its absence is a merge order and
+    resolves itself, and the skip reason names the owner so it cannot quietly
+    become permanent. Everything else here fails.
+    """
+    spec = MODELS[name]
+    path = spec["reference"]
+    if path.is_file():
+        return harness.load_reference(path)
+    pytest.skip(
+        f"{path.name} is not in this tree; it is committed by "
+        f"{spec['provided_by']}, and this golden asserts against it rather "
+        f"than generating its own reference"
+    )
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _convert(model, backend, device):
+    """Convert through the shipped entry points, with the device declared.
+
+    The ``default_dtype`` scope is not decoration: ``run`` calls
+    ``torch.set_default_dtype`` from the source model's parameters and never
+    puts it back, and the accelerated modules read the process-wide default
+    at construction time. Leaving that to escape would silently re-dtype
+    every later test in the session.
+    """
+    with torch_tools.default_dtype("float64"):
+        if backend == audit.CUEQ:
+            from mace.cli.convert_e3nn_cueq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+                run as run_e3nn_to_cueq,
+            )
+
+            return run_e3nn_to_cueq(model, device=device)
+        from mace.cli.convert_e3nn_oeq import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            run as run_e3nn_to_oeq,
+        )
+
+        return run_e3nn_to_oeq(model, device=device)
+
+
+def _calculator(model, device):
+    from mace.calculators import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        MACECalculator,
+    )
+
+    return MACECalculator(models=[model], device=device, default_dtype="float64")
+
+
+# ---------------------------------------------------------------------------
+# The goldens
+#
+# mp_small is a cueq case only, and that is a decision rather than an
+# oversight: an oeq case carrying `network` would also be collected by the AMD
+# job (its expression is "gpu and not cueq"), which would put a download into
+# a job whose required-capability list says it has no network test to reach.
+# The anchor covers oeq on both vendors; MACE-MP-0 small adds a published,
+# many-element model on the one vendor that can run both backends.
+# ---------------------------------------------------------------------------
+
+CASES = [
+    pytest.param(
+        "tiny_scaleshift", audit.CUEQ, marks=pytest.mark.cueq, id="tiny_scaleshift-cueq"
+    ),
+    pytest.param(
+        "tiny_scaleshift", audit.OEQ, marks=pytest.mark.oeq, id="tiny_scaleshift-oeq"
+    ),
+    pytest.param(
+        "mp_small",
+        audit.CUEQ,
+        marks=[pytest.mark.cueq, pytest.mark.network],
+        id="mp_small-cueq",
+    ),
+]
+
+
+
+def _fixtures_for(model):
+    """The fixtures this model can evaluate at all.
+
+    Derived from the model rather than hardcoded, because the manifest is
+    shared with every other golden family: a bare ``load_fixtures()`` hands
+    whichever structures the next family commits to a model that has no
+    z-table entry for their elements, which fails as a KeyError rather than
+    as a tolerance miss. The tiny anchor is H/C/O; a published foundation
+    model covers far more, and both get exactly their own subset.
+    """
+    return harness.load_fixtures(
+        elements=[int(z) for z in model.atomic_numbers]
+    )
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("model_name,backend", CASES)
+def test_converted_model_reproduces_the_committed_cpu_reference(model_name, backend):
+    reference = _reference_for(model_name)
+
+    source = MODELS[model_name]["load"](DEVICE)
+    fixtures = _fixtures_for(source)
+    source_class = type(source).__name__
+    converted = _convert(source, backend, DEVICE)
+
+    assert type(converted).__name__ == source_class, (
+        "the conversion returned a different model class; the golden would be "
+        "comparing a different architecture against the reference"
+    )
+    calc = _calculator(converted, DEVICE)
+    running = calc.models[0]
+    assert running is converted, (
+        "the calculator did not keep the converted module, so the audit below "
+        "would be watching an object that never runs"
+    )
+    assert next(running.parameters()).device.type == "cuda", (
+        "the evaluated model is not on the accelerator"
+    )
+
+    sites = audit.assert_vendor_kernels(running, backend)
+    with audit.watch(sites) as counts:
+        snapshot = harness.snapshot_outputs(
+            calc,
+            fixtures,
+            dtype="float64",
+            device=DEVICE,
+            backend=backend,
+            metadata={"converted_from": source_class, "n_kernel_sites": len(sites)},
+        )
+    audit.assert_every_site_ran(sites, counts, backend)
+
+    harness.compare_to_reference(
+        snapshot, reference, row=harness.FP64_ACCELERATED_BACKEND.name
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "backend",
+    [
+        pytest.param(audit.CUEQ, marks=pytest.mark.cueq, id="cueq"),
+        pytest.param(audit.OEQ, marks=pytest.mark.oeq, id="oeq"),
+    ],
+)
+def test_the_calculators_own_backend_flag_reaches_the_same_kernels(backend):
+    """The route a user takes, held to the same standard as the converter.
+
+    ``MACECalculator(enable_cueq=True)`` does the conversion itself and passes
+    its own ``device`` through (mace/calculators/mace.py:359-369). That is the
+    shipped path, and it would be perfectly possible for the golden above to
+    pin fused kernels while the calculator flag quietly produced unfused ones.
+    """
+    from mace.calculators import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        MACECalculator,
+    )
+
+    flag = {audit.CUEQ: "enable_cueq", audit.OEQ: "enable_oeq"}[backend]
+    calc = MACECalculator(
+        models=[_load_anchor(ANCHOR_MODEL, DEVICE)],
+        device=DEVICE,
+        default_dtype="float64",
+        **{flag: True},
+    )
+    sites = audit.assert_vendor_kernels(calc.models[0], backend)
+    with audit.watch(sites) as counts:
+        harness.snapshot_outputs(
+            calc,
+            harness.load_fixtures(["water_cluster"]),
+            dtype="float64",
+            device=DEVICE,
+            backend=backend,
+        )
+    audit.assert_every_site_ran(sites, counts, backend)
+
+
+# ---------------------------------------------------------------------------
+# The audit, exercised without a GPU
+#
+# These are the tests that keep the oracle above honest, and they were written
+# to run on a laptop on purpose: the failure they guard against is a *passing*
+# test, so it can never be discovered by watching a GPU job stay green.
+# ---------------------------------------------------------------------------
+
+
+def test_a_value_comparison_alone_cannot_tell_an_unaccelerated_model_apart():
+    """Why every case above audits the module tree.
+
+    The plain e3nn anchor is the model the references were taken from, so it
+    reproduces them at the *accelerated* tolerance row with room to spare --
+    while running no vendor kernel whatsoever. Any backend golden that
+    asserted values only would be green on this model.
+    """
+    model = _load_anchor()
+    snapshot = harness.snapshot_outputs(
+        _calculator(model, "cpu"),
+        _fixtures_for(model),
+        dtype="float64",
+        device="cpu",
+        backend="e3nn",
+    )
+    harness.compare_to_reference(
+        snapshot,
+        harness.load_reference(ANCHOR_REFERENCE),
+        row=harness.FP64_ACCELERATED_BACKEND.name,
+    )
+
+    for backend in audit.BACKENDS:
+        with pytest.raises(AssertionError) as complaint:
+            audit.assert_vendor_kernels(model, backend)
+        message = str(complaint.value)
+        assert "interactions.0.conv_tp" in message
+        assert "e3nn" in message
+
+
+@pytest.mark.cueq
+def test_converting_for_the_cpu_leaves_cueq_unfused_and_the_audit_says_so():
+    """The first of the two silent failures, reproduced end to end.
+
+    ``convert_e3nn_cueq.run`` ties conv fusion to ``device == "cuda"``. This
+    is the same call the goldens make with the wrong device, and the model it
+    returns is a real cueq model -- ``ChannelWiseTensorProduct`` in the conv
+    slot, ``cuet.SymmetricContraction`` in the products -- which is exactly
+    why nothing else in the tree would notice. Measured here: it reproduces
+    the committed reference to 1.7e-16, eleven orders of magnitude inside the
+    1e-5 accelerated row, so there is no tightening of a tolerance that would
+    catch this. Only the structure says which kernel is in place.
+    """
+    converted = _convert(_load_anchor(), audit.CUEQ, "cpu")
+    conv = converted.interactions[0].conv_tp
+    assert audit.qualname(conv).startswith("cuequivariance"), (
+        f"expected a cuEquivariance module in the conv slot, got "
+        f"{audit.qualname(conv)}; this test is no longer reproducing the "
+        f"unfused-but-converted case it exists for"
+    )
+    assert not hasattr(converted.interactions[0], "conv_fusion")
+
+    snapshot = harness.snapshot_outputs(
+        _calculator(converted, "cpu"),
+        _fixtures_for(converted),
+        dtype="float64",
+        device="cpu",
+        backend="cueq",
+    )
+    harness.compare_to_reference(
+        snapshot,
+        harness.load_reference(ANCHOR_REFERENCE),
+        row=harness.FP64_ACCELERATED_BACKEND.name,
+    )
+
+    with pytest.raises(AssertionError) as complaint:
+        audit.assert_vendor_kernels(converted, audit.CUEQ)
+    message = str(complaint.value)
+    assert "conv_fusion" in message
+    assert "device == 'cuda'" in message
+
+
+@pytest.mark.cueq
+def test_the_audits_verdict_tracks_whether_the_fused_ops_are_installed():
+    """The second silent failure, against the real cuEquivariance object.
+
+    ``cuet.SegmentedPolynomial(..., method="uniform_1d")`` does not fail when
+    ``cuequivariance_ops_torch`` is missing: it warns, sets ``.method`` to
+    ``"naive"`` and hands back a working module. This test asks for the fused
+    kernels and then asserts the audit's verdict matches what the host can
+    actually provide -- rejection where the ops are absent (a plain
+    ``[cueq]`` install, which is what the CPU backend job has), acceptance
+    where they are present (a ``[cueq-cuda-*]`` install). Both directions
+    matter: an audit that always failed would be just as useless as one that
+    always passed.
+
+    MACE's own wrapper refuses the naive downgrade at construction time. This
+    goes around that guard deliberately -- the guard is code under test, and a
+    golden that depends on it is trusting the thing it is checking.
+    """
+    import cuequivariance as cue  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    import cuequivariance_torch as cuet  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    from mace.tools.cg import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        O3_e3nn,
+    )
+
+    polynomial = (
+        cue.descriptors.channelwise_tensor_product(
+            cue.Irreps(O3_e3nn, "16x0e + 16x1o"),
+            cue.Irreps(O3_e3nn, "0e + 1o + 2e"),
+            cue.Irreps(O3_e3nn, "16x0e + 16x1o"),
+        )
+        .flatten_coefficient_modes()
+        .squeeze_modes()
+        .polynomial
+    )
+    segmented = cuet.SegmentedPolynomial(
+        polynomial, math_dtype=torch.float64, method="uniform_1d"
+    )
+    fused_ops_available = getattr(segmented, "method", None) == "uniform_1d"
+
+    model = _StandInModel([_StandInInteraction(_unguarded_fusion_wrapper(segmented))])
+    if fused_ops_available:
+        sites = audit.assert_vendor_kernels(model, audit.CUEQ)
+        assert len(sites) == 1
+        assert "naive" not in sites[0].implementation.lower()
+        return
+    with pytest.raises(AssertionError) as complaint:
+        audit.assert_vendor_kernels(model, audit.CUEQ)
+    message = str(complaint.value)
+    assert "naive" in message
+    # The failure has to name the cause, not only the symptom: "method is
+    # naive" sends somebody reading cuequivariance's source, while the ops
+    # wheel that will not import is the thing to fix.
+    assert "cuequivariance_ops_torch" in message
+
+
+def test_the_audit_accepts_a_well_formed_oeq_conversion_and_only_that():
+    """A positive control for the branch no CPU host can reach for real.
+
+    OpenEquivariance JIT-compiles its kernels and does not install without a
+    toolkit, so nothing on a laptop -- or on any non-GPU CI job -- ever hands
+    the oeq branch a healthy model. Without this, a mistake in that branch
+    would first surface as a red vendor job, and the reading would be
+    ambiguous: broken audit or broken conversion? The stand-in carries exactly
+    the three things the audit reads, so it also fails if the audit starts
+    reading something else.
+    """
+    healthy = _StandInModel([_StandInInteraction(_StandInOeqConv(fused=True))])
+    sites = audit.assert_vendor_kernels(healthy, audit.OEQ)
+    assert [site.path for site in sites] == ["interactions.0.conv_tp"]
+
+    unwrapped = _StandInModel([_StandInInteraction(_StandInOeqConv(fused=False))])
+    with pytest.raises(AssertionError) as complaint:
+        audit.assert_vendor_kernels(unwrapped, audit.OEQ)
+    assert "with_oeq_conv_fusion" in str(complaint.value)
+
+    unfused_block = _StandInModel(
+        [_StandInInteraction(_StandInOeqConv(fused=True), fused=False)]
+    )
+    with pytest.raises(AssertionError) as complaint:
+        audit.assert_vendor_kernels(unfused_block, audit.OEQ)
+    assert "conv_fusion" in str(complaint.value)
+
+
+def test_the_audit_fails_a_site_that_is_installed_and_never_called():
+    """Structure is not execution, and the audit checks both separately."""
+    kernels = [_fake_fused_conv(), _fake_fused_conv()]
+    model = _StandInModel([_StandInInteraction(k) for k in kernels])
+    sites = audit.assert_vendor_kernels(model, audit.CUEQ)
+
+    with audit.watch(sites) as counts:
+        kernels[0](torch.zeros(1))
+    assert counts == {"interactions.0.conv_tp": 1, "interactions.1.conv_tp": 0}
+
+    with pytest.raises(AssertionError) as complaint:
+        audit.assert_every_site_ran(sites, counts, audit.CUEQ)
+    assert "interactions.1.conv_tp" in str(complaint.value)
+
+    with audit.watch(sites) as counts:
+        for kernel in kernels:
+            kernel(torch.zeros(1))
+    audit.assert_every_site_ran(sites, counts, audit.CUEQ)
+
+    # The hooks must not outlive the block, or one test's audit would count
+    # calls made by the next one.
+    kernels[0](torch.zeros(1))
+    assert counts == {"interactions.0.conv_tp": 1, "interactions.1.conv_tp": 1}
+
+
+def test_the_conversion_whitelist_refuses_the_plain_anchor_and_both_converters_stop():
+    """Why parity uses the ScaleShiftMACE anchor.
+
+    ``extract_config_mace_model`` returns an ``{"error": ...}`` payload for a
+    plain ``MACE`` rather than a config, and neither converter checks for it.
+    What matters for a golden is that the refusal is a *stop*: both converters
+    die on the malformed config instead of returning a model that would then
+    be compared against a reference. Pinned so the choice of anchor is a
+    stated contract rather than a workaround for a surprise.
+    """
+    from mace.tools.scripts_utils import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        extract_config_mace_model,
+    )
+
+    plain = _load_anchor(PLAIN_ANCHOR_MODEL)
+    refused = extract_config_mace_model(plain)
+    assert isinstance(refused, dict) and set(refused) == {"error"}
+
+    for backend in audit.BACKENDS:
+        with pytest.raises((TypeError, KeyError)):
+            _convert(plain, backend, "cpu")
+
+    accepted = extract_config_mace_model(_load_anchor())
+    assert "error" not in accepted
+
+
+def test_the_tolerance_row_is_the_shared_accelerated_one():
+    """No second table, and no local number.
+
+    Named explicitly because this file is the only consumer of the
+    accelerated row: if it ever stops importing it, nothing else fails.
+    """
+    row = harness.FP64_ACCELERATED_BACKEND
+    assert harness.TOLERANCES[row.name] is row
+    assert (row.atol, row.rtol) == (1e-5, 0.0)
+    assert row.atol > harness.FP64_CPU_REFERENCE.atol, (
+        "the accelerated row exists because the comparison crosses a kernel "
+        "and a device; if it is no looser than the CPU row, say so there"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stand-ins for the CPU tests above
+#
+# Small on purpose: they carry only what the audit reads, so a change to the
+# audit that stops reading something fails here rather than passing quietly.
+# ---------------------------------------------------------------------------
+
+
+class _FakeUniform1dKernel(torch.nn.Module):
+    """Stands in for the fused implementation object cuEquivariance selects."""
+
+
+class _FakeSegmentedPolynomial(torch.nn.Module):
+    """Stands in for ``cuet.SegmentedPolynomial`` with the fused method."""
+
+    def __init__(self):
+        super().__init__()
+        self.method = "uniform_1d"
+        self.m = _FakeUniform1dKernel()
+
+    def forward(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return None
+
+
+def _unguarded_fusion_wrapper(segmented):
+    """A ``CueqConvFusionWrapper`` built without its constructor's guard.
+
+    The guard is what MACE does about the naive downgrade today. Going around
+    it is the point: the audit has to hold on its own, so that removing or
+    weakening the guard shows up as a failing test rather than as a golden
+    that silently starts pinning the naive path.
+    """
+    from mace.modules.wrapper_ops import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+        CueqConvFusionWrapper,
+    )
+
+    class _Unguarded(CueqConvFusionWrapper):  # pylint: disable=too-few-public-methods
+        def __init__(self, conv_tp):  # pylint: disable=super-init-not-called
+            torch.nn.Module.__init__(self)
+            self.conv_tp = conv_tp
+
+        def forward(self, *args, **kwargs):
+            # The real wrapper's forward takes MACE's four conv arguments and
+            # rearranges them for cuEquivariance. Nothing here is testing that
+            # rearrangement, only that a call is observable, so this passes
+            # whatever it is given straight through.
+            return self.conv_tp(*args, **kwargs)
+
+    return _Unguarded(segmented)
+
+
+def _fake_fused_conv():
+    return _unguarded_fusion_wrapper(_FakeSegmentedPolynomial())
+
+
+class _StandInOeqConv(torch.nn.Module):
+    """Stands in for ``oeq.TensorProductConv`` after ``with_oeq_conv_fusion``.
+
+    ``__module__`` is rewritten below because the audit identifies a vendor
+    module by the package it comes from, which is the one property a fake
+    cannot have by accident.
+    """
+
+    def __init__(self, fused=True):
+        super().__init__()
+        if fused:
+            self.original_forward = self.forward
+
+    def forward(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return None
+
+
+_StandInOeqConv.__module__ = "openequivariance.implementations.convolution"
+
+
+class _StandInInteraction(torch.nn.Module):
+    def __init__(self, conv_tp, fused=True):
+        super().__init__()
+        self.conv_tp = conv_tp
+        if fused:
+            self.conv_fusion = True
+
+
+class _StandInModel(torch.nn.Module):
+    def __init__(self, interactions):
+        super().__init__()
+        self.interactions = torch.nn.ModuleList(interactions)
+        self.products = torch.nn.ModuleList([])


### PR DESCRIPTION
The backend suite only checks cueq and oeq against an e3nn model built beside them in the same process, which moves whenever the e3nn side moves. Nothing held the accelerated path to a number somebody would have to rewrite a file to change. This converts the ScaleShiftMACE anchor on the accelerator, and MACE-MP-0 small where a job may download, then asserts the committed CPU e3nn references at the shared accelerated tolerance row. No reference is added and none is regenerated.

The hard part is that matching those references proves nothing about kernels: they came from the unaccelerated path, so the unaccelerated path reproduces them exactly. There are two ways to get there silently and both are real. Converting with the default device leaves conv fusion off, because the converter ties it to `device == "cuda"`, and the resulting model is genuinely cuEquivariance, runs the unfused product, and reproduces the anchor to 1.7e-16 — eleven orders inside the row, so no tolerance can catch it. And cuEquivariance downgrades to its naive implementation with a warning and no error when the ops wheel will not import, which is the state of any plain `[cueq]` install. A value-only golden is green in both cases while no vendor kernel has run.

So every case audits the module tree for the accelerated implementation and counts the calls into it with forward hooks. The audit does not lean on the refusal MACE already has in its fusion wrapper, since that is code under test. Both failure modes are exercised on a host with no GPU: the unfused conversion end to end, and the naive downgrade as the real thing wherever `cuequivariance_ops_torch` is absent, which is what the CPU backend job has.

Markers keep the per-vendor selection intact. The network case is cueq-only, because an oeq one would be collected by the AMD job, whose required capabilities promise no network test it can reach. The extension workflow's backend filter learns `tests/golden`, or no job with cuequivariance installed would review a change to any of this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4e553bb2c0998e48ccb2cbe086cb09c841e92360. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->