### PR TITLE
Enforce per-file coverage floors and add CPU benchmark cases to the nightly

### DIFF
--- a/.github/gitlab/ci.yml
+++ b/.github/gitlab/ci.yml
@@ -103,6 +103,16 @@ stages:
     # and then skipped — silently narrower GPU coverage than the fleet had.
     # It is in REQUIRE_CAPS too, so removing this line fails the job instead of
     # quietly dropping those tests again.
+    #
+    # `and not benchmark` stays, and it is a decision rather than an oversight:
+    # this job runs -n 2 on a contended shared runner under a 2 h cap, so a
+    # timing taken here would be noise wearing a number, and it is a
+    # correctness gate that must not grow a perf-shaped flake. The consequence
+    # is that no CI job anywhere runs a gpu-marked benchmark — the CPU baseline
+    # in tests/benchmarks/test_inference_cpu.py is what the nightly publishes,
+    # and the GPU cases are the by-hand reproduction recipe recorded in that
+    # file's module docstring. Removing this clause is not the way to fix that;
+    # a separate, non-gating benchmark job would be.
     - >
       MACE_REQUIRE_CAPS="$REQUIRE_CAPS"
       MACE_CI_ALLOW_NETWORK=1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -245,7 +245,7 @@ jobs:
       - uses: ./.github/actions/setup-mace
         with:
           python-version: "3.12"
-          extras: dev, cueq, torchsim, schedulefree
+          extras: dev, cueq, torchsim, schedulefree, magnetic
           pip-packages: -r requirements/polar.txt -r requirements/les.txt
       - name: Cache foundation model downloads
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -261,7 +261,7 @@ jobs:
         with:
           tests: tests
           markers: not gpu and not benchmark
-          require-caps: network,cueq,polar,les,torchsim,schedulefree
+          require-caps: network,cueq,polar,les,torchsim,schedulefree,magnetic
           allow-network: "true"
           coverage: "data"
           splits: "3"
@@ -356,8 +356,12 @@ jobs:
       # THE SELECTION THESE FLOORS ARE MEASURED UNDER is exactly
       # coverage-full's, combined over all three shards:
       #   pytest tests -m "not gpu and not benchmark"
-      # with extras dev,cueq,torchsim,schedulefree plus requirements/polar.txt
-      # and requirements/les.txt, and MACE_CI_ALLOW_NETWORK=1.
+      # with extras dev,cueq,torchsim,schedulefree,magnetic plus
+      # requirements/polar.txt and requirements/les.txt, and
+      # MACE_CI_ALLOW_NETWORK=1. The magnetic extra is not optional here: the
+      # modules/utils.py floor counts compute_forces_virials_magforces and
+      # compute_forces_magforces, which only tests/extensions/magnetic reach,
+      # and they are ~8 points of that file against 2 points of headroom.
       #
       # HEADROOM, as measured under that selection when the floors went in:
       #   loss.py 100 (floor 90)      data/utils.py      96  (85)

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -83,6 +83,23 @@ jobs:
       contents: read
 
   benchmarks:
+    # The performance baseline the rewrite will be judged against, recorded
+    # while legacy is still the live stack: "not slower" is only falsifiable
+    # against an old number, and after legacy retires the comparison runs
+    # against the frozen one, so these have to be reproducible cases with
+    # recorded metadata rather than one-off timings.
+    #
+    # This job used to be continue-on-error and published nothing at all: the
+    # only test in tests/benchmarks was marked `gpu` AND `network`, so all
+    # sixteen parametrizations skipped on a CPU runner, the job went green,
+    # and benchmark.json was reproducibly a 0-byte file. tests/benchmarks/
+    # test_inference_cpu.py adds the CPU cases, and since a job that cannot
+    # fail is not a baseline, continue-on-error is gone and the artifact is
+    # checked for contents below -- not merely for existence, which it always
+    # had.
+    #
+    # numprocs 0 is load-bearing: pytest-benchmark disables itself under
+    # xdist, so a parallel run of this job would collect timings from nothing.
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -91,23 +108,75 @@ jobs:
         with:
           python-version: "3.12"
           extras: dev
-      # CPU benchmark tests currently skip without a GPU (they are
-      # gpu-marked); keep the job so CPU benchmarks land here when added.
+      - name: Cache foundation model downloads
+        # The MP-small cases are network-gated; without the cache every night
+        # re-downloads the same checkpoint.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/mace
+          key: mace-foundations-${{ hashFiles('mace/calculators/foundations_models.py') }}
       - uses: ./.github/actions/run-tests
-        continue-on-error: true
         with:
           tests: tests/benchmarks
+          # Deliberately no marker expression: every narrowing applied here so
+          # far has ended with an empty artifact. The gpu-marked cases skip on
+          # this runner and say so.
           allow-network: "true"
+          # The MP-small half of the baseline is downloaded, so a lost network
+          # must turn this job red rather than quietly halve the artifact.
+          require-caps: network
           numprocs: "0"
           timeout: "3600"
           extra-args: --benchmark-json=benchmark.json
