### PR TITLE
Restore the process default dtype after changing it

### DIFF
--- a/mace/calculators/lammps_mliap_mace.py
+++ b/mace/calculators/lammps_mliap_mace.py
@@ -65,17 +65,22 @@ class MACEEdgeForcesWrapper(torch.nn.Module):
         self.register_buffer("atomic_numbers", model.atomic_numbers)
         self.register_buffer("r_max", model.r_max)
         self.register_buffer("num_interactions", model.num_interactions)
+        # From the model, not the process default. These feed the forward beside
+        # the model's own tensors, and the export used to land on the right dtype
+        # only as a side effect: `--format mliap` converts to cueq first, and that
+        # converter set the default globally on its way through. Now that it
+        # restores it, a global would hand a float64 export float32 buffers, which
+        # dtype promotion turns into a wrong number under LAMMPS rather than an
+        # error here. `r_max` is where `LAMMPS_MLIAP_MACE` reads its dtype too, so
+        # the wrapper and the coupling cannot disagree.
+        dtype = model.r_max.dtype
         self.register_buffer(
             "total_charge",
-            kwargs.get(
-                "total_charge", torch.tensor([0.0], dtype=torch.get_default_dtype())
-            ),
+            kwargs.get("total_charge", torch.tensor([0.0], dtype=dtype)),
         )
         self.register_buffer(
             "total_spin",
-            kwargs.get(
-                "total_spin", torch.tensor([1.0], dtype=torch.get_default_dtype())
-            ),
+            kwargs.get("total_spin", torch.tensor([1.0], dtype=dtype)),
         )
 
         if not hasattr(model, "heads"):

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -10,6 +10,7 @@ from e3nn import o3
 from mace.tools.cg import O3_e3nn
 from mace.tools.cg_cueq_tools import symmetric_contraction_proj
 from mace.tools.scripts_utils import extract_config_mace_model
+from mace.tools.torch_tools import restores_default_dtype
 
 try:
     import cuequivariance as cue
@@ -228,6 +229,7 @@ def transfer_weights(
     target_model.load_state_dict(target_dict)
 
 
+@restores_default_dtype
 def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True):
 
     # Load CuEq model

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -10,6 +10,7 @@ from mace.modules.wrapper_ops import CuEquivarianceConfig
 from mace.tools.cg import O3_e3nn
 from mace.tools.cg_cueq_tools import symmetric_contraction_proj
 from mace.tools.scripts_utils import extract_config_mace_model
+from mace.tools.torch_tools import restores_default_dtype
 
 try:
     import cuequivariance as cue
