### PR TITLE
Fix the dtype of the reference batch in the LAMMPS real tier

### DIFF
--- a/tests/integrations/lammps/_harness.py
+++ b/tests/integrations/lammps/_harness.py
@@ -45,7 +45,16 @@ def water_unit_cell() -> Atoms:
 
 
 def model_batch(model: torch.nn.Module, atoms: Atoms) -> dict:
-    """Standard AtomicData batch for `atoms` matching the model's metadata."""
+    """Standard AtomicData batch for `atoms` matching the model's metadata.
+
+    `AtomicData` builds its tensors at the process-wide default dtype, which is
+    float32 unless a test set it otherwise, while these models are float64. The
+    mismatch does not surface as a dtype complaint about the batch: it surfaces
+    deep inside the first scripted e3nn graph as `both inputs should have same
+    dtype`, naming nothing. So the batch follows the model, taking its dtype
+    from `r_max` exactly as `LAMMPS_MLIAP_MACE.__init__` does.
+    """
+    dtype = model.r_max.dtype
     z_table = AtomicNumberTable([int(z) for z in model.atomic_numbers])
     config = data.config_from_atoms(atoms)
     loader = torch_geometric.dataloader.DataLoader(
@@ -58,7 +67,13 @@ def model_batch(model: torch.nn.Module, atoms: Atoms) -> dict:
         shuffle=False,
         drop_last=False,
     )
-    return next(iter(loader)).to_dict()
+    batch = next(iter(loader)).to_dict()
+    return {
+        key: value.to(dtype)
+        if torch.is_tensor(value) and value.is_floating_point()
+        else value
+        for key, value in batch.items()
+    }
 
 
 def lammps_style_cluster(model: torch.nn.Module, n_repeat: int):


### PR DESCRIPTION
The nightly's `lammps-real` job fails in the python half of the test, not in LAMMPS.

`model_batch` builds the batch at the process default dtype (float32 under pytest) while the model is float64, so the forward fails inside e3nn with `both inputs should have same dtype`. That line never ran before #1644, because the test used to die earlier inside LAMMPS. This is why it shows up only now.

The batch now takes its dtype from the model, the same way `LAMMPS_MLIAP_MACE.__init__` reads it from `r_max`. `test_export.py` and `test_ghost_parity.py` handle the same problem by calling `set_default_dtype`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 54169a48d92dc1e5f863ac7b4a3273747d562d3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->