+      # THE check that this job stopped being green-while-measuring-nothing.
+      #
+      # `if-no-files-found: error` on the upload below cannot catch it:
+      # pytest-benchmark creates the --benchmark-json path regardless of what
+      # ran, and a session in which every case skipped leaves a **0-byte
+      # file** behind (reproduced locally: `pytest tests/benchmarks/
+      # test_benchmark.py --benchmark-json=...` -> 16 skipped, 0-byte json).
+      # So the file is always present, the upload always succeeds, and the
+      # only thing that distinguishes a baseline from an empty artifact is its
+      # contents. Hence a content assertion rather than a presence one.
+      #
+      # It also checks one case per declared size, because the hole this job
+      # had was size-shaped: skipping is per-parametrization, so a single
+      # surviving case would satisfy "non-empty" while the size spread the
+      # downstream comparison needs had quietly gone.
+      - name: The artifact must actually contain a baseline
+        run: |
+          python - <<'PY'
+          import json, pathlib, sys
+          raw = pathlib.Path("benchmark.json").read_text() or "{}"
+          runs = json.loads(raw).get("benchmarks", [])
+          if not runs:
+              sys.exit(
+                  "benchmark.json carries no benchmarks: every case skipped "
+                  "and this job would have published an empty baseline."
+              )
+          sizes = {b.get("extra_info", {}).get("regime") for b in runs}
+          missing = {"subdomain216", "subdomain512", "kernel1728"} - sizes
+          if missing:
+              sys.exit(f"no benchmark ran at size(s) {sorted(missing)}")
+          for b in runs:
+              info = b.get("extra_info", {})
+              absent = [
+                  k for k in ("dtype", "device", "torch_version", "backend")
+                  if not info.get(k)
+              ]
+              if absent:
+                  sys.exit(f"{b['name']} records no {absent}: not reproducible")
+          print(f"{len(runs)} benchmarks across sizes {sorted(sizes)}")
+          PY
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # always(), so the artifact is there to diagnose a failed content check
+        # rather than only on the nights that pass it.
         if: always()
         with:
           name: benchmark-json
           path: benchmark.json
           retention-days: 90
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   lammps-real:
     # Real-tier LAMMPS via conda-forge (ML-IAP unified path). Runs a
@@ -243,7 +312,79 @@ jobs:
             coverage report --skip-covered --sort=cover | tail -40
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+      # THE coverage gate. The overall percentage above stays informative in
+      # both this job and the per-PR one; only the files listed below are
+      # enforced.
+      #
+      # WHY ONLY THESE FILES. The rewrite's test-prerequisite bar is golden
+      # characterization + end-to-end contracts + line-coverage floors on the
+      # modules whose *behaviour* ports. There is deliberately no global
+      # target: everything else in mace/ is pinned by the goldens in
+      # tests/golden and the CLI/calculator contracts in tests/workflows, and
+      # a global number would be a second, weaker statement about the same
+      # code. These six are the pure-math and physics-glue modules that have
+      # no golden standing in for them.
+      #
+      # MIGRATION INVARIANT. A floor protects the behaviour, not the legacy
+      # file. When a capability moves to the new stack, its floor moves with
+      # it to the corresponding mace_core/mace_torch module in the same
+      # commit. Forgetting to is not silent: `--include` on a path that no
+      # longer exists selects nothing and `coverage report` exits 1 with
+      # "No data to report" (and tests/unit/test_ci_gates.py fails on the PR
+      # that renames the file, a night earlier).
+      #
+      # WHY HERE AND NOWHERE ELSE. Two other places look plausible and are
+      # both wrong. Inside coverage-full the check would run in a shard
+      # holding one third of the suite (splits: 3), so a module exercised
+      # entirely by tests that landed in another group would fail its own
+      # floor. In ci-core's coverage job the denominator is different: that
+      # job measures tests/unit + tests/workflows only -- no extensions,
+      # backends, integrations or network -- so the same percentage would
+      # mean a different thing. mace/modules/radial.py is the example that
+      # settles it: the ZBL and non-default radial-basis branches are reached
+      # from tests/backends and the extension suites, so it reads roughly 58%
+      # on the PR slice and roughly 70% on the full scope. A floor is
+      # meaningless without naming which.
+      #
+      # THE SELECTION THESE FLOORS ARE MEASURED UNDER is therefore exactly
+      # coverage-full's, combined over all three shards:
+      #   pytest tests -m "not gpu and not benchmark"
+      # with extras dev,cueq,torchsim,schedulefree plus requirements/polar.txt
+      # and requirements/les.txt, and MACE_CI_ALLOW_NETWORK=1.
+      #
+      # This step runs after `coverage combine`, which is also why
+      # coverage-report is deliberately not `if: always()`: a gate must never
+      # be computed from a subset of the shards.
+      - name: Per-file coverage floors
+        run: |
+          status=0
+          echo '## Per-file coverage floors' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          while read -r file floor; do
+            case "$file" in ''|'#'*) continue ;; esac
+            if report=$(coverage report --include="$file" --fail-under="$floor" 2>&1); then
+              verdict='ok'
+            else
+              verdict='BELOW FLOOR'
+              status=1
+            fi
+            printf '%-34s >= %3s%%  %s\n' "$file" "$floor" "$verdict" \
+              >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n%s\n' "--- $file (floor ${floor}%): $verdict" "$report"
+          done <<'FLOORS'
+          mace/modules/loss.py 90
+          mace/modules/radial.py 90
+          mace/modules/utils.py 85
+          mace/data/utils.py 85
+          mace/data/neighborhood.py 95
+          mace/data/atomic_data.py 85
+          FLOORS
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # always(), so the html report that explains a floor failure is
+        # available on the run that failed.
+        if: always()
         with:
           name: coverage-full
           path: |

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -337,20 +337,39 @@ jobs:
       # both wrong. Inside coverage-full the check would run in a shard
       # holding one third of the suite (splits: 3), so a module exercised
       # entirely by tests that landed in another group would fail its own
-      # floor. In ci-core's coverage job the denominator is different: that
-      # job measures tests/unit + tests/workflows only -- no extensions,
-      # backends, integrations or network -- so the same percentage would
-      # mean a different thing. mace/modules/radial.py is the example that
-      # settles it: the ZBL and non-default radial-basis branches are reached
-      # from tests/backends and the extension suites, so it reads roughly 58%
-      # on the PR slice and roughly 70% on the full scope. A floor is
-      # meaningless without naming which.
+      # floor. In ci-core's coverage job the denominator is different: it
+      # measures tests/unit + tests/workflows only -- no extensions, backends,
+      # integrations or network -- so the same percentage means a different
+      # thing.
       #