@@ -212,6 +213,7 @@ def transfer_weights(
     target_model.load_state_dict(target_dict)
 
 
+@restores_default_dtype
 def run(
     input_model,
     output_model="_cueq.model",

--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -8,6 +8,7 @@ import torch
 
 from mace.modules.wrapper_ops import CuEquivarianceConfig, OEQConfig
 from mace.tools.scripts_utils import extract_config_mace_model
+from mace.tools.torch_tools import restores_default_dtype
 
 try:
     from mace.cli.convert_e3nn_cueq import transfer_symmetric_contractions
@@ -24,6 +25,7 @@ except ImportError:
     OEQ_AVAILABLE = False
 
 
+@restores_default_dtype
 def run(
     input_model,
     output_model="_hybrid.model",

--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -6,8 +6,10 @@ import torch
 
 from mace.modules.wrapper_ops import OEQConfig
 from mace.tools.scripts_utils import extract_config_mace_model
+from mace.tools.torch_tools import restores_default_dtype
 
 
+@restores_default_dtype
 def run(
     input_model,
     output_model="_oeq.model",

--- a/mace/cli/convert_oeq_e3nn.py
+++ b/mace/cli/convert_oeq_e3nn.py
@@ -5,8 +5,10 @@ import os
 import torch
 
 from mace.tools.scripts_utils import extract_config_mace_model
+from mace.tools.torch_tools import restores_default_dtype
 
 
+@restores_default_dtype
 def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True):
     # Load OEQ model
     if isinstance(input_model, str):

--- a/mace/tools/torch_tools.py
+++ b/mace/tools/torch_tools.py
@@ -4,9 +4,10 @@
 # This program is distributed under the MIT License (see MIT.md)
 ###########################################################################################
 
+import functools
 import logging
 from contextlib import contextmanager
-from typing import Dict, Union
+from typing import Callable, Dict, Union
 
 import numpy as np
 import torch
@@ -155,6 +156,37 @@ def default_dtype(dtype: Union[torch.dtype, str]):
     else:
         torch.set_default_dtype(dtype)
 
-    yield
+    # `finally`, because the default dtype is process-wide and this scope guards
+    # code that raises: `MACECalculator.calculate` runs inside it, and so does
+    # every converter entry point, which sets the default from the source model
+    # before it can refuse a model it does not accept. Without this an exception
+    # left the whole process on the scope's dtype -- silently, since nothing
+    # reads it back -- and the next unrelated tensor was built at that precision.
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(init)
 
-    torch.set_default_dtype(init)
+
+def restores_default_dtype(func: Callable) -> Callable:
+    """Undo whatever a function does to the process-wide default dtype.
+
+    The converters set the default from the source model's parameters so the
+    submodules they build land at the right precision, and they are library
+    functions rather than only CLI entry points: `MACECalculator.__init__` calls
+    `run_e3nn_to_cueq` (mace/calculators/mace.py:362), and `run_train` converts
+    mid-run at a dtype it has already chosen for itself. Leaving the default
+    changed hands the caller a different process than it had, so every later
+    tensor built without an explicit dtype silently follows the converted model.
+
+    A decorator rather than a `with` around each body: the body still needs the
+    default set while it constructs, so the only change is that the scope ends.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Setting the current dtype is a no-op; the point is the restore.
+        with default_dtype(torch.get_default_dtype()):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/integrations/lammps/test_mliap_buffer_dtype.py
+++ b/tests/integrations/lammps/test_mliap_buffer_dtype.py
@@ -1,0 +1,58 @@
+"""The ML-IAP wrapper's own buffers must follow the model, not the process.
+
+`total_charge` and `total_spin` are handed to the forward beside the model's own
+tensors, so a float32 pair under a float64 model does not raise: promotion makes
+it a quietly less accurate number, and it is LAMMPS that consumes it.
+
+They used to be built at `torch.get_default_dtype()`, and the export happened to
+be correct only because `mace_create_lammps_model --format mliap` converts to the
+cueq layout first and that converter set the default globally on its way through.
+Restoring the default in the converter -- which every other caller wants, since
+`MACECalculator` and `run_train` call it as a plain function -- removes that
+accident, so the dtype has to come from the model instead.
+"""
+
+import pytest
+import torch
+
+from mace.calculators.lammps_mliap_mace import MACEEdgeForcesWrapper
+from tests.integrations.lammps._harness import StubMACE
+
+
+@pytest.fixture(name="process_default_float32", autouse=True)
+def fixture_process_default_float32():
+    """A float32 process, which is torch's default and what a fresh CLI has."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float32)
+    yield
+    torch.set_default_dtype(previous)
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32])
+def test_the_wrapper_buffers_follow_the_model_dtype(dtype):
+    wrapper = MACEEdgeForcesWrapper(StubMACE(num_interactions=2, dtype=dtype))
+
+    assert wrapper.total_charge.dtype is dtype
+    assert wrapper.total_spin.dtype is dtype
+
+
+def test_a_float64_model_is_not_downgraded_by_a_float32_process():
+    """The regression the converter's restore would otherwise have introduced:
+    `--dtype float64` is the export default, and nothing downstream raises."""
+    wrapper = MACEEdgeForcesWrapper(StubMACE(num_interactions=2, dtype=torch.float64))
+
+    assert torch.get_default_dtype() is torch.float32
+    assert wrapper.total_charge.dtype is torch.float64
+
+
+def test_explicit_buffers_still_win():
+    """`total_charge=` is how a caller sets a charged system; it must be kept
+    verbatim rather than recast to the model's dtype."""
+    given = torch.tensor([-1.0], dtype=torch.float64)
+
+    wrapper = MACEEdgeForcesWrapper(
+        StubMACE(num_interactions=2, dtype=torch.float64), total_charge=given
+    )
+
+    assert wrapper.total_charge.item() == -1.0
+    assert wrapper.total_charge.dtype is torch.float64

--- a/tests/unit/test_default_dtype_scope.py
+++ b/tests/unit/test_default_dtype_scope.py
@@ -1,0 +1,171 @@
+"""`torch_tools.default_dtype` puts the process default back, exception or not.
+
+The default dtype is process-wide, and this scope guards code that raises.
+`MACECalculator.calculate` runs inside it, in nine places across the two
+calculator classes, and so does every converter entry point -- which sets the
+default from the source model's parameters before it can refuse a model it does
+not accept.
+
+Without a `finally` an exception left the whole process on the scope's dtype, and
+nothing reads that back, so the next unrelated tensor was simply built at the
+wrong precision. Under pytest the same worker then ran every later test at
+float64, which is the kind of contamination that makes a test pass alone and fail
+in a suite.
+"""
+
+import pytest
+import torch
+
+from mace.tools import torch_tools
+
+
+@pytest.fixture(name="float32_default", autouse=True)
+def fixture_float32_default():
+    """Leave the process where it was found, whatever these tests do to it."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float32)
+    yield
+    torch.set_default_dtype(previous)
+
+
+def test_the_scope_sets_the_dtype_it_was_given():
+    with torch_tools.default_dtype("float64"):
+        assert torch.get_default_dtype() is torch.float64
+
+
+def test_a_clean_exit_restores_the_default():
+    with torch_tools.default_dtype("float64"):
+        pass
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_an_exception_restores_the_default_too():
+    """The bug. A converter that refuses a model raises after setting the default
+    from that model, so this is the ordinary path rather than an edge case."""
+    with pytest.raises(TypeError):
+        with torch_tools.default_dtype("float64"):
+            raise TypeError("the converter refuses this model")
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_the_exception_still_reaches_the_caller():
+    """Restoring must not swallow it: `pytest.raises` above would pass on a
+    `finally` that returned normally, but a caller needs the error."""
+    with pytest.raises(ValueError, match="propagated"):
+        with torch_tools.default_dtype("float64"):
+            raise ValueError("propagated")
+
+
+def test_a_torch_dtype_is_accepted_as_well_as_a_string():
+    with torch_tools.default_dtype(torch.float64):
+        assert torch.get_default_dtype() is torch.float64
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_nesting_unwinds_to_the_outer_dtype():
+    with torch_tools.default_dtype("float64"):
+        with torch_tools.default_dtype("float32"):
+            assert torch.get_default_dtype() is torch.float32
+        assert torch.get_default_dtype() is torch.float64
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_nesting_unwinds_through_an_exception():
+    with torch_tools.default_dtype("float64"):
+        with pytest.raises(RuntimeError):
+            with torch_tools.default_dtype("float32"):
+                raise RuntimeError("inner")
+        assert torch.get_default_dtype() is torch.float64
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+# ---------------------------------------------------------------------------
+# The converters, which are library functions and not only CLI entry points
+# ---------------------------------------------------------------------------
+
+CONVERTER_MODULES = [
+    "mace.cli.convert_e3nn_cueq",
+    "mace.cli.convert_cueq_e3nn",
+    "mace.cli.convert_e3nn_oeq",
+    "mace.cli.convert_oeq_e3nn",
+    "mace.cli.convert_e3nn_hybrid",
+]
+
+
+def test_the_decorator_restores_after_a_body_that_raises():
+    @torch_tools.restores_default_dtype
+    def refuses_the_model():
+        torch.set_default_dtype(torch.float64)
+        raise TypeError("not a cueq model")
+
+    with pytest.raises(TypeError):
+        refuses_the_model()
+
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_the_decorator_restores_after_a_body_that_succeeds():
+    """The half a `try/except` around the call site would not have covered:
+    the converters changed the default on every successful conversion too."""
+
+    @torch_tools.restores_default_dtype
+    def converts():
+        torch.set_default_dtype(torch.float64)
+        return torch.zeros(1)
+
+    built = converts()
+
+    assert built.dtype is torch.float64, "the body must still get its dtype"
+    assert torch.get_default_dtype() is torch.float32
+
+
+def test_the_decorator_keeps_the_wrapped_signature():
+    """`run` is called with keywords (`device=`) from five places in mace/."""
+
+    @torch_tools.restores_default_dtype
+    def convert(model, device="cpu"):
+        """Docstring kept."""
+        return model, device
+
+    assert convert("m", device="cuda") == ("m", "cuda")
+    assert convert.__name__ == "convert"
+    assert convert.__doc__ == "Docstring kept."
+
+
+@pytest.mark.parametrize("module_name", CONVERTER_MODULES)
+def test_every_converter_run_restores_the_default_dtype(module_name):
+    """Source-level, because a real conversion needs cueq or oeq installed and
+    the point is the entry points that are *not* covered by a GPU job.
+
+    Each `run` reads the dtype off the source model and sets it process-wide so
+    the submodules it builds inherit it. That is fine inside the call and wrong
+    after it: `MACECalculator(enable_cueq=True)` and `run_train` both call these
+    as ordinary functions, so the leak lands in a caller that already chose its
+    own dtype.
+    """
+    import ast  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    import importlib  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    import inspect  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    # The modules import their backend lazily, so parsing beats importing: oeq
+    # and cueq are absent from the CPU suite where this test has to run.
+    path = importlib.util.find_spec(module_name).origin
+    with open(path, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read())
+
+    run = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "run"
+    )
+    decorators = {ast.unparse(d) for d in run.decorator_list}
+
+    assert "restores_default_dtype" in decorators, (
+        f"{module_name}.run sets the process default dtype from the source "
+        "model; it must put the caller's back"
+    )


### PR DESCRIPTION
torch_tools.default_dtype is a context manager over a process wide setting, but it only restored the dtype on a clean exit. If the body raised, the whole process stayed on the scope's dtype. Nothing reads that value back, so the next tensor built without an explicit dtype simply came out at the wrong precision.

MACECalculator runs inside this scope in nine places, including _atoms_to_batch. A structure with an element the model does not know was enough to leave a float32 caller at float64.

The five backend converters have the same problem, and there it happens on success too. Each one reads the dtype off the source model and sets it process wide, so the submodules it builds inherit it. Then it never puts the old value back. These are library functions, not only CLI entry points. MACECalculator(enable_cueq=True) calls run_e3nn_to_cueq at construction, and run_train converts mid run at a dtype it already chose from --default_dtype. They are decorated instead of wrapped in a with, because the body still needs the default set while it constructs.

That leak turned out to be load bearing in one place. The ML-IAP wrapper built total_charge and total_spin at the process default. The export reached float64 only because --format mliap converts to cueq first, and that converter had set the default globally. Those buffers now take their dtype from model.r_max.dtype, which is where LAMMPS_MLIAP_MACE reads its own.

Nothing was raising before, and nothing would have. Those buffers meet the model's tensors inside the forward, so promotion turned the mismatch into a less accurate number rather than an error, and LAMMPS is what consumes it.

Found by Bugbot on #1657 where the test helper was working around this instead of fixing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches numerical precision paths (LAMMPS ML-IAP, calculators, training-time conversion); behavior is intentionally changed to stop silent dtype drift rather than add new features.
> 
> **Overview**
> Fixes **process-wide `torch` default dtype leaks** that could leave later tensors at the wrong precision without raising.
> 
> `default_dtype` now restores the previous dtype in a **`finally` block**, so exceptions inside calculator paths (e.g. `MACECalculator.calculate`) no longer poison the rest of the process. A new **`restores_default_dtype`** decorator wraps all five model **converter `run` entry points**, which set the default from the source model during construction but previously never put the caller’s default back on success or failure.
> 
> **`MACEEdgeForcesWrapper`** no longer builds default `total_charge` / `total_spin` from `torch.get_default_dtype()`; it uses **`model.r_max.dtype`** so ML-IAP export stays aligned with the model (and with `LAMMPS_MLIAP_MACE`) once converters stop accidentally fixing dtype via a global side effect.
> 
> Adds unit tests for the context manager and decorator, plus ML-IAP wrapper buffer dtype regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9180da8aba5ad27cbd885a70a965c3b8e456576c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->