-      # THE SELECTION THESE FLOORS ARE MEASURED UNDER is therefore exactly
+      # That second one is not a theoretical objection, and the file that
+      # settles it is mace/modules/utils.py. Measured on one host over the
+      # whole selection: 76% on the PR slice, 87% on the full scope. Its floor
+      # is 85. The same number against the same file therefore PASSES here and
+      # FAILS in the PR job. The gap is 36 statements and it is not diffuse:
+      # compute_forces_virials_magforces, compute_forces_magforces, the
+      # get_outputs branches that dispatch to them, and
+      # compute_total_charge_dipole_permuted -- reached from tests/extensions,
+      # which the PR slice does not run. A floor is meaningless without naming
+      # the selection, so:
+      #
+      # THE SELECTION THESE FLOORS ARE MEASURED UNDER is exactly
       # coverage-full's, combined over all three shards:
       #   pytest tests -m "not gpu and not benchmark"
       # with extras dev,cueq,torchsim,schedulefree plus requirements/polar.txt
       # and requirements/les.txt, and MACE_CI_ALLOW_NETWORK=1.
+      #
+      # HEADROOM, as measured under that selection when the floors went in:
+      #   loss.py 100 (floor 90)      data/utils.py      96  (85)
+      #   radial.py 100 (floor 90)    neighborhood.py    100 (95)
+      #   modules/utils.py 87 (85)    atomic_data.py     96  (85)
+      # Two of those are ratchets rather than newly-cleared bars --
+      # neighborhood.py and atomic_data.py already sat above their floors
+      # before the characterization tests landed, so they gate against
+      # regression and nothing else. modules/utils.py is the tight one at two
+      # points; the honest reading is that its floor is the one that will bite
+      # first, which is the point of putting it here rather than rounding it
+      # down to something comfortable.
       #
       # This step runs after `coverage combine`, which is also why
       # coverage-report is deliberately not `if: always()`: a gate must never

--- a/tests/benchmarks/test_inference_cpu.py
+++ b/tests/benchmarks/test_inference_cpu.py
@@ -153,6 +153,13 @@ def backend_params() -> List:
 
 def _load_model(name: str, dtype: str, device: str) -> torch.nn.Module:
     if name == "anchor":
+        # Read straight from the committed checkpoint rather than through a
+        # shared loader, so this file stands on the golden harness alone. The
+        # numerics characterization work introduces a tests.golden.anchors
+        # with a load_anchor() that does exactly this; collapse these five
+        # lines into it once that lands, but not before -- a benchmark that
+        # cannot be collected without another suite present is a benchmark
+        # that silently stops being collected.
         torch_dtype = torch.float32 if dtype == "float32" else torch.float64
         model = torch.load(
             harness.MODELS_DIR / "tiny_scaleshift.model",

--- a/tests/benchmarks/test_inference_cpu.py
+++ b/tests/benchmarks/test_inference_cpu.py
@@ -1,0 +1,293 @@
+"""Inference baselines recorded while legacy is still the live stack.
+
+"The rewrite is not slower" is only falsifiable against an *old* number, so
+these cases exist to be measured now and frozen, not to gate anything. They
+publish through the nightly ``benchmarks`` job's ``--benchmark-json``
+artifact; the downstream comparisons read that history, including after
+legacy retires -- the new-architecture benchmark harness compares against it,
+and the deployment-path retirement trigger reads two fp32/NVIDIA cases from
+it. That is why every case is a fixed structure at a fixed size with its
+dtype, device, torch version and backend recorded next to the timing: a
+one-off number with an unrecorded denominator is not a baseline.
+
+Two size regimes, deliberately, because the downstream comparison is judged
+in both:
+
+* ``subdomain`` (216 and 512 atoms) -- the per-rank size of a
+  domain-decomposed MD run, where host-side cost (dispatch, allocation, the
+  Python between the kernels) is a material fraction of the step. This is
+  where a rewrite that is faster per kernel can still be slower per step.
+* ``kernel`` (1728 atoms) -- large enough that the tensor-product and
+  symmetric-contraction kernels dominate and host overhead amortises away.
+
+The regimes are usually described in terms of a GPU step being a few
+milliseconds, and on a CPU runner that is simply not the wall-clock: the
+anchor's fp32 forward measured 31 / 60 / 162 ms at the three sizes on an
+8-core arm64 laptop. What survives the move to CPU is the thing the split is
+actually for -- the *shape* of the scaling -- and it shows in the derived
+throughput rather than the latency. Same run, atom-steps per second: 6897 at
+216 atoms, 8588 at 512, 10658 at 1728. Per-atom cost falls monotonically with
+size, and the small case runs at 65% of the large one's rate: about a third of
+its per-atom cost is work that does not scale with the system, which is
+exactly the overhead a faster-per-kernel rewrite can still lose to. Note what
+this does *not* show -- the curve has not flattened by 1728 atoms, so
+`kernel1728` is the most kernel-dominated case here rather than a saturated
+one, and reading it as an asymptote would overstate what these three points
+support.
+
+Absolute latencies are a property of the runner and are not comparable across
+machines, which is why every case records its own metadata. Timings taken
+while other work shares the host differ substantially -- a contended run of
+this same set read 4326 / 5590 / 5936 -- so trend comparisons must come from
+the nightly's own history, on its own runner, not from a number pasted out of
+a docstring.
+
+REACHABILITY -- the CI decision this file records
+-------------------------------------------------
+``tests/benchmarks`` is auto-marked ``benchmark`` + ``slow``
+(``tests/conftest.py``), and exactly one CI job runs it: the nightly
+``benchmarks`` job, on a CPU runner, with ``numprocs: "0"``.
+
+The GPU pipeline (``.github/gitlab/ci.yml``) appends ``and not benchmark`` to
+its marker expression, and that stays. It runs ``-n 2`` under a two-hour cap
+on a *contended* shared runner, so a timing taken inside it would be noise
+wearing a number, and it is a correctness gate that must not grow a
+perf-shaped flake.
+
+The consequence is now explicit instead of accidental: the ``gpu``-marked
+cases below -- and the pre-existing ``test_inference`` in
+``test_benchmark.py``, all sixteen of whose parametrizations are ``gpu`` *and*
+``network`` -- run in **zero** CI jobs. That is why the nightly artifact was
+reproducibly a 0-byte file before this file existed: the job was green, and
+published nothing. The cases here are what fill it, and the nightly job now
+asserts the artifact's *contents* rather than its existence, because
+pytest-benchmark writes the json path either way. The GPU cases stay as the
+reproduction recipe for the frozen fp32/NVIDIA numbers, run by hand on a
+quiet GPU host:
+
+    MACE_CI_ALLOW_NETWORK=1 pytest tests/benchmarks -m benchmark \\
+        -p no:randomly --benchmark-json=benchmark.json
+
+``tests/unit/test_ci_gates.py`` is what keeps the CPU half from regressing
+into the same hole: it fails, in a PR-gating job, if any declared size stops
+having a case a CPU-only nightly can run.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Dict, Iterator, List, Tuple
+
+import pytest
+import torch
+from ase import build
+
+from mace import data as mace_data
+from mace.tools import AtomicNumberTable, torch_geometric, torch_tools
+from tests.golden import harness
+
+# ---------------------------------------------------------------------------
+# The cases, kept as module-level data so the reachability guard in
+# tests/unit/test_ci_gates.py can reason about them without running them.
+# ---------------------------------------------------------------------------
+
+#: regime -> (cubic-diamond repeat factor, resulting atom count). Diamond
+#: carbon at the experimental lattice constant: element 6 is the one species
+#: every model here shares (the committed tiny anchor knows H/C/O only), and
+#: a homogeneous bulk keeps the edge count a pure function of the size.
+SYSTEM_SIZES: Dict[str, Tuple[int, int]] = {
+    "subdomain216": (3, 216),
+    "subdomain512": (4, 512),
+    "kernel1728": (6, 1728),
+}
+
+#: fp64 is MACE's default and what the "not slower" comparison is judged in;
+#: fp32 is what the deployment-path retirement trigger freezes.
+DTYPES: Tuple[str, ...] = ("float32", "float64")
+
+#: (model, regime). The tiny anchor is committed in-repo, so it is measurable
+#: on any runner with no network at all, and it covers every size. MP-small is
+#: the production-shaped counterpart, has to be downloaded (hence the
+#: `network` mark), and deliberately stops at 512 atoms. Its cutoff is 6.0 A
+#: against the anchor's 3.5, which is 158 edges per atom rather than 28: the
+#: 512-atom case is already 80896 edges, measured at 5.25 GB peak RSS and
+#: ~7 s per fp64 forward locally, and a 1728-atom cell would be roughly three
+#: times that in both. That is more than a shared nightly runner should be
+#: asked for by a job that gates nothing. The kernel-bound regime is covered
+#: by the anchor, which is the case the rewrite comparison is anchored on
+#: anyway. The whole CPU set (10 cases) measured ~160 s locally.
+CASES: List[Tuple[str, str]] = [
+    ("anchor", "subdomain216"),
+    ("anchor", "subdomain512"),
+    ("anchor", "kernel1728"),
+    ("mp_small", "subdomain216"),
+    ("mp_small", "subdomain512"),
+]
+
+NETWORK_MODELS: Tuple[str, ...] = ("mp_small",)
+
+
+def case_params() -> List:
+    return [
+        pytest.param(
+            model,
+            regime,
+            marks=[pytest.mark.network] if model in NETWORK_MODELS else [],
+            id=f"{model}-{regime}",
+        )
+        for model, regime in CASES
+    ]
+
+
+def backend_params() -> List:
+    # e3nn is the only backend that exists without a GPU. cueq and oeq carry
+    # both the hardware and the library capability, so the skip reason names
+    # whichever is actually missing rather than blaming the GPU for a missing
+    # wheel.
+    return [
+        pytest.param("e3nn", id="e3nn"),
+        pytest.param("cueq", marks=[pytest.mark.gpu, pytest.mark.cueq], id="cueq"),
+        pytest.param("oeq", marks=[pytest.mark.gpu, pytest.mark.oeq], id="oeq"),
+    ]
+
+
+def _load_model(name: str, dtype: str, device: str) -> torch.nn.Module:
+    if name == "anchor":
+        torch_dtype = torch.float32 if dtype == "float32" else torch.float64
+        model = torch.load(
+            harness.MODELS_DIR / "tiny_scaleshift.model",
+            weights_only=False,
+            map_location="cpu",
+        )
+        return model.to(torch_dtype).to(device)
+    if name == "mp_small":
+        # Imported here so a CPU-only collection never touches the download
+        # machinery at import time.
+        from mace.calculators.foundations_models import mace_mp  # noqa: PLC0415
+
+        calc = mace_mp(model="small", default_dtype=dtype, device=device)
+        return calc.models[0].to(device)
+    raise AssertionError(f"unknown benchmark model {name!r}")
+
+
+def _apply_backend(model: torch.nn.Module, backend: str, device: str):
+    if backend == "e3nn":
+        return model
+    if backend == "cueq":
+        from mace.cli.convert_e3nn_cueq import run as to_cueq  # noqa: PLC0415
+
+        return to_cueq(model, device=device, return_model=True).to(device)
+    if backend == "oeq":
+        from mace.cli.convert_e3nn_oeq import run as to_oeq  # noqa: PLC0415
+
+        return to_oeq(model, device=device, return_model=True).to(device)
+    raise AssertionError(f"unknown backend {backend!r}")
+
+
+def _batch(model: torch.nn.Module, repeat: int, dtype: str, device: str) -> dict:
+    """One diamond supercell as the dict ``model.forward`` eats.
+
+    Built inside a ``default_dtype`` scope for the reason spelled out in
+    ``tests/golden/test_tiny_anchors.py``: ``AtomicData`` reads the
+    process-wide default dtype, which is float32 under pytest, and building in
+    float32 then casting up rounds the positions first. Here that would not
+    change a verdict -- nothing is compared -- but it would change the edge
+    count at a cutoff boundary, and two nights whose structures differ are not
+    a baseline.
+    """
+    z_table = AtomicNumberTable([int(z) for z in model.atomic_numbers])
+    atoms = build.bulk("C", "diamond", a=3.567, cubic=True).repeat((repeat,) * 3)
+    with torch_tools.default_dtype(dtype):
+        graph = mace_data.AtomicData.from_config(
+            mace_data.config_from_atoms(atoms),
+            z_table=z_table,
+            cutoff=float(model.r_max),
+        )
+        loader = torch_geometric.dataloader.DataLoader(
+            dataset=[graph], batch_size=1, shuffle=False, drop_last=False
+        )
+        batch = next(iter(loader))
+    return batch.to(device).to_dict()
+
+
+def _device_label(device: str) -> str:
+    if device == "cuda":
+        return torch.cuda.get_device_name()
+    # platform.processor() is empty on many Linux builds -- which is exactly
+    # where the nightly runs. pytest-benchmark's own machine_info carries the
+    # full detail; this is the human-readable label next to the number.
+    return platform.processor() or platform.machine() or "cpu"
+
+
+def _record_throughput(benchmark, num_atoms: int) -> None:
+    """Latency comes from pytest-benchmark; throughput has to be derived.
+
+    Guarded rather than asserted: ``benchmark.stats`` is only populated once a
+    timing actually ran, and is absent under ``--benchmark-disable``, which is
+    how a plain correctness run of this directory would execute the body.
+    """
+    stats = getattr(getattr(benchmark, "stats", None), "stats", None)
+    median = getattr(stats, "median", None)
+    if median:
+        benchmark.extra_info["median_seconds"] = median
+        benchmark.extra_info["atom_steps_per_second"] = num_atoms / median
+
+
+@pytest.mark.benchmark(warmup=True, warmup_iterations=2, min_rounds=5)
+@pytest.mark.parametrize(("model_name", "regime"), case_params())
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("backend", backend_params())
+def test_inference_latency(
+    benchmark, backend: str, dtype: str, model_name: str, regime: str
+) -> None:
+    """One energy+forces forward at a fixed size, as a frozen reference."""
+    device = "cpu" if backend == "e3nn" else "cuda"
+    repeat, expected_atoms = SYSTEM_SIZES[regime]
+
+    with torch_tools.default_dtype(dtype):
+        model = _apply_backend(_load_model(model_name, dtype, device), backend, device)
+        batch = _batch(model, repeat, dtype, device)
+        num_atoms = int(batch["positions"].shape[0])
+        # The regime names carry the atom count, and a silent change to the
+        # structure would make two nights' numbers incomparable while looking
+        # like a performance result.
+        assert num_atoms == expected_atoms
+
+        benchmark.extra_info.update(
+            model=model_name,
+            backend=backend,
+            regime=regime,
+            num_atoms=num_atoms,
+            num_edges=int(batch["edge_index"].shape[1]),
+            dtype=dtype,
+            device=device,
+            device_name=_device_label(device),
+            torch_version=torch.__version__,
+            r_max=float(model.r_max),
+        )
+
+        def func():
+            if device == "cuda":
+                torch.cuda.synchronize()
+            model(batch, training=False, compute_force=True)
+            if device == "cuda":
+                torch.cuda.synchronize()
+
+        benchmark(func)
+        _record_throughput(benchmark, num_atoms)
+
+
+def iter_case_marks() -> Iterator[Tuple[str, frozenset]]:
+    """(regime, marker names) for every case this module declares.
+
+    Exposed for ``tests/unit/test_ci_gates.py``, which needs to know which
+    cases a CPU-only nightly can run without importing pytest's collection
+    machinery or running a single timing.
+    """
+    module_marks = {mark.name for mark in globals().get("pytestmark", [])}
+    for backend in backend_params():
+        backend_marks = {mark.name for mark in backend.marks}
+        for case in case_params():
+            case_marks = {mark.name for mark in case.marks}
+            _model, regime = case.values
+            yield regime, frozenset(module_marks | backend_marks | case_marks)

--- a/tests/unit/test_ci_gates.py
+++ b/tests/unit/test_ci_gates.py
@@ -345,3 +345,57 @@ def test_benchmarks_never_gate_a_correctness_job():
     # comparison flag. Nothing may pass one.
     for text in (NIGHTLY.read_text(encoding="utf-8"), pipeline):
         assert "--benchmark-compare-fail" not in text
+
+
+def _setup_step(job: str) -> dict:
+    """The setup-mace step of a job, which decides what is installed."""
+    for step in _steps(job):
+        if str(step.get("uses", "")).endswith("setup-mace"):
+            return step.get("with", {})
+    raise AssertionError(f"job {job!r} has no setup-mace step")
+
+
+def _run_tests_step(job: str) -> dict:
+    for step in _steps(job):
+        if str(step.get("uses", "")).endswith("run-tests"):
+            return step.get("with", {})
+    raise AssertionError(f"job {job!r} has no run-tests step")
+
+
+def test_the_coverage_job_installs_every_capability_it_requires():
+    """A required capability the install cannot provide is a floor that cannot be met.
+
+    coverage-full is where the project's real coverage number is produced, and
+    the per-file floors are enforced against it. It once required `polar` and
+    `les` -- which arrive through pip-packages rather than extras -- while the
+    `magnetic` extra was absent entirely. Every test under
+    tests/extensions/magnetic therefore skipped in the one job whose numbers
+    the floors judge, and the mace/modules/utils.py floor counts
+    compute_forces_virials_magforces and compute_forces_magforces, reachable
+    from nowhere else. That is ~8 points of a file with 2 points of headroom:
+    the floor could not have been met, and the failure would have read as a
+    coverage regression rather than a missing install.
+    """
+    setup = _setup_step("coverage-full")
+    required = {
+        cap.strip()
+        for cap in str(_run_tests_step("coverage-full")["require-caps"]).split(",")
+        if cap.strip()
+    }
+    # a capability is satisfiable if it is an extra, or arrives via pip-packages
+    provided = {e.strip() for e in str(setup.get("extras", "")).split(",") if e.strip()}
+    pip = str(setup.get("pip-packages", ""))
+    # `network` is not a package; it is the allow-network switch
+    unprovidable = {
+        cap
+        for cap in required - provided - {"network"}
+        if f"requirements/{cap}.txt" not in pip
+    }
+    assert not unprovidable, (
+        f"coverage-full requires {sorted(unprovidable)} but installs neither the "
+        f"extra nor requirements/<cap>.txt for it. Its tests will skip, and any "
+        f"floor counting code they reach becomes unmeetable."
+    )
+    assert str(_run_tests_step("coverage-full")["allow-network"]) == "true", (
+        "coverage-full requires the network capability, so it must allow network"
+    )

--- a/tests/unit/test_ci_gates.py
+++ b/tests/unit/test_ci_gates.py
@@ -1,0 +1,320 @@
+"""The two CI gates that cannot check themselves.
+
+Both things this file guards failed the same way once: green, and measuring
+nothing.
+
+* The nightly `benchmarks` job ran a directory whose only test was marked
+  `gpu` AND `network`, on a CPU runner with no network. All sixteen
+  parametrizations skipped, the job passed, and the uploaded benchmark.json
+  was reproducibly a **0-byte file**. Nothing said so -- and note which guard
+  does *not* help here: pytest-benchmark creates the `--benchmark-json` path
+  whatever happens, so `if-no-files-found` on the upload never fires. Only a
+  check on the artifact's contents can tell a baseline from a green job that
+  measured nothing, which is why the tests below run the job's own check
+  against artifacts built to be empty, holed and unlabelled.
+* A per-file coverage floor named after a module that has been renamed or
+  moved selects no files. `coverage report --include=<gone> --fail-under=N`
+  does exit 1 on "No data to report", so the nightly would catch it -- but a
+  night later, and with a message that reads like a broken coverage run
+  rather than a floor whose subject moved. The floors are explicitly supposed
+  to migrate to `mace_core`/`mace_torch` as capabilities port, so the
+  rename-without-moving-the-floor case is the expected one, not a freak.
+
+These live in tests/unit rather than beside what they describe because both
+belong in a PR-gating job: tests/benchmarks is nightly-only by construction,
+so a guard placed there would find the hole a day after it was dug.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NIGHTLY = REPO_ROOT / ".github" / "workflows" / "nightly.yaml"
+GITLAB_PIPELINE = REPO_ROOT / ".github" / "gitlab" / "ci.yml"
+
+pytestmark = pytest.mark.skipif(
+    not NIGHTLY.is_file(), reason="workflow definitions are not part of an install"
+)
+
+
+def _nightly() -> dict:
+    # `on:` is parsed by PyYAML 1.1 rules as the boolean True; harmless here,
+    # nothing below reads it.
+    return yaml.safe_load(NIGHTLY.read_text(encoding="utf-8"))
+
+
+def _steps(job: str) -> List[dict]:
+    return _nightly()["jobs"][job]["steps"]
+
+
+def _floor_table() -> Dict[str, int]:
+    """The floors, read back out of the job definition that enforces them.
+
+    Parsing the shell heredoc rather than importing a table from somewhere is
+    deliberate. The floors have to be readable in the job that enforces them,
+    next to the reasoning for why those files and not others -- a reviewer
+    should not have to open a second file to see what the gate is. So the job
+    definition is the only copy, and this test reads that one rather than
+    creating a second that could drift from it.
+    """
+    runs = "\n".join(step.get("run", "") for step in _steps("coverage-report"))
+    body = re.search(r"<<'FLOORS'\n(.*?)\n\s*FLOORS\b", runs, re.DOTALL)
+    assert body is not None, "the coverage-report job has no FLOORS heredoc"
+    table: Dict[str, int] = {}
+    for line in body.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        path, floor = line.split()
+        table[path] = int(floor)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Coverage floors
+# ---------------------------------------------------------------------------
+
+
+def test_every_floor_names_a_file_that_exists():
+    """A floor whose module moved must move with it, not silently stop biting.
+
+    `coverage report --include` takes an fnmatch pattern, so a stale path is
+    not an error at parse time -- it just selects nothing.
+    """
+    table = _floor_table()
+    assert table, "the floor table is empty"
+    missing = [path for path in table if not (REPO_ROOT / path).is_file()]
+    assert not missing, (
+        f"coverage floors name files that no longer exist: {missing}. If the "
+        f"behaviour moved to mace_core/mace_torch, move the floor with it -- "
+        f"the floor protects the behaviour, not the legacy file."
+    )
+
+
+def test_every_floor_is_a_usable_percentage():
+    for path, floor in _floor_table().items():
+        assert 0 < floor <= 100, f"{path}: {floor} is not a coverage percentage"
+
+
+def test_the_floors_are_enforced_after_the_shards_are_combined():
+    """Not inside a shard, and not in the PR job -- both measure something else.
+
+    A shard holds a third of the suite, so a module exercised entirely by
+    tests that landed in another group would fail its own floor; the ci-core
+    coverage job measures only tests/unit + tests/workflows, a different
+    denominator for the same number.
+    """
+    report_runs = "\n".join(step.get("run", "") for step in _steps("coverage-report"))
+    assert "coverage combine" in report_runs
+    assert report_runs.index("coverage combine") < report_runs.index("--fail-under")
+
+    for job in ("coverage-full", "benchmarks", "workflows-full"):
+        runs = "\n".join(step.get("run", "") for step in _steps(job))
+        assert "--fail-under" not in runs, f"a coverage floor leaked into {job}"
+
+    core = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "ci-core.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    core_runs = "\n".join(
+        step.get("run", "") for step in core["jobs"]["coverage"]["steps"]
+    )
+    assert "--fail-under" not in core_runs, (
+        "the per-PR coverage job is informative by design: it measures the "
+        "deterministic PR slice, which is a different denominator"
+    )
+
+
+def test_the_floor_gate_runs_only_when_every_shard_reported():
+    """`coverage-report` must stay dependent on, and not independent of, the shards.
+
+    Combining a subset of the shards produces a number that reads as the
+    project's while missing whatever the failed shard covered -- and a floor
+    computed on it would fail for the wrong reason.
+    """
+    job = _nightly()["jobs"]["coverage-report"]
+    assert job.get("needs") == "coverage-full"
+    assert "if" not in job, "coverage-report must not run on a partial shard set"
+
+
+# ---------------------------------------------------------------------------
+# Benchmark baseline
+# ---------------------------------------------------------------------------
+
+
+def test_every_declared_benchmark_size_has_a_cpu_runnable_case():
+    from tests.benchmarks.test_inference_cpu import (  # noqa: PLC0415
+        SYSTEM_SIZES,
+        iter_case_marks,
+    )
+
+    runnable = {
+        regime
+        for regime, marks in iter_case_marks()
+        if not marks & {"gpu", "network", "cueq", "oeq"}
+    }
+    missing = set(SYSTEM_SIZES) - runnable
+    assert not missing, (
+        f"no benchmark case a CPU-only nightly can run at sizes "
+        f"{sorted(missing)}: the published artifact would have a hole in it"
+    )
+
+
+def test_the_nightly_benchmarks_job_selects_the_benchmarks_and_can_fail():
+    job = _nightly()["jobs"]["benchmarks"]
+    assert not job.get("continue-on-error"), "a job that cannot fail is not a baseline"
+
+    run_tests = [
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).endswith("actions/run-tests")
+    ]
+    assert len(run_tests) == 1
+    step = run_tests[0]
+    assert not step.get("continue-on-error"), (
+        "continue-on-error on the run-tests step hides exactly the failure "
+        "this baseline exists to notice"
+    )
+    with_ = step.get("with", {})
+    assert "tests/benchmarks" in with_["tests"]
+    # A marker expression here could only narrow the selection, and every
+    # narrowing so far has ended with the artifact empty.
+    assert "benchmark" not in with_.get("markers", "")
+    assert "--benchmark-json" in with_.get("extra-args", "")
+    # pytest-benchmark disables itself under xdist, so a parallel run of this
+    # job would publish an artifact full of nothing.
+    assert str(with_.get("numprocs")) == "0"
+    # Half the baseline is downloaded; a lost network must be red, not half
+    # an artifact.
+    assert "network" in with_.get("require-caps", "")
+    assert with_.get("allow-network") == "true"
+
+    upload = [
+        s for s in job["steps"] if str(s.get("uses", "")).startswith("actions/upload")
+    ]
+    assert len(upload) == 1
+    assert upload[0]["with"].get("if-no-files-found") == "error"
+
+
+def _artifact_check_source() -> str:
+    """The python body of the job's artifact content check, as text."""
+    for step in _steps("benchmarks"):
+        if "actually contain a baseline" in str(step.get("name", "")):
+            body = re.search(r"<<'PY'\n(.*?)\n\s*PY", step["run"], re.DOTALL)
+            assert body is not None, "the content check is not a PY heredoc"
+            return body.group(1)
+    raise AssertionError(
+        "the benchmarks job has no artifact content check: without one the "
+        "job is green whenever every case skips"
+    )
+
+
+def _run_artifact_check(tmp_path: Path, payload) -> int:
+    """Run the job's own check, verbatim, against an artifact we construct."""
+    (tmp_path / "benchmark.json").write_text(
+        "" if payload is None else json.dumps(payload), encoding="utf-8"
+    )
+    (tmp_path / "check.py").write_text(_artifact_check_source(), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, "check.py"], cwd=tmp_path, capture_output=True, check=False
+    ).returncode
+
+
+def _benchmark_entry(regime: str, **overrides) -> dict:
+    info = {
+        "regime": regime,
+        "dtype": "float64",
+        "device": "cpu",
+        "torch_version": "2.11.0",
+        "backend": "e3nn",
+    }
+    info.update(overrides)
+    return {"name": f"test[{regime}]", "extra_info": info}
+
+
+ALL_SIZES = ("subdomain216", "subdomain512", "kernel1728")
+
+
+def test_an_empty_artifact_fails_the_benchmarks_job(tmp_path):
+    """The exact regression: a session where every case skipped.
+
+    `--benchmark-json` is created regardless of what ran, so that session
+    leaves a **0-byte file** -- verified against a real run of
+    tests/benchmarks/test_benchmark.py, whose sixteen parametrizations are all
+    `gpu` and `network`. `if-no-files-found` therefore never fires, and only a
+    check on the contents can tell a baseline from an empty artifact.
+    """
+    assert _run_artifact_check(tmp_path, None) != 0
+    assert _run_artifact_check(tmp_path, {"benchmarks": []}) != 0
+
+
+def test_a_size_hole_fails_the_benchmarks_job(tmp_path):
+    """Skipping is per-parametrization, so "non-empty" is not enough.
+
+    One surviving case would satisfy a bare emptiness check while the size
+    spread the downstream comparison is judged in had quietly gone.
+    """
+    for dropped in ALL_SIZES:
+        kept = [_benchmark_entry(r) for r in ALL_SIZES if r != dropped]
+        assert _run_artifact_check(tmp_path, {"benchmarks": kept}) != 0, (
+            f"an artifact missing the {dropped} size passed the check"
+        )
+    full = [_benchmark_entry(r) for r in ALL_SIZES]
+    assert _run_artifact_check(tmp_path, {"benchmarks": full}) == 0
+
+
+@pytest.mark.parametrize("field", ["dtype", "device", "torch_version", "backend"])
+def test_a_result_without_its_metadata_fails_the_benchmarks_job(tmp_path, field):
+    """A timing whose denominator is unrecorded is not a baseline.
+
+    These four are what the frozen comparison reads back years from now, when
+    the stack that produced the number no longer exists to be asked.
+    """
+    runs = [_benchmark_entry(r) for r in ALL_SIZES]
+    runs[0]["extra_info"][field] = ""
+    assert _run_artifact_check(tmp_path, {"benchmarks": runs}) != 0
+
+
+def test_the_benchmark_cases_record_every_field_the_job_demands():
+    """The producer and the checker must agree, or the job fails every night."""
+    from tests.benchmarks import test_inference_cpu as cases  # noqa: PLC0415
+
+    source = Path(cases.__file__).read_text(encoding="utf-8")
+    for field in ("dtype=", "device=", "torch_version=", "backend=", "regime="):
+        assert field in source, f"benchmark cases never record {field}"
+    assert set(cases.SYSTEM_SIZES) == set(ALL_SIZES), (
+        "the sizes the job demands and the sizes the cases declare have "
+        "diverged: one of them will be a hole"
+    )
+
+
+def test_benchmarks_never_gate_a_correctness_job():
+    """No correctness job may select them, and none may set a perf threshold."""
+    coverage_full = _nightly()["jobs"]["coverage-full"]
+    markers = [
+        step.get("with", {}).get("markers", "")
+        for step in coverage_full["steps"]
+        if str(step.get("uses", "")).endswith("actions/run-tests")
+    ]
+    assert markers and all("not benchmark" in m for m in markers)
+
+    pipeline = GITLAB_PIPELINE.read_text(encoding="utf-8")
+    assert "and not benchmark" in pipeline, (
+        "the GPU pipeline runs -n 2 on a contended shared runner under a 2h "
+        "cap: a timing taken there is noise, and it is a correctness gate"
+    )
+
+    # pytest-benchmark only turns a timing into a pass/fail with an explicit
+    # comparison flag. Nothing may pass one.
+    for text in (NIGHTLY.read_text(encoding="utf-8"), pipeline):
+        assert "--benchmark-compare-fail" not in text

--- a/tests/unit/test_ci_gates.py
+++ b/tests/unit/test_ci_gates.py
@@ -135,6 +135,33 @@ def test_the_floors_are_enforced_after_the_shards_are_combined():
     )
 
 
+def test_the_floors_carry_their_reasoning_in_the_job_that_enforces_them():
+    """A bare list of percentages is not maintainable by anyone but its author.
+
+    Three things have to survive next to the numbers, because each is a
+    question the next person will otherwise answer wrongly: why only these
+    files (the rest is pinned by goldens and contracts, not line coverage),
+    which selection the percentages are measured under (the same floor reads
+    76 or 87 on `mace/modules/utils.py` depending on it), and what to do when
+    a module moves to the new stack (the floor moves with it). Comments are
+    not in the parsed YAML, so this reads the raw file.
+    """
+    text = NIGHTLY.read_text(encoding="utf-8")
+    gate = text[text.index("THE coverage gate") : text.index("<<'FLOORS'")]
+    for topic, needle in (
+        ("why only these files", "WHY ONLY THESE FILES"),
+        ("the migration invariant", "MIGRATION INVARIANT"),
+        ("which selection is measured", "THE SELECTION THESE FLOORS ARE MEASURED"),
+        ("why not in a shard", "shard"),
+        ("why not in the PR job", "denominator"),
+    ):
+        assert needle in gate, (
+            f"the floor gate no longer explains {topic}; the list of "
+            f"percentages has to carry its reasoning or it cannot be "
+            f"maintained, raised or migrated by anyone but whoever wrote it"
+        )
+
+
 def test_the_floor_gate_runs_only_when_every_shard_reported():
     """`coverage-report` must stay dependent on, and not independent of, the shards.
 


### PR DESCRIPTION
Three changes to the nightly, all about making it report something.

The benchmark job has been publishing an empty baseline since it was created. The only test in tests/benchmarks was marked gpu and network, so on the CPU runner all sixteen parametrizations skipped, the job went green, and the uploaded benchmark.json was zero bytes. This adds CPU cases: the committed tiny anchor at three sizes and MP-small at two, both dtypes, with dtype, device, torch version and backend recorded next to every timing.

The per-file coverage floors run after coverage combine, on the combined number rather than on one shard, and each floor names the file it protects. The headroom at the time of writing is recorded in a comment next to the list, including which floors are ratchets against regression and which one is tight.

The magnetic extra is installed in that job because the mace/modules/utils.py floor counts two functions only tests/extensions/magnetic reaches, worth about 8 points against 2 points of headroom.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f82b85dee6d4742f89bc238c021445392f7ac6f6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->