### PR TITLE
Characterize the loss, derivative, E0 and scaling numerics

### DIFF
--- a/tests/golden/anchors.py
+++ b/tests/golden/anchors.py
@@ -1,0 +1,134 @@
+"""Loading the committed anchors, and building the graphs they consume.
+
+`harness.py` may not import the framework, so the two operations every
+anchor-based test starts with -- read the checkpoint, turn an ase structure
+into the batch the forward pass eats -- have to live somewhere else. They
+live here rather than in one test file because five suites now need them
+(`test_tiny_anchors`, the numerics characterization, the train-step gradient
+golden, and the parity work that follows), and a second copy of `_batch` is
+exactly how two suites end up silently measuring different things.
+
+The one subtlety worth reading before copying this code: **the graph is built
+inside a `default_dtype` scope, not cast afterwards.** `AtomicData` reads the
+process-wide default dtype, which is float32 under pytest. Building in float32
+and casting up rounds the positions first, and the anchor then reproduces its
+own reference only to about 2e-8 relative -- under the fp64 row, so it reads
+as agreement, while making a bit-exact comparison impossible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Sequence
+
+import torch
+from ase import Atoms
+
+from mace import data
+from mace.tools import torch_geometric, torch_tools, utils
+
+from . import harness
+
+#: anchor name -> where its pieces live and what class it must be.
+ANCHORS: Dict[str, dict] = {
+    "tiny_scaleshift": {
+        "model": harness.MODELS_DIR / "tiny_scaleshift.model",
+        "sidecar": harness.MODELS_DIR / "tiny_scaleshift.build.json",
+        "reference": harness.REFERENCES_DIR / "tiny_scaleshift_e3nn_cpu_fp64.json",
+        "class": "ScaleShiftMACE",
+    },
+    "tiny_mace": {
+        "model": harness.MODELS_DIR / "tiny_mace.model",
+        "sidecar": harness.MODELS_DIR / "tiny_mace.build.json",
+        "reference": harness.REFERENCES_DIR / "tiny_mace_e3nn_cpu_fp64.json",
+        "class": "MACE",
+    },
+}
+
+#: the seeded synthetic training set the trainable anchor was fitted on. Not
+#: an evaluation fixture -- it is the only committed structure set that
+#: carries reference labels, so it is what a loss or a gradient is taken on.
+TRAIN_SET = harness.FIXTURES_DIR / "tiny_train.xyz"
+
+
+def anchor_path(name: str) -> Path:
+    return ANCHORS[name]["model"]
+
+
+def load_anchor(name: str, dtype: torch.dtype = torch.float64) -> torch.nn.Module:
+    """Read a committed anchor checkpoint and cast it to ``dtype``."""
+    model = torch.load(anchor_path(name), weights_only=False, map_location="cpu")
+    return model.to(dtype)
+
+
+def _dtype_name(dtype: torch.dtype) -> str:
+    return {torch.float32: "float32", torch.float64: "float64"}[dtype]
+
+
+def anchor_batch(
+    model: torch.nn.Module,
+    structures: Sequence[Atoms],
+    dtype: torch.dtype = torch.float64,
+):
+    """Collate ``structures`` into the Batch ``model`` consumes.
+
+    The Batch object itself, not its dict: the loss functions read `ref.ptr`
+    and the per-config weights off the batch, and only the forward pass wants
+    the dict.
+    """
+    z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
+    with torch_tools.default_dtype(_dtype_name(dtype)):
+        graphs = [
+            data.AtomicData.from_config(
+                data.config_from_atoms(atoms),
+                z_table=z_table,
+                cutoff=float(model.r_max),
+            )
+            for atoms in structures
+        ]
+        loader = torch_geometric.dataloader.DataLoader(
+            graphs, batch_size=len(graphs), shuffle=False
+        )
+        batch = next(iter(loader))
+    return batch
+
+
+def anchor_graph(
+    model: torch.nn.Module,
+    atoms: Atoms,
+    dtype: torch.dtype = torch.float64,
+) -> Dict[str, torch.Tensor]:
+    """One structure as the input dict of ``model.forward``.
+
+    The trailing cast is belt and braces for any tensor the `default_dtype`
+    scope does not reach; the scope is what makes the numbers right.
+    """
+    graph = anchor_batch(model, [atoms], dtype).to_dict()
+    return {
+        key: (
+            value.to(dtype)
+            if torch.is_tensor(value) and torch.is_floating_point(value)
+            else value
+        )
+        for key, value in graph.items()
+    }
+
+
+def load_training_structures(
+    *, isolated_atoms: bool = False, limit: int | None = None
+) -> list:
+    """Read `fixtures/tiny_train.xyz`, by default without the isolated atoms.
+
+    The three single-atom configurations carry no neighbours and no forces
+    worth fitting; they are there so the E0 extraction has something to find,
+    which is a different test's business.
+    """
+    from ase.io import read  # noqa: PLC0415  (ase.io pulls in a lot)
+
+    structures: Iterable[Atoms] = read(TRAIN_SET, ":")
+    kept = [
+        atoms
+        for atoms in structures
+        if isolated_atoms or atoms.info.get("config_type") != "IsolatedAtom"
+    ]
+    return kept if limit is None else kept[:limit]

--- a/tests/golden/anchors.py
+++ b/tests/golden/anchors.py
@@ -8,12 +8,24 @@ live here rather than in one test file because five suites now need them
 golden, and the parity work that follows), and a second copy of `_batch` is
 exactly how two suites end up silently measuring different things.
 
-The one subtlety worth reading before copying this code: **the graph is built
-inside a `default_dtype` scope, not cast afterwards.** `AtomicData` reads the
-process-wide default dtype, which is float32 under pytest. Building in float32
-and casting up rounds the positions first, and the anchor then reproduces its
-own reference only to about 2e-8 relative -- under the fp64 row, so it reads
-as agreement, while making a bit-exact comparison impossible.
+Two subtleties worth reading before copying this code.
+
+**The graph is built inside a `default_dtype` scope, not cast afterwards.**
+`AtomicData` reads the process-wide default dtype, which is float32 under
+pytest. Building in float32 and casting up rounds the positions first, and the
+anchor then reproduces its own reference only to about 2e-8 relative -- under
+the fp64 row, so it reads as agreement, while making a bit-exact comparison
+impossible.
+
+**`KeySpecification.from_defaults()` is passed explicitly, because the default
+argument is an empty one.** `config_from_atoms` defaults to a bare
+`KeySpecification()` (mace/data/utils.py:174), which reads no property out of
+the structure at all, and `AtomicData.from_config` then falls back to
+`energy = 0.0` and `forces = zeros` (mace/data/atomic_data.py:308-321) while
+the matching weights fall back to 1.0 -- so a loss taken on that batch is the
+loss against zero labels, at full weight, with nothing to distinguish it from
+the real one but its value. `from_defaults()` maps the `REF_energy` /
+`REF_forces` keys `fixtures/tiny_train.xyz` actually carries.
 """
 
 from __future__ import annotations
@@ -25,6 +37,7 @@ import torch
 from ase import Atoms
 
 from mace import data
+from mace.data.utils import KeySpecification
 from mace.tools import torch_geometric, torch_tools, utils
 
 from . import harness
@@ -80,7 +93,7 @@ def anchor_batch(
     with torch_tools.default_dtype(_dtype_name(dtype)):
         graphs = [
             data.AtomicData.from_config(
-                data.config_from_atoms(atoms),
+                data.config_from_atoms(atoms, KeySpecification.from_defaults()),
                 z_table=z_table,
                 cutoff=float(model.r_max),
             )

--- a/tests/golden/docs/gradients.md
+++ b/tests/golden/docs/gradients.md
@@ -1,0 +1,37 @@
+# The gradient goldens
+
+Target: `gradients`, part of `all`.
+
+`references/tiny_{scaleshift,mace}_train_step_grad_fp64.json` hold one
+forward+backward of an energy+forces loss on the first four labelled
+structures of `fixtures/tiny_train.xyz`, at fp64 on CPU, with the committed
+weights — so the numbers depend on nothing that was randomly drawn. They
+exist because a loss-decrease smoke test and a final-error table are both
+green while `d(loss)/d(theta)` is wrong by the size of initialisation noise.
+
+What is committed is a **digest**, not the 37,704-element gradient vector:
+per parameter, its shape and count plus `sum`, `abs_sum`, `sq_sum` and
+`sum_k g_k·cos(k+1)`. The raw vectors would be about 1.5 MB in every clone —
+more than both checkpoints together — and unreadable in a diff. The four
+reductions are chosen so nothing plausible survives all of them: the sum
+catches a sign flip, the other two a magnitude change that cancels in the
+sum, and the positional projection catches a **permutation**, which the first
+four cannot see at all and which is what an irreps-layout mistake produces.
+`cos` of an integer rather than a seeded vector, so a reimplementation in
+another framework can reproduce it without sharing an RNG.
+
+Measured resolution: the response is linear with a gain of 0.49, so at the
+1e-6 row the golden resolves a change of about 2e-6 in a single weight, six
+orders below the weights themselves. A test asserts that, and another asserts
+the permutation claim, rather than leaving either as a paragraph.
+
+The same run records `gradcheck`/`gradgradcheck` pass-flags for the position
+and strain derivatives, at the fp64 row rather than at torch's much looser
+defaults.
+
+This family consumes the anchors it digests rather than owning them; it reads
+them through the shared anchor registry.
+
+## Running
+
+No marker; runs in the ci-core `unit` job with everything else.

--- a/tests/golden/docs/gradients.md
+++ b/tests/golden/docs/gradients.md
@@ -20,7 +20,7 @@ four cannot see at all and which is what an irreps-layout mistake produces.
 `cos` of an integer rather than a seeded vector, so a reimplementation in
 another framework can reproduce it without sharing an RNG.
 
-Measured resolution: the response is linear with a gain of 0.49, so at the
+Measured resolution: the response is linear with a gain of 0.57, so at the
 1e-6 row the golden resolves a change of about 2e-6 in a single weight, six
 orders below the weights themselves. A test asserts that, and another asserts
 the permutation claim, rather than leaving either as a paragraph.

--- a/tests/golden/references/tiny_mace_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_mace_train_step_grad_fp64.json
@@ -2,7 +2,7 @@
   "backend": "e3nn",
   "device": "cpu",
   "dtype": "float64",
-  "global_gradient_norm": 1.4837363748044736,
+  "global_gradient_norm": 1.3171696106763509,
   "gradcheck": {
     "gradcheck_positions": true,
     "gradcheck_strain": true,
@@ -10,7 +10,7 @@
     "gradgradcheck_strain": true
   },
   "kind": "train_step_gradient",
-  "loss": 21.446199390111943,
+  "loss": 24.723692968766137,
   "metadata": {
     "loss": "WeightedEnergyForcesLoss",
     "loss_weights": {
@@ -26,320 +26,320 @@
   "n_elements": 37704,
   "parameters": {
     "interactions.0.conv_tp_weights.layer0.weight": {
-      "abs_sum": 7.579726721026498,
+      "abs_sum": 6.319428825870839,
       "count": 512,
-      "projection": 0.4791740978093222,
+      "projection": 0.44472347670545276,
       "shape": [
         8,
         64
       ],
-      "sq_sum": 0.2944893357438082,
-      "sum": -0.19263668292707528
+      "sq_sum": 0.20160784769931583,
+      "sum": -0.18997803941908892
     },
     "interactions.0.conv_tp_weights.layer1.weight": {
-      "abs_sum": 16.303927832694853,
+      "abs_sum": 13.833957785627442,
       "count": 4096,
-      "projection": -0.1614301925299697,
+      "projection": 0.021013464349724648,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.1866902487771301,
-      "sum": 2.988583159841702
+      "sq_sum": 0.1292873228115174,
+      "sum": 2.512040442898427
     },
     "interactions.0.conv_tp_weights.layer2.weight": {
-      "abs_sum": 11.817187418224133,
+      "abs_sum": 10.157282996131347,
       "count": 4096,
-      "projection": 0.20639028046584085,
+      "projection": 0.10776017442424035,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.1165743155333454,
-      "sum": 1.9960022896061387
+      "sq_sum": 0.08394589600139193,
+      "sum": 1.7525880505121019
     },
     "interactions.0.conv_tp_weights.layer3.weight": {
-      "abs_sum": 6.095719754492556,
+      "abs_sum": 5.497110282875777,
       "count": 3072,
-      "projection": -0.013652315993947159,
+      "projection": -0.07121129329884561,
       "shape": [
         64,
         48
       ],
-      "sq_sum": 0.06608664114087898,
-      "sum": -0.11203072563657374
+      "sq_sum": 0.050669036317179506,
+      "sum": -0.07605038224898902
     },
     "interactions.0.linear.weight": {
-      "abs_sum": 5.530141368385257,
+      "abs_sum": 4.907302867731019,
       "count": 768,
-      "projection": -0.24908815298845455,
+      "projection": -0.21626451246534098,
       "shape": [
         768
       ],
-      "sq_sum": 0.2717234371644226,
-      "sum": -0.32794509184236964
+      "sq_sum": 0.18796159338890506,
+      "sum": -0.3043713430198708
     },
     "interactions.0.linear_up.weight": {
-      "abs_sum": 3.4659149575666426,
+      "abs_sum": 3.2620582614336477,
       "count": 256,
-      "projection": -0.18170104512277127,
+      "projection": -0.18003883485439082,
       "shape": [
         256
       ],
-      "sq_sum": 0.11239724897480868,
-      "sum": -0.4587006644087656
+      "sq_sum": 0.09730369092301402,
+      "sum": -0.34459169512989396
     },
     "interactions.0.skip_tp.weight": {
-      "abs_sum": 9.655222284958768,
+      "abs_sum": 8.874599965953632,
       "count": 2304,
-      "projection": -0.6516244553199896,
+      "projection": -0.7118469692231979,
       "shape": [
         2304
       ],
-      "sq_sum": 0.2984424481733429,
-      "sum": 0.3070199627924519
+      "sq_sum": 0.25616877004654365,
+      "sum": 0.3169792834920432
     },
     "interactions.1.conv_tp_weights.layer0.weight": {
-      "abs_sum": 0.565573900601701,
+      "abs_sum": 0.46377874195377106,
       "count": 512,
-      "projection": -0.018232172844689143,
+      "projection": 0.003557809025407012,
       "shape": [
         8,
         64
       ],
-      "sq_sum": 0.0013220694569538016,
-      "sum": 0.019053945576894944
+      "sq_sum": 0.0009163680219055518,
+      "sum": 0.020099579887882055
     },
     "interactions.1.conv_tp_weights.layer1.weight": {
-      "abs_sum": 1.1567827287295407,
+      "abs_sum": 0.9714821469554223,
       "count": 4096,
-      "projection": 0.006797947620981204,
+      "projection": 0.005955541736772447,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.0008232223316660703,
-      "sum": -0.047262723943173136
+      "sq_sum": 0.0005609712645350037,
+      "sum": -0.007150619968668111
     },
     "interactions.1.conv_tp_weights.layer2.weight": {
-      "abs_sum": 1.310671672980143,
+      "abs_sum": 1.073136013070855,
       "count": 4096,
-      "projection": 0.01756955865355666,
+      "projection": 0.0210534156385648,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.0010461953141431548,
-      "sum": -0.06286670074782777
+      "sq_sum": 0.0006950949630121787,
+      "sum": -0.027349008990623213
     },
     "interactions.1.conv_tp_weights.layer3.weight": {
-      "abs_sum": 0.9255407692114992,
+      "abs_sum": 0.7585535320220602,
       "count": 7168,
-      "projection": 0.0076635233990586995,
+      "projection": 0.009889453687680794,
       "shape": [
         64,
         112
       ],
-      "sq_sum": 0.0010460975268065144,
-      "sum": 0.02339343340235857
+      "sq_sum": 0.000704192792885085,
+      "sum": 0.00956977136207154
     },
     "interactions.1.linear.weight": {
-      "abs_sum": 0.3716441587126341,
+      "abs_sum": 0.300326251207717,
       "count": 1792,
-      "projection": -7.4392200217774165e-06,
+      "projection": 0.00306931965217726,
       "shape": [
         1792
       ],
-      "sq_sum": 0.0012717517061730924,
-      "sum": 0.008111816340977285
+      "sq_sum": 0.0008011041614917982,
+      "sum": 0.007330266115359961
     },
     "interactions.1.linear_up.weight": {
-      "abs_sum": 0.5656088436258349,
+      "abs_sum": 0.47616440471634836,
       "count": 512,
-      "projection": -0.051277383738121574,
+      "projection": -0.031005120862511823,
       "shape": [
         512
       ],
-      "sq_sum": 0.002004667122673079,
-      "sum": 0.02580043210300491
+      "sq_sum": 0.0012675716552094146,
+      "sum": 0.014333561599688592
     },
     "interactions.1.skip_tp.weight": {
-      "abs_sum": 3.1439778570388075,
+      "abs_sum": 2.983048916321393,
       "count": 768,
-      "projection": -0.22759340838036757,
+      "projection": -0.21607064443313423,
       "shape": [
         768
       ],
-      "sq_sum": 0.04424365199044607,
-      "sum": -0.3395329261158733
+      "sq_sum": 0.04049900569783452,
+      "sum": -0.3107262296678711
     },
     "node_embedding.linear.weight": {
-      "abs_sum": 1.8415494330086428,
+      "abs_sum": 1.669073753003537,
       "count": 48,
-      "projection": 0.039953263422138355,
+      "projection": 0.032511598123534075,
       "shape": [
         48
       ],
-      "sq_sum": 0.10179846865517322,
-      "sum": -1.2047772749766028
+      "sq_sum": 0.08479060579726687,
+      "sum": -1.0883982688367986
     },
     "products.0.linear.weight": {
-      "abs_sum": 4.712577323139607,
+      "abs_sum": 4.4628793872715,
       "count": 512,
-      "projection": 0.21683820669102094,
+      "projection": 0.1725189885863865,
       "shape": [
         512
       ],
-      "sq_sum": 0.2527919407219787,
-      "sum": -0.05150002698505271
+      "sq_sum": 0.21483313844759494,
+      "sum": -0.056620360334816336
     },
     "products.0.symmetric_contractions.contractions.0.weights.0": {
-      "abs_sum": 0.8013865962794775,
+      "abs_sum": 0.6917236566587929,
       "count": 144,
-      "projection": 0.0004136127347637575,
+      "projection": -0.005301030020950739,
       "shape": [
         3,
         3,
         16
       ],
-      "sq_sum": 0.03448367107194492,
-      "sum": -0.21188778186638155
+      "sq_sum": 0.025399295103056614,
+      "sum": -0.19013639660002252
     },
     "products.0.symmetric_contractions.contractions.0.weights.1": {
-      "abs_sum": 1.9248755420361099,
+      "abs_sum": 1.8614180891078345,
       "count": 48,
-      "projection": -0.23432743511420734,
+      "projection": -0.15638708038688787,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.2133672338893482,
-      "sum": -0.21882640579103504
+      "sq_sum": 0.19693101421564338,
+      "sum": -0.26998435856101666
     },
     "products.0.symmetric_contractions.contractions.0.weights_max": {
-      "abs_sum": 0.15168778638926933,
+      "abs_sum": 0.12653759580996612,
       "count": 528,
-      "projection": -0.025630957354638363,
+      "projection": -0.02120415589826926,
       "shape": [
         3,
         11,
         16
       ],
-      "sq_sum": 0.0006972449325916752,
-      "sum": -0.0077643189855160005
+      "sq_sum": 0.0004878789754982739,
+      "sum": -0.008617032353705728
     },
     "products.0.symmetric_contractions.contractions.1.weights.0": {
-      "abs_sum": 0.025955595764591215,
+      "abs_sum": 0.02150047235281103,
       "count": 192,
-      "projection": 0.0007966617123929662,
+      "projection": 0.0006103927935743618,
       "shape": [
         3,
         4,
         16
       ],
-      "sq_sum": 1.0903347140927417e-05,
-      "sum": -0.0001999669732007292
+      "sq_sum": 7.351161286516038e-06,
+      "sum": 0.0003934245883528576
     },
     "products.0.symmetric_contractions.contractions.1.weights.1": {
-      "abs_sum": 0.17201522227926025,
+      "abs_sum": 0.12320246291840056,
       "count": 48,
-      "projection": 0.030637118529905236,
+      "projection": 0.01963835748867517,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.0011532818607436364,
-      "sum": 0.02960756159362981
+      "sq_sum": 0.0006088692928685974,
+      "sum": 0.031593024098252466
     },
     "products.0.symmetric_contractions.contractions.1.weights_max": {
-      "abs_sum": 0.006910614815434594,
+      "abs_sum": 0.006131065085020816,
       "count": 1008,
-      "projection": 0.0001352070107919197,
+      "projection": 9.9207621932206e-05,
       "shape": [
         3,
         21,
         16
       ],
-      "sq_sum": 4.109264485826953e-07,
-      "sum": -0.0002459245952049435
+      "sq_sum": 3.2460454429558395e-07,
+      "sum": -0.00015768166123611318
     },
     "products.1.linear.weight": {
-      "abs_sum": 0.4677842060508822,
+      "abs_sum": 0.31568822992905743,
       "count": 256,
-      "projection": -0.013958510944570998,
+      "projection": -0.008981678461337062,
       "shape": [
         256
       ],
-      "sq_sum": 0.002096918774866827,
-      "sum": 0.08919375386349995
+      "sq_sum": 0.0009416201170864774,
+      "sum": 0.060234684364244666
     },
     "products.1.symmetric_contractions.contractions.0.weights.0": {
-      "abs_sum": 0.0028631810702954433,
+      "abs_sum": 0.0026322075762417307,
       "count": 144,
-      "projection": -0.0007873431208965319,
+      "projection": -0.0007224068100614193,
       "shape": [
         3,
         3,
         16
       ],
-      "sq_sum": 3.2230107985675865e-07,
-      "sum": 0.0012929822430242334
+      "sq_sum": 2.5251591592984465e-07,
+      "sum": 0.001254752533560361
     },
     "products.1.symmetric_contractions.contractions.0.weights.1": {
-      "abs_sum": 0.14208266940507225,
+      "abs_sum": 0.11424604146022257,
       "count": 48,
-      "projection": 0.027579490982234188,
+      "projection": 0.00497721852257129,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.0012516006619358463,
-      "sum": 0.026195431383905416
+      "sq_sum": 0.0008960105252983465,
+      "sum": 0.028055832296053244
     },
     "products.1.symmetric_contractions.contractions.0.weights_max": {
-      "abs_sum": 4.201740106961678e-05,
+      "abs_sum": 3.633692182454232e-05,
       "count": 528,
-      "projection": -2.1960108588284427e-06,
+      "projection": -1.7930559284438015e-06,
       "shape": [
         3,
         11,
         16
       ],
-      "sq_sum": 2.9741070638510967e-11,
-      "sum": 7.582947503225005e-06
+      "sq_sum": 2.115569564904448e-11,
+      "sum": 6.7691527446194284e-06
     },
     "readouts.0.linear.weight": {
-      "abs_sum": 0.9985218925568662,
+      "abs_sum": 0.9206585058890172,
       "count": 16,
-      "projection": -0.22244647887040547,
+      "projection": -0.15866415043112714,
       "shape": [
         16
       ],
-      "sq_sum": 0.1164356191375385,
-      "sum": -0.36317158745622913
+      "sq_sum": 0.09931956738573507,
+      "sum": -0.33148713129442764
     },
     "readouts.1.linear_1.weight": {
-      "abs_sum": 1.2756563469516053,
+      "abs_sum": 1.0806096022246607,
       "count": 128,
-      "projection": -0.014796318462983585,
+      "projection": -0.0062879628363154555,
       "shape": [
         128
       ],
-      "sq_sum": 0.03792477457540829,
-      "sum": -0.3504556813543211
+      "sq_sum": 0.029664320118432994,
+      "sum": -0.3155355247337176
     },
     "readouts.1.linear_2.weight": {
-      "abs_sum": 0.47250957770474133,
+      "abs_sum": 0.4017072273273972,
       "count": 8,
-      "projection": 0.23909228803729976,
+      "projection": 0.18155156955885096,
       "shape": [
         8
       ],
-      "sq_sum": 0.041299908075382225,
-      "sum": 0.009423630698315283
+      "sq_sum": 0.028667069263164556,
+      "sum": 0.018021989171437644
     }
   },
   "parameters_without_a_gradient": [],

--- a/tests/golden/references/tiny_mace_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_mace_train_step_grad_fp64.json
@@ -1,0 +1,358 @@
+{
+  "backend": "e3nn",
+  "device": "cpu",
+  "dtype": "float64",
+  "global_gradient_norm": 1.4837363748044736,
+  "gradcheck": {
+    "gradcheck_positions": true,
+    "gradcheck_strain": true,
+    "gradgradcheck_positions": true,
+    "gradgradcheck_strain": true
+  },
+  "kind": "train_step_gradient",
+  "loss": 21.446199390111943,
+  "metadata": {
+    "loss": "WeightedEnergyForcesLoss",
+    "loss_weights": {
+      "energy_weight": 1.0,
+      "forces_weight": 10.0
+    },
+    "model": "tiny_mace.model",
+    "model_class": "MACE",
+    "projection": "sum_k g_k * cos(k + 1), C-order flattening",
+    "seed": 20260810,
+    "structures": "first 4 non-isolated configurations of fixtures/tiny_train.xyz"
+  },
+  "n_elements": 37704,
+  "parameters": {
+    "interactions.0.conv_tp_weights.layer0.weight": {
+      "abs_sum": 7.579726721026498,
+      "count": 512,
+      "projection": 0.4791740978093222,
+      "shape": [
+        8,
+        64
+      ],
+      "sq_sum": 0.2944893357438082,
+      "sum": -0.19263668292707528
+    },
+    "interactions.0.conv_tp_weights.layer1.weight": {
+      "abs_sum": 16.303927832694853,
+      "count": 4096,
+      "projection": -0.1614301925299697,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.1866902487771301,
+      "sum": 2.988583159841702
+    },
+    "interactions.0.conv_tp_weights.layer2.weight": {
+      "abs_sum": 11.817187418224133,
+      "count": 4096,
+      "projection": 0.20639028046584085,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.1165743155333454,
+      "sum": 1.9960022896061387
+    },
+    "interactions.0.conv_tp_weights.layer3.weight": {
+      "abs_sum": 6.095719754492556,
+      "count": 3072,
+      "projection": -0.013652315993947159,
+      "shape": [
+        64,
+        48
+      ],
+      "sq_sum": 0.06608664114087898,
+      "sum": -0.11203072563657374
+    },
+    "interactions.0.linear.weight": {
+      "abs_sum": 5.530141368385257,
+      "count": 768,
+      "projection": -0.24908815298845455,
+      "shape": [
+        768
+      ],
+      "sq_sum": 0.2717234371644226,
+      "sum": -0.32794509184236964
+    },
+    "interactions.0.linear_up.weight": {
+      "abs_sum": 3.4659149575666426,
+      "count": 256,
+      "projection": -0.18170104512277127,
+      "shape": [
+        256
+      ],
+      "sq_sum": 0.11239724897480868,
+      "sum": -0.4587006644087656
+    },
+    "interactions.0.skip_tp.weight": {
+      "abs_sum": 9.655222284958768,
+      "count": 2304,
+      "projection": -0.6516244553199896,
+      "shape": [
+        2304
+      ],
+      "sq_sum": 0.2984424481733429,
+      "sum": 0.3070199627924519
+    },
+    "interactions.1.conv_tp_weights.layer0.weight": {
+      "abs_sum": 0.565573900601701,
+      "count": 512,
+      "projection": -0.018232172844689143,
+      "shape": [
+        8,
+        64
+      ],
+      "sq_sum": 0.0013220694569538016,
+      "sum": 0.019053945576894944
+    },
+    "interactions.1.conv_tp_weights.layer1.weight": {
+      "abs_sum": 1.1567827287295407,
+      "count": 4096,
+      "projection": 0.006797947620981204,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.0008232223316660703,
+      "sum": -0.047262723943173136
+    },
+    "interactions.1.conv_tp_weights.layer2.weight": {
+      "abs_sum": 1.310671672980143,
+      "count": 4096,
+      "projection": 0.01756955865355666,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.0010461953141431548,
+      "sum": -0.06286670074782777
+    },
+    "interactions.1.conv_tp_weights.layer3.weight": {
+      "abs_sum": 0.9255407692114992,
+      "count": 7168,
+      "projection": 0.0076635233990586995,
+      "shape": [
+        64,
+        112
+      ],
+      "sq_sum": 0.0010460975268065144,
+      "sum": 0.02339343340235857
+    },
+    "interactions.1.linear.weight": {
+      "abs_sum": 0.3716441587126341,
+      "count": 1792,
+      "projection": -7.4392200217774165e-06,
+      "shape": [
+        1792
+      ],
+      "sq_sum": 0.0012717517061730924,
+      "sum": 0.008111816340977285
+    },
+    "interactions.1.linear_up.weight": {
+      "abs_sum": 0.5656088436258349,
+      "count": 512,
+      "projection": -0.051277383738121574,
+      "shape": [
+        512
+      ],
+      "sq_sum": 0.002004667122673079,
+      "sum": 0.02580043210300491
+    },
+    "interactions.1.skip_tp.weight": {
+      "abs_sum": 3.1439778570388075,
+      "count": 768,
+      "projection": -0.22759340838036757,
+      "shape": [
+        768
+      ],
+      "sq_sum": 0.04424365199044607,
+      "sum": -0.3395329261158733
+    },
+    "node_embedding.linear.weight": {
+      "abs_sum": 1.8415494330086428,
+      "count": 48,
+      "projection": 0.039953263422138355,
+      "shape": [
+        48
+      ],
+      "sq_sum": 0.10179846865517322,
+      "sum": -1.2047772749766028
+    },
+    "products.0.linear.weight": {
+      "abs_sum": 4.712577323139607,
+      "count": 512,
+      "projection": 0.21683820669102094,
+      "shape": [
+        512
+      ],
+      "sq_sum": 0.2527919407219787,
+      "sum": -0.05150002698505271
+    },
+    "products.0.symmetric_contractions.contractions.0.weights.0": {
+      "abs_sum": 0.8013865962794775,
+      "count": 144,
+      "projection": 0.0004136127347637575,
+      "shape": [
+        3,
+        3,
+        16
+      ],
+      "sq_sum": 0.03448367107194492,
+      "sum": -0.21188778186638155
+    },
+    "products.0.symmetric_contractions.contractions.0.weights.1": {
+      "abs_sum": 1.9248755420361099,
+      "count": 48,
+      "projection": -0.23432743511420734,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.2133672338893482,
+      "sum": -0.21882640579103504
+    },
+    "products.0.symmetric_contractions.contractions.0.weights_max": {
+      "abs_sum": 0.15168778638926933,
+      "count": 528,
+      "projection": -0.025630957354638363,
+      "shape": [
+        3,
+        11,
+        16
+      ],
+      "sq_sum": 0.0006972449325916752,
+      "sum": -0.0077643189855160005
+    },
+    "products.0.symmetric_contractions.contractions.1.weights.0": {
+      "abs_sum": 0.025955595764591215,
+      "count": 192,
+      "projection": 0.0007966617123929662,
+      "shape": [
+        3,
+        4,
+        16
+      ],
+      "sq_sum": 1.0903347140927417e-05,
+      "sum": -0.0001999669732007292
+    },
+    "products.0.symmetric_contractions.contractions.1.weights.1": {
+      "abs_sum": 0.17201522227926025,
+      "count": 48,
+      "projection": 0.030637118529905236,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.0011532818607436364,
+      "sum": 0.02960756159362981
+    },
+    "products.0.symmetric_contractions.contractions.1.weights_max": {
+      "abs_sum": 0.006910614815434594,
+      "count": 1008,
+      "projection": 0.0001352070107919197,
+      "shape": [
+        3,
+        21,
+        16
+      ],
+      "sq_sum": 4.109264485826953e-07,
+      "sum": -0.0002459245952049435
+    },
+    "products.1.linear.weight": {
+      "abs_sum": 0.4677842060508822,
+      "count": 256,
+      "projection": -0.013958510944570998,
+      "shape": [
+        256
+      ],
+      "sq_sum": 0.002096918774866827,
+      "sum": 0.08919375386349995
+    },
+    "products.1.symmetric_contractions.contractions.0.weights.0": {
+      "abs_sum": 0.0028631810702954433,
+      "count": 144,
+      "projection": -0.0007873431208965319,
+      "shape": [
+        3,
+        3,
+        16
+      ],
+      "sq_sum": 3.2230107985675865e-07,
+      "sum": 0.0012929822430242334
+    },
+    "products.1.symmetric_contractions.contractions.0.weights.1": {
+      "abs_sum": 0.14208266940507225,
+      "count": 48,
+      "projection": 0.027579490982234188,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.0012516006619358463,
+      "sum": 0.026195431383905416
+    },
+    "products.1.symmetric_contractions.contractions.0.weights_max": {
+      "abs_sum": 4.201740106961678e-05,
+      "count": 528,
+      "projection": -2.1960108588284427e-06,
+      "shape": [
+        3,
+        11,
+        16
+      ],
+      "sq_sum": 2.9741070638510967e-11,
+      "sum": 7.582947503225005e-06
+    },
+    "readouts.0.linear.weight": {
+      "abs_sum": 0.9985218925568662,
+      "count": 16,
+      "projection": -0.22244647887040547,
+      "shape": [
+        16
+      ],
+      "sq_sum": 0.1164356191375385,
+      "sum": -0.36317158745622913
+    },
+    "readouts.1.linear_1.weight": {
+      "abs_sum": 1.2756563469516053,
+      "count": 128,
+      "projection": -0.014796318462983585,
+      "shape": [
+        128
+      ],
+      "sq_sum": 0.03792477457540829,
+      "sum": -0.3504556813543211
+    },
+    "readouts.1.linear_2.weight": {
+      "abs_sum": 0.47250957770474133,
+      "count": 8,
+      "projection": 0.23909228803729976,
+      "shape": [
+        8
+      ],
+      "sq_sum": 0.041299908075382225,
+      "sum": 0.009423630698315283
+    }
+  },
+  "parameters_without_a_gradient": [],
+  "provenance": {
+    "description": "One forward+backward of an energy+forces loss on the tiny_mace anchor, reduced to a per-parameter gradient digest. Legacy characterization: what FM-00 must reproduce and what PAR-1 diffs legacy against v1.",
+    "evaluated_with": "e3nn, CPU, float64",
+    "recipe": "tests/golden/train_step.py",
+    "source": "tests/golden/models/tiny_mace.model",
+    "tolerance_row": "fp64_cpu_reference"
+  },
+  "schema_version": 1,
+  "units": {
+    "energy": "eV",
+    "length": "Ang"
+  }
+}

--- a/tests/golden/references/tiny_mace_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_mace_train_step_grad_fp64.json
@@ -344,7 +344,7 @@
   },
   "parameters_without_a_gradient": [],
   "provenance": {
-    "description": "One forward+backward of an energy+forces loss on the tiny_mace anchor, reduced to a per-parameter gradient digest. Legacy characterization: what FM-00 must reproduce and what PAR-1 diffs legacy against v1.",
+    "description": "One forward+backward of an energy+forces loss on the tiny_mace anchor, reduced to a per-parameter gradient digest. A rewrite of the training path has to reproduce these, and a rewrite that changes them has to say which gradient moved and why.",
     "evaluated_with": "e3nn, CPU, float64",
     "recipe": "tests/golden/train_step.py",
     "source": "tests/golden/models/tiny_mace.model",

--- a/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
@@ -1,0 +1,358 @@
+{
+  "backend": "e3nn",
+  "device": "cpu",
+  "dtype": "float64",
+  "global_gradient_norm": 0.4377097960821653,
+  "gradcheck": {
+    "gradcheck_positions": true,
+    "gradcheck_strain": true,
+    "gradgradcheck_positions": true,
+    "gradgradcheck_strain": true
+  },
+  "kind": "train_step_gradient",
+  "loss": 0.3584699958726426,
+  "metadata": {
+    "loss": "WeightedEnergyForcesLoss",
+    "loss_weights": {
+      "energy_weight": 1.0,
+      "forces_weight": 10.0
+    },
+    "model": "tiny_scaleshift.model",
+    "model_class": "ScaleShiftMACE",
+    "projection": "sum_k g_k * cos(k + 1), C-order flattening",
+    "seed": 20260810,
+    "structures": "first 4 non-isolated configurations of fixtures/tiny_train.xyz"
+  },
+  "n_elements": 37704,
+  "parameters": {
+    "interactions.0.conv_tp_weights.layer0.weight": {
+      "abs_sum": 2.788001409830277,
+      "count": 512,
+      "projection": 0.29285179229097236,
+      "shape": [
+        8,
+        64
+      ],
+      "sq_sum": 0.03129154858235829,
+      "sum": -0.020248448345735914
+    },
+    "interactions.0.conv_tp_weights.layer1.weight": {
+      "abs_sum": 5.1455542993409615,
+      "count": 4096,
+      "projection": 0.15923329937075062,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.018549962767202,
+      "sum": 0.5946572928278898
+    },
+    "interactions.0.conv_tp_weights.layer2.weight": {
+      "abs_sum": 3.9821481731392576,
+      "count": 4096,
+      "projection": -0.1126011213402125,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.010485735855425704,
+      "sum": 0.3155110335284571
+    },
+    "interactions.0.conv_tp_weights.layer3.weight": {
+      "abs_sum": 2.3003616810816023,
+      "count": 3072,
+      "projection": -0.012218285398300246,
+      "shape": [
+        64,
+        48
+      ],
+      "sq_sum": 0.007152167210762705,
+      "sum": 0.022619127751047227
+    },
+    "interactions.0.linear.weight": {
+      "abs_sum": 1.4586242662695963,
+      "count": 768,
+      "projection": -0.1895658916812491,
+      "shape": [
+        768
+      ],
+      "sq_sum": 0.01231614908713416,
+      "sum": 0.15922816743314697
+    },
+    "interactions.0.linear_up.weight": {
+      "abs_sum": 0.9215719698673027,
+      "count": 256,
+      "projection": 0.026590297800401987,
+      "shape": [
+        256
+      ],
+      "sq_sum": 0.007336684616035474,
+      "sum": 0.12810844581829595
+    },
+    "interactions.0.skip_tp.weight": {
+      "abs_sum": 3.0006585298818216,
+      "count": 2304,
+      "projection": 0.06551536526485824,
+      "shape": [
+        2304
+      ],
+      "sq_sum": 0.0334599004306561,
+      "sum": 0.014311048001083978
+    },
+    "interactions.1.conv_tp_weights.layer0.weight": {
+      "abs_sum": 0.6657519753466667,
+      "count": 512,
+      "projection": 0.019579244840276455,
+      "shape": [
+        8,
+        64
+      ],
+      "sq_sum": 0.0018616073470872632,
+      "sum": 0.06341674292518003
+    },
+    "interactions.1.conv_tp_weights.layer1.weight": {
+      "abs_sum": 1.2796017875414973,
+      "count": 4096,
+      "projection": 0.0061270395186497125,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.0010661071973347828,
+      "sum": 0.024913991359547936
+    },
+    "interactions.1.conv_tp_weights.layer2.weight": {
+      "abs_sum": 1.462942643265341,
+      "count": 4096,
+      "projection": 0.013331140019653695,
+      "shape": [
+        64,
+        64
+      ],
+      "sq_sum": 0.001573175979104044,
+      "sum": 0.12407222410641663
+    },
+    "interactions.1.conv_tp_weights.layer3.weight": {
+      "abs_sum": 0.8796352665695909,
+      "count": 7168,
+      "projection": 0.002461140510817611,
+      "shape": [
+        64,
+        112
+      ],
+      "sq_sum": 0.001384811479831184,
+      "sum": -0.048301105445588494
+    },
+    "interactions.1.linear.weight": {
+      "abs_sum": 0.41899876030783334,
+      "count": 1792,
+      "projection": -0.0029536406873578447,
+      "shape": [
+        1792
+      ],
+      "sq_sum": 0.0023155902460735905,
+      "sum": -0.005702784857592557
+    },
+    "interactions.1.linear_up.weight": {
+      "abs_sum": 0.49676101645264437,
+      "count": 512,
+      "projection": -0.03054525619504167,
+      "shape": [
+        512
+      ],
+      "sq_sum": 0.0015274519625689132,
+      "sum": 0.04909013383120342
+    },
+    "interactions.1.skip_tp.weight": {
+      "abs_sum": 1.0088681066517349,
+      "count": 768,
+      "projection": 0.02035437399038644,
+      "shape": [
+        768
+      ],
+      "sq_sum": 0.003885859208996946,
+      "sum": -0.14124096098179484
+    },
+    "node_embedding.linear.weight": {
+      "abs_sum": 0.47096594660560587,
+      "count": 48,
+      "projection": 0.0066850129333898,
+      "shape": [
+        48
+      ],
+      "sq_sum": 0.007376478429403369,
+      "sum": 0.1509143480518122
+    },
+    "products.0.linear.weight": {
+      "abs_sum": 1.661215146411035,
+      "count": 512,
+      "projection": 0.1024158372791461,
+      "shape": [
+        512
+      ],
+      "sq_sum": 0.013625462941555196,
+      "sum": 0.05449465131604936
+    },
+    "products.0.symmetric_contractions.contractions.0.weights.0": {
+      "abs_sum": 0.22576690850236586,
+      "count": 144,
+      "projection": 0.008798568589636195,
+      "shape": [
+        3,
+        3,
+        16
+      ],
+      "sq_sum": 0.0016438492428601315,
+      "sum": 0.015122979762326653
+    },
+    "products.0.symmetric_contractions.contractions.0.weights.1": {
+      "abs_sum": 0.5295323878379838,
+      "count": 48,
+      "projection": -0.12306182670328152,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.01444217177583827,
+      "sum": 0.02553718683303676
+    },
+    "products.0.symmetric_contractions.contractions.0.weights_max": {
+      "abs_sum": 0.0979930937423099,
+      "count": 528,
+      "projection": -0.011218793368790505,
+      "shape": [
+        3,
+        11,
+        16
+      ],
+      "sq_sum": 0.0001651323823716894,
+      "sum": 0.010253294988345025
+    },
+    "products.0.symmetric_contractions.contractions.1.weights.0": {
+      "abs_sum": 0.054451988314473676,
+      "count": 192,
+      "projection": -0.0007199874756154215,
+      "shape": [
+        3,
+        4,
+        16
+      ],
+      "sq_sum": 5.5468921853966946e-05,
+      "sum": -0.020185364763503067
+    },
+    "products.0.symmetric_contractions.contractions.1.weights.1": {
+      "abs_sum": 0.1497550577928138,
+      "count": 48,
+      "projection": -0.04396185167159128,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.0013898195980304832,
+      "sum": 0.027805457086638917
+    },
+    "products.0.symmetric_contractions.contractions.1.weights_max": {
+      "abs_sum": 0.03386005866208357,
+      "count": 1008,
+      "projection": 0.00015790304081523876,
+      "shape": [
+        3,
+        21,
+        16
+      ],
+      "sq_sum": 9.87548030711196e-06,
+      "sum": 0.00942821296910239
+    },
+    "products.1.linear.weight": {
+      "abs_sum": 0.5050429425342315,
+      "count": 256,
+      "projection": -0.01848233226400572,
+      "shape": [
+        256
+      ],
+      "sq_sum": 0.0029853534834416388,
+      "sum": 0.09440375493769328
+    },
+    "products.1.symmetric_contractions.contractions.0.weights.0": {
+      "abs_sum": 0.014552713986201525,
+      "count": 144,
+      "projection": -0.005561897317214507,
+      "shape": [
+        3,
+        3,
+        16
+      ],
+      "sq_sum": 1.0770808701210973e-05,
+      "sum": 0.0035017945481109858
+    },
+    "products.1.symmetric_contractions.contractions.0.weights.1": {
+      "abs_sum": 0.1822912700394066,
+      "count": 48,
+      "projection": 0.035590322792980925,
+      "shape": [
+        3,
+        1,
+        16
+      ],
+      "sq_sum": 0.002656660615390703,
+      "sum": 0.03544767609053103
+    },
+    "products.1.symmetric_contractions.contractions.0.weights_max": {
+      "abs_sum": 0.0014270909238827845,
+      "count": 528,
+      "projection": -8.405828918210146e-05,
+      "shape": [
+        3,
+        11,
+        16
+      ],
+      "sq_sum": 6.196346826660813e-08,
+      "sum": 0.0005987806086162391
+    },
+    "readouts.0.linear.weight": {
+      "abs_sum": 0.22954998424783546,
+      "count": 16,
+      "projection": 0.00028509587407002336,
+      "shape": [
+        16
+      ],
+      "sq_sum": 0.00637826138172445,
+      "sum": -0.1314352058829677
+    },
+    "readouts.1.linear_1.weight": {
+      "abs_sum": 0.4245182376944351,
+      "count": 128,
+      "projection": 0.0148459792811504,
+      "shape": [
+        128
+      ],
+      "sq_sum": 0.0036419516087816428,
+      "sum": 0.10940654253997534
+    },
+    "readouts.1.linear_2.weight": {
+      "abs_sum": 0.1146499604176466,
+      "count": 8,
+      "projection": -0.031186266363245507,
+      "shape": [
+        8
+      ],
+      "sq_sum": 0.003001794981991499,
+      "sum": 0.11449102592605298
+    }
+  },
+  "parameters_without_a_gradient": [],
+  "provenance": {
+    "description": "One forward+backward of an energy+forces loss on the tiny_scaleshift anchor, reduced to a per-parameter gradient digest. Legacy characterization: what FM-00 must reproduce and what PAR-1 diffs legacy against v1.",
+    "evaluated_with": "e3nn, CPU, float64",
+    "recipe": "tests/golden/train_step.py",
+    "source": "tests/golden/models/tiny_scaleshift.model",
+    "tolerance_row": "fp64_cpu_reference"
+  },
+  "schema_version": 1,
+  "units": {
+    "energy": "eV",
+    "length": "Ang"
+  }
+}

--- a/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
@@ -2,7 +2,7 @@
   "backend": "e3nn",
   "device": "cpu",
   "dtype": "float64",
-  "global_gradient_norm": 0.4377097960821653,
+  "global_gradient_norm": 0.7645596262576995,
   "gradcheck": {
     "gradcheck_positions": true,
     "gradcheck_strain": true,
@@ -10,7 +10,7 @@
     "gradgradcheck_strain": true
   },
   "kind": "train_step_gradient",
-  "loss": 0.3584699958726426,
+  "loss": 3.3574308122410774,
   "metadata": {
     "loss": "WeightedEnergyForcesLoss",
     "loss_weights": {
@@ -26,320 +26,320 @@
   "n_elements": 37704,
   "parameters": {
     "interactions.0.conv_tp_weights.layer0.weight": {
-      "abs_sum": 2.788001409830277,
+      "abs_sum": 5.873366826553417,
       "count": 512,
-      "projection": 0.29285179229097236,
+      "projection": 0.24064310820752263,
       "shape": [
         8,
         64
       ],
-      "sq_sum": 0.03129154858235829,
-      "sum": -0.020248448345735914
+      "sq_sum": 0.141659240248297,
+      "sum": -0.09462925419581308
     },
     "interactions.0.conv_tp_weights.layer1.weight": {
-      "abs_sum": 5.1455542993409615,
+      "abs_sum": 11.068615525481292,
       "count": 4096,
-      "projection": 0.15923329937075062,
+      "projection": 0.22989753686008096,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.018549962767202,
-      "sum": 0.5946572928278898
+      "sq_sum": 0.09238269157975346,
+      "sum": 1.0428354561101427
     },
     "interactions.0.conv_tp_weights.layer2.weight": {
-      "abs_sum": 3.9821481731392576,
+      "abs_sum": 7.8848451813491565,
       "count": 4096,
-      "projection": -0.1126011213402125,
+      "projection": -0.33104426367260587,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.010485735855425704,
-      "sum": 0.3155110335284571
+      "sq_sum": 0.040596750397405776,
+      "sum": 0.6334317816153324
     },
     "interactions.0.conv_tp_weights.layer3.weight": {
-      "abs_sum": 2.3003616810816023,
+      "abs_sum": 4.223736881295166,
       "count": 3072,
-      "projection": -0.012218285398300246,
+      "projection": -0.06787300603546889,
       "shape": [
         64,
         48
       ],
-      "sq_sum": 0.007152167210762705,
-      "sum": 0.022619127751047227
+      "sq_sum": 0.026800703836216775,
+      "sum": -0.0034688521538683847
     },
     "interactions.0.linear.weight": {
-      "abs_sum": 1.4586242662695963,
+      "abs_sum": 2.307446596269552,
       "count": 768,
-      "projection": -0.1895658916812491,
+      "projection": -0.13677973437768823,
       "shape": [
         768
       ],
-      "sq_sum": 0.01231614908713416,
-      "sum": 0.15922816743314697
+      "sq_sum": 0.028011941614185434,
+      "sum": 0.1563020821388137
     },
     "interactions.0.linear_up.weight": {
-      "abs_sum": 0.9215719698673027,
+      "abs_sum": 1.6646117691544229,
       "count": 256,
-      "projection": 0.026590297800401987,
+      "projection": 0.07035183914435479,
       "shape": [
         256
       ],
-      "sq_sum": 0.007336684616035474,
-      "sum": 0.12810844581829595
+      "sq_sum": 0.022029679630867535,
+      "sum": 0.440134214462544
     },
     "interactions.0.skip_tp.weight": {
-      "abs_sum": 3.0006585298818216,
+      "abs_sum": 4.069185497035575,
       "count": 2304,
-      "projection": 0.06551536526485824,
+      "projection": -0.024617189441234935,
       "shape": [
         2304
       ],
-      "sq_sum": 0.0334599004306561,
-      "sum": 0.014311048001083978
+      "sq_sum": 0.05678965948462972,
+      "sum": 0.026278234366242083
     },
     "interactions.1.conv_tp_weights.layer0.weight": {
-      "abs_sum": 0.6657519753466667,
+      "abs_sum": 1.0417192193789035,
       "count": 512,
-      "projection": 0.019579244840276455,
+      "projection": 0.07293607741624059,
       "shape": [
         8,
         64
       ],
-      "sq_sum": 0.0018616073470872632,
-      "sum": 0.06341674292518003
+      "sq_sum": 0.005023925570082485,
+      "sum": 0.039271743600180625
     },
     "interactions.1.conv_tp_weights.layer1.weight": {
-      "abs_sum": 1.2796017875414973,
+      "abs_sum": 1.7834139925298091,
       "count": 4096,
-      "projection": 0.0061270395186497125,
+      "projection": 0.0017359343725741327,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.0010661071973347828,
-      "sum": 0.024913991359547936
+      "sq_sum": 0.0023288471186912354,
+      "sum": 0.27091603252363017
     },
     "interactions.1.conv_tp_weights.layer2.weight": {
-      "abs_sum": 1.462942643265341,
+      "abs_sum": 1.8199458066144012,
       "count": 4096,
-      "projection": 0.013331140019653695,
+      "projection": 0.0036656830885616913,
       "shape": [
         64,
         64
       ],
-      "sq_sum": 0.001573175979104044,
-      "sum": 0.12407222410641663
+      "sq_sum": 0.002883144912175051,
+      "sum": 0.33775655878327093
     },
     "interactions.1.conv_tp_weights.layer3.weight": {
-      "abs_sum": 0.8796352665695909,
+      "abs_sum": 1.1757079196740117,
       "count": 7168,
-      "projection": 0.002461140510817611,
+      "projection": 0.0036589854702175637,
       "shape": [
         64,
         112
       ],
-      "sq_sum": 0.001384811479831184,
-      "sum": -0.048301105445588494
+      "sq_sum": 0.0024829161577345654,
+      "sum": -0.11430807447046087
     },
     "interactions.1.linear.weight": {
-      "abs_sum": 0.41899876030783334,
+      "abs_sum": 0.6077459091076262,
       "count": 1792,
-      "projection": -0.0029536406873578447,
+      "projection": 0.006692555146074832,
       "shape": [
         1792
       ],
-      "sq_sum": 0.0023155902460735905,
-      "sum": -0.005702784857592557
+      "sq_sum": 0.0054996857635924035,
+      "sum": -0.006052143836937442
     },
     "interactions.1.linear_up.weight": {
-      "abs_sum": 0.49676101645264437,
+      "abs_sum": 0.7309022274300083,
       "count": 512,
-      "projection": -0.03054525619504167,
+      "projection": 0.02166152886297391,
       "shape": [
         512
       ],
-      "sq_sum": 0.0015274519625689132,
-      "sum": 0.04909013383120342
+      "sq_sum": 0.0034518925227648082,
+      "sum": 0.043872047117082584
     },
     "interactions.1.skip_tp.weight": {
-      "abs_sum": 1.0088681066517349,
+      "abs_sum": 1.3925493746880138,
       "count": 768,
-      "projection": 0.02035437399038644,
+      "projection": 0.024799513739639237,
       "shape": [
         768
       ],
-      "sq_sum": 0.003885859208996946,
-      "sum": -0.14124096098179484
+      "sq_sum": 0.0077614760095516926,
+      "sum": -0.18700609819966763
     },
     "node_embedding.linear.weight": {
-      "abs_sum": 0.47096594660560587,
+      "abs_sum": 0.8264070006130604,
       "count": 48,
-      "projection": 0.0066850129333898,
+      "projection": 0.1613973902583563,
       "shape": [
         48
       ],
-      "sq_sum": 0.007376478429403369,
-      "sum": 0.1509143480518122
+      "sq_sum": 0.023810711369794034,
+      "sum": -0.0870572342413031
     },
     "products.0.linear.weight": {
-      "abs_sum": 1.661215146411035,
+      "abs_sum": 2.406387740375279,
       "count": 512,
-      "projection": 0.1024158372791461,
+      "projection": 0.13514632181435732,
       "shape": [
         512
       ],
-      "sq_sum": 0.013625462941555196,
-      "sum": 0.05449465131604936
+      "sq_sum": 0.027532182082484424,
+      "sum": 0.020840077887081726
     },
     "products.0.symmetric_contractions.contractions.0.weights.0": {
-      "abs_sum": 0.22576690850236586,
+      "abs_sum": 0.3512196170352663,
       "count": 144,
-      "projection": 0.008798568589636195,
+      "projection": 0.044458674960477625,
       "shape": [
         3,
         3,
         16
       ],
-      "sq_sum": 0.0016438492428601315,
-      "sum": 0.015122979762326653
+      "sq_sum": 0.004138910748038116,
+      "sum": -0.011453263466790632
     },
     "products.0.symmetric_contractions.contractions.0.weights.1": {
-      "abs_sum": 0.5295323878379838,
+      "abs_sum": 0.790404681387363,
       "count": 48,
-      "projection": -0.12306182670328152,
+      "projection": -0.13558721018362274,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.01444217177583827,
-      "sum": 0.02553718683303676
+      "sq_sum": 0.02687725590215074,
+      "sum": -0.037153420462284675
     },
     "products.0.symmetric_contractions.contractions.0.weights_max": {
-      "abs_sum": 0.0979930937423099,
+      "abs_sum": 0.13178707119650382,
       "count": 528,
-      "projection": -0.011218793368790505,
+      "projection": -0.004934758427462956,
       "shape": [
         3,
         11,
         16
       ],
-      "sq_sum": 0.0001651323823716894,
-      "sum": 0.010253294988345025
+      "sq_sum": 0.00017679428894317424,
+      "sum": 0.008319245779803173
     },
     "products.0.symmetric_contractions.contractions.1.weights.0": {
-      "abs_sum": 0.054451988314473676,
+      "abs_sum": 0.10049797800582164,
       "count": 192,
-      "projection": -0.0007199874756154215,
+      "projection": -0.0036843619404761828,
       "shape": [
         3,
         4,
         16
       ],
-      "sq_sum": 5.5468921853966946e-05,
-      "sum": -0.020185364763503067
+      "sq_sum": 0.00027694633646328565,
+      "sum": -0.023214733999506618
     },
     "products.0.symmetric_contractions.contractions.1.weights.1": {
-      "abs_sum": 0.1497550577928138,
+      "abs_sum": 0.2868740108459979,
       "count": 48,
-      "projection": -0.04396185167159128,
+      "projection": -0.08684355756665141,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.0013898195980304832,
-      "sum": 0.027805457086638917
+      "sq_sum": 0.00699230194609351,
+      "sum": 0.08496097808542143
     },
     "products.0.symmetric_contractions.contractions.1.weights_max": {
-      "abs_sum": 0.03386005866208357,
+      "abs_sum": 0.06441990651024652,
       "count": 1008,
-      "projection": 0.00015790304081523876,
+      "projection": -0.002107301397414188,
       "shape": [
         3,
         21,
         16
       ],
-      "sq_sum": 9.87548030711196e-06,
-      "sum": 0.00942821296910239
+      "sq_sum": 5.533617561073191e-05,
+      "sum": 0.02707017163508363
     },
     "products.1.linear.weight": {
-      "abs_sum": 0.5050429425342315,
+      "abs_sum": 0.7081836776723226,
       "count": 256,
-      "projection": -0.01848233226400572,
+      "projection": -0.0031156015197695962,
       "shape": [
         256
       ],
-      "sq_sum": 0.0029853534834416388,
-      "sum": 0.09440375493769328
+      "sq_sum": 0.00909744874479769,
+      "sum": 0.0821421261151435
     },
     "products.1.symmetric_contractions.contractions.0.weights.0": {
-      "abs_sum": 0.014552713986201525,
+      "abs_sum": 0.013192549970833608,
       "count": 144,
-      "projection": -0.005561897317214507,
+      "projection": -0.0038200149487340766,
       "shape": [
         3,
         3,
         16
       ],
-      "sq_sum": 1.0770808701210973e-05,
-      "sum": 0.0035017945481109858
+      "sq_sum": 7.804652542753609e-06,
+      "sum": -0.0002464144249620799
     },
     "products.1.symmetric_contractions.contractions.0.weights.1": {
-      "abs_sum": 0.1822912700394066,
+      "abs_sum": 0.24757413664707328,
       "count": 48,
-      "projection": 0.035590322792980925,
+      "projection": -0.03475241703948478,
       "shape": [
         3,
         1,
         16
       ],
-      "sq_sum": 0.002656660615390703,
-      "sum": 0.03544767609053103
+      "sq_sum": 0.006958843994582919,
+      "sum": 0.01971601692867267
     },
     "products.1.symmetric_contractions.contractions.0.weights_max": {
-      "abs_sum": 0.0014270909238827845,
+      "abs_sum": 0.0014446349287042738,
       "count": 528,
-      "projection": -8.405828918210146e-05,
+      "projection": -7.407405678016044e-05,
       "shape": [
         3,
         11,
         16
       ],
-      "sq_sum": 6.196346826660813e-08,
-      "sum": 0.0005987806086162391
+      "sq_sum": 5.96796577921706e-08,
+      "sum": 0.00016245650358948677
     },
     "readouts.0.linear.weight": {
-      "abs_sum": 0.22954998424783546,
+      "abs_sum": 0.3369115233920475,
       "count": 16,
-      "projection": 0.00028509587407002336,
+      "projection": -0.0311036884038164,
       "shape": [
         16
       ],
-      "sq_sum": 0.00637826138172445,
-      "sum": -0.1314352058829677
+      "sq_sum": 0.011676908106534581,
+      "sum": -0.16854666762112483
     },
     "readouts.1.linear_1.weight": {
-      "abs_sum": 0.4245182376944351,
+      "abs_sum": 0.7362481440301989,
       "count": 128,
-      "projection": 0.0148459792811504,
+      "projection": 0.045225762901999374,
       "shape": [
         128
       ],
-      "sq_sum": 0.0036419516087816428,
-      "sum": 0.10940654253997534
+      "sq_sum": 0.00958805779252629,
+      "sum": 0.28852918482915885
     },
     "readouts.1.linear_2.weight": {
-      "abs_sum": 0.1146499604176466,
+      "abs_sum": 0.3616208966941328,
       "count": 8,
-      "projection": -0.031186266363245507,
+      "projection": -0.07286437393762138,
       "shape": [
         8
       ],
-      "sq_sum": 0.003001794981991499,
-      "sum": 0.11449102592605298
+      "sq_sum": 0.01965930543714511,
+      "sum": 0.29435041626036385
     }
   },
   "parameters_without_a_gradient": [],

--- a/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
+++ b/tests/golden/references/tiny_scaleshift_train_step_grad_fp64.json
@@ -344,7 +344,7 @@
   },
   "parameters_without_a_gradient": [],
   "provenance": {
-    "description": "One forward+backward of an energy+forces loss on the tiny_scaleshift anchor, reduced to a per-parameter gradient digest. Legacy characterization: what FM-00 must reproduce and what PAR-1 diffs legacy against v1.",
+    "description": "One forward+backward of an energy+forces loss on the tiny_scaleshift anchor, reduced to a per-parameter gradient digest. A rewrite of the training path has to reproduce these, and a rewrite that changes them has to say which gradient moved and why.",
     "evaluated_with": "e3nn, CPU, float64",
     "recipe": "tests/golden/train_step.py",
     "source": "tests/golden/models/tiny_scaleshift.model",

--- a/tests/golden/targets/gradients.py
+++ b/tests/golden/targets/gradients.py
@@ -1,0 +1,47 @@
+"""One training step per anchor, reduced to a per-parameter gradient digest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.golden import harness, targets
+from tests.golden.paths import REPO_ROOT
+
+ORDER = 35
+HELP = "the one-training-step gradient digests"
+
+
+def run() -> None:
+    # Late import: see the package docstring. A gradient step needs the whole
+    # framework.
+    from tests.golden.train_step import (  # pylint: disable=import-outside-toplevel
+        GRADIENT_REFERENCES,
+        snapshot,
+    )
+
+    # Read through the shared registry rather than importing the anchors
+    # module: this family consumes checkpoints it does not own, and going
+    # through all_anchors() is what keeps that a lookup instead of a
+    # dependency between two families.
+    anchors = targets.all_anchors()
+    for name, reference_name in GRADIENT_REFERENCES.items():
+        payload = snapshot(name)
+        path = harness.write_reference(
+            harness.REFERENCES_DIR / reference_name,
+            payload,
+            provenance={
+                "source": f"tests/golden/models/{Path(anchors[name][0]).name}",
+                "recipe": "tests/golden/train_step.py",
+                "description": (
+                    "One forward+backward of an energy+forces loss on the "
+                    f"{name} anchor, reduced to a per-parameter gradient "
+                    "digest. A rewrite of the training path has to reproduce "
+                    "these, and a rewrite that changes them has to say which "
+                    "gradient moved and why."
+                ),
+                "evaluated_with": "e3nn, CPU, float64",
+                "tolerance_row": harness.FP64_CPU_REFERENCE.name,
+            },
+            allow_overwrite=True,
+        )
+        print(f"  gradient  {name:15s} -> {path.relative_to(REPO_ROOT)}")

--- a/tests/golden/test_tiny_anchors.py
+++ b/tests/golden/test_tiny_anchors.py
@@ -15,63 +15,12 @@ import numpy as np
 import pytest
 import torch
 
-from mace import data
 from mace.modules.utils import get_edge_vectors_and_lengths
-from mace.tools import torch_geometric, torch_tools, utils
+from mace.tools import torch_tools
 from tests.golden import harness
-
-ANCHORS = {
-    "tiny_scaleshift": {
-        "model": harness.MODELS_DIR / "tiny_scaleshift.model",
-        "sidecar": harness.MODELS_DIR / "tiny_scaleshift.build.json",
-        "reference": harness.REFERENCES_DIR / "tiny_scaleshift_e3nn_cpu_fp64.json",
-        "class": "ScaleShiftMACE",
-    },
-    "tiny_mace": {
-        "model": harness.MODELS_DIR / "tiny_mace.model",
-        "sidecar": harness.MODELS_DIR / "tiny_mace.build.json",
-        "reference": harness.REFERENCES_DIR / "tiny_mace_e3nn_cpu_fp64.json",
-        "class": "MACE",
-    },
-}
-
-
-def _load(name):
-    return torch.load(
-        ANCHORS[name]["model"], weights_only=False, map_location="cpu"
-    ).to(torch.float64)
-
-
-def _batch(model, atoms):
-    """One structure as the graph batch the model consumes, in float64.
-
-    AtomicData reads the process-wide default dtype, which is float32 under
-    pytest, so the graph is *built* inside a float64 scope. Casting a float32
-    graph up afterwards is not the same thing and was what this used to do:
-    the positions have already been rounded, and the anchor then reproduces
-    the calculator's numbers only to about 2e-8 relative -- close enough to
-    the fp64 row to look like agreement and far enough to make a bit-exact
-    comparison impossible. The trailing cast stays as a belt-and-braces for
-    any tensor the scope does not reach.
-    """
-    z_table = utils.AtomicNumberTable([int(z) for z in model.atomic_numbers])
-    with torch_tools.default_dtype("float64"):
-        config = data.config_from_atoms(atoms)
-        atomic_data = data.AtomicData.from_config(
-            config, z_table=z_table, cutoff=float(model.r_max)
-        )
-        loader = torch_geometric.dataloader.DataLoader(
-            [atomic_data], batch_size=1, shuffle=False
-        )
-        graph = next(iter(loader)).to_dict()
-    return {
-        key: (
-            value.to(torch.float64)
-            if torch.is_tensor(value) and torch.is_floating_point(value)
-            else value
-        )
-        for key, value in graph.items()
-    }
+from tests.golden.anchors import ANCHORS
+from tests.golden.anchors import anchor_graph as _batch
+from tests.golden.anchors import load_anchor as _load
 
 
 @pytest.fixture(name="fixtures", scope="module")

--- a/tests/golden/test_train_step_gradient.py
+++ b/tests/golden/test_train_step_gradient.py
@@ -117,8 +117,8 @@ def test_the_digest_resolves_a_weight_change_six_orders_below_the_weights():
     """Why this golden is worth its bytes, as a measured resolution.
 
     Perturbing one weight and watching the digest, the response is linear
-    with a gain of 0.49: a change of d in a single weight moves the largest
-    digest field by about 0.49 * d. Against the 1e-6 reference row that puts
+    with a gain of 0.57: a change of d in a single weight moves the largest
+    digest field by about 0.57 * d. Against the 1e-6 reference row that puts
     the detection floor at a weight change of roughly 2e-6, while the weights
     themselves are of order 1 -- so a gradient defect anywhere near the scale
     of initialisation noise is six orders above what this can see, which is
@@ -126,7 +126,7 @@ def test_the_digest_resolves_a_weight_change_six_orders_below_the_weights():
 
     The perturbation used here is 1e-5, comfortably above the floor and still
     far below anything an error table would report: it moves the loss by
-    1.9e-7 eV.
+    2.5e-7 eV.
     """
     anchor = "tiny_scaleshift"
     baseline = train_step(anchor)

--- a/tests/golden/test_train_step_gradient.py
+++ b/tests/golden/test_train_step_gradient.py
@@ -1,14 +1,15 @@
 """The one-training-step gradient golden.
 
-This closes the training-numerics gap: the loss-decrease smoke test (P0-5)
-and the committed final-error table both stay green while `d(loss)/d(theta)`
-is wrong by an amount comparable to initialisation noise, because they only
-ever look at where training ended up. A committed single-step gradient looks
-at the derivative itself.
+This closes the training-numerics gap: the loss-decrease smoke test and the
+committed final-error table both stay green while `d(loss)/d(theta)` is wrong
+by an amount comparable to initialisation noise, because they only ever look
+at where training ended up. A committed single-step gradient looks at the
+derivative itself.
 
-It is a **legacy characterization**, not a parity test -- nothing outside the
-frozen stack is involved. FM-00 is what has to reproduce it; PAR-1 upgrades
-it from "introduce the test" to "run it against both stacks and diff".
+It characterizes the current implementation rather than comparing two of
+them: nothing outside this stack is involved. A rewrite of the training path
+has to reproduce these numbers, and a rewrite that changes them has to say
+which gradient moved and why.
 
 Read `train_step.py` for the digest design and for why the raw 37,704-element
 gradient vector is not what is committed. The two properties that make the

--- a/tests/golden/test_train_step_gradient.py
+++ b/tests/golden/test_train_step_gradient.py
@@ -1,0 +1,157 @@
+"""The one-training-step gradient golden.
+
+This closes the training-numerics gap: the loss-decrease smoke test (P0-5)
+and the committed final-error table both stay green while `d(loss)/d(theta)`
+is wrong by an amount comparable to initialisation noise, because they only
+ever look at where training ended up. A committed single-step gradient looks
+at the derivative itself.
+
+It is a **legacy characterization**, not a parity test -- nothing outside the
+frozen stack is involved. FM-00 is what has to reproduce it; PAR-1 upgrades
+it from "introduce the test" to "run it against both stacks and diff".
+
+Read `train_step.py` for the digest design and for why the raw 37,704-element
+gradient vector is not what is committed. The two properties that make the
+digest trustworthy -- that it moves when a single weight moves by 1e-9, and
+that it notices a permutation -- are asserted below rather than argued.
+
+No GPU, no network, no optional dependency, no capability marker.
+"""
+
+import pytest
+import torch
+
+from tests.golden import harness
+from tests.golden.train_step import (
+    GRADIENT_REFERENCES,
+    _digest,
+    deviations,
+    snapshot,
+    train_step,
+)
+
+TOL = harness.FP64_CPU_REFERENCE
+
+
+@pytest.fixture(name="taken", scope="module")
+def fixture_taken():
+    """One step per anchor, taken once for the whole module."""
+    return {name: snapshot(name) for name in GRADIENT_REFERENCES}
+
+
+@pytest.mark.parametrize("anchor", sorted(GRADIENT_REFERENCES))
+def test_the_step_reproduces_its_committed_gradient(anchor, taken):
+    reference = harness.load_reference(
+        harness.REFERENCES_DIR / GRADIENT_REFERENCES[anchor]
+    )
+    problems = deviations(taken[anchor], reference, TOL)
+    assert not problems, "\n  ".join([f"{anchor}:"] + problems)
+
+
+@pytest.mark.parametrize("anchor", sorted(GRADIENT_REFERENCES))
+def test_the_reference_records_what_produced_it(anchor):
+    reference = harness.load_reference(
+        harness.REFERENCES_DIR / GRADIENT_REFERENCES[anchor]
+    )
+    assert reference["kind"] == "train_step_gradient"
+    assert reference["dtype"] == "float64"
+    assert reference["device"] == "cpu"
+    assert reference["metadata"]["loss"] == "WeightedEnergyForcesLoss"
+    assert reference["metadata"]["seed"]
+    assert reference["provenance"]["recipe"] == "tests/golden/train_step.py"
+    assert reference["provenance"]["tolerance_row"] == TOL.name
+    assert reference["n_elements"] > 1000
+    assert reference["parameters_without_a_gradient"] == [], (
+        "a parameter with no gradient is a parameter this golden does not "
+        "pin; it has to be explained before it is committed"
+    )
+
+
+@pytest.mark.parametrize("anchor", sorted(GRADIENT_REFERENCES))
+def test_gradcheck_and_gradgradcheck_pass_on_the_tiny_fixtures(anchor, taken):
+    """The pass-flags, recomputed here and also committed in the reference.
+
+    `gradgradcheck` is the one that matters: force training backpropagates
+    through the force computation itself, so the second derivative is on the
+    critical path and a first-order-correct implementation is not enough.
+    """
+    flags = taken[anchor]["gradcheck"]
+    assert set(flags) == {
+        "gradcheck_positions",
+        "gradgradcheck_positions",
+        "gradcheck_strain",
+        "gradgradcheck_strain",
+    }
+    assert all(flags.values()), flags
+    committed = harness.load_reference(
+        harness.REFERENCES_DIR / GRADIENT_REFERENCES[anchor]
+    )["gradcheck"]
+    assert committed == flags
+
+
+@pytest.mark.parametrize("anchor", sorted(GRADIENT_REFERENCES))
+def test_the_backward_ran_through_the_second_derivative_path(anchor, taken):
+    """An energy-only loss would leave the force term's graph unbuilt.
+
+    The recorded loss is the energy+forces combination, so if the forces
+    contribution ever stopped reaching the parameters the loss would still be
+    finite and the gradients would still exist -- they would just be a
+    different, smaller number. Checked by taking the same step with the
+    forces weight removed and requiring the digest to disagree.
+    """
+    from tests.golden import train_step as module  # noqa: PLC0415
+
+    energy_only = dict(module.LOSS_WEIGHTS)
+    energy_only["forces_weight"] = 0.0
+    saved = module.LOSS_WEIGHTS
+    try:
+        module.LOSS_WEIGHTS = energy_only
+        without_forces = train_step(anchor)
+    finally:
+        module.LOSS_WEIGHTS = saved
+    assert deviations(without_forces, taken[anchor], TOL)
+
+
+def test_the_digest_resolves_a_weight_change_six_orders_below_the_weights():
+    """Why this golden is worth its bytes, as a measured resolution.
+
+    Perturbing one weight and watching the digest, the response is linear
+    with a gain of 0.49: a change of d in a single weight moves the largest
+    digest field by about 0.49 * d. Against the 1e-6 reference row that puts
+    the detection floor at a weight change of roughly 2e-6, while the weights
+    themselves are of order 1 -- so a gradient defect anywhere near the scale
+    of initialisation noise is six orders above what this can see, which is
+    the claim the Context makes and the one a final-error table cannot.
+
+    The perturbation used here is 1e-5, comfortably above the floor and still
+    far below anything an error table would report: it moves the loss by
+    1.9e-7 eV.
+    """
+    anchor = "tiny_scaleshift"
+    baseline = train_step(anchor)
+    nudged = train_step(
+        anchor, perturbation=("node_embedding.linear.weight", 0, 1e-5)
+    )
+    problems = deviations(nudged, baseline, TOL)
+    assert problems, "the digest did not notice a perturbed weight"
+    # and it is the gradient that moved, not merely the loss: the loss shift
+    # is itself under the row, so a golden that pinned only the loss would
+    # have missed this.
+    assert abs(nudged["loss"] - baseline["loss"]) < TOL.atol
+
+
+def test_the_projection_is_what_catches_a_permuted_gradient():
+    """The design justification for the fifth number, as a measurement.
+
+    Swapping two elements leaves the sum, the absolute sum and the sum of
+    squares bit-identical -- so the first four fields cannot distinguish a
+    correct gradient from one whose irreps layout is permuted, which is the
+    likeliest way this codebase gets a port wrong. Only the positional
+    projection moves.
+    """
+    gradient = torch.tensor([0.5, -1.25, 3.0, 0.125], dtype=torch.float64)
+    permuted = gradient[[1, 0, 2, 3]]
+    original, swapped = _digest(gradient), _digest(permuted)
+    for field in ("sum", "abs_sum", "sq_sum", "count"):
+        assert original[field] == swapped[field], field
+    assert original["projection"] != swapped["projection"]

--- a/tests/golden/train_step.py
+++ b/tests/golden/train_step.py
@@ -101,6 +101,15 @@ def train_step(anchor: str, perturbation=None) -> dict:
     structures = load_training_structures(limit=N_STRUCTURES)
     with torch_tools.default_dtype("float64"):
         batch = anchor_batch(model, structures, torch.float64)
+        # A batch whose labels never arrived carries zeros at full weight, and
+        # the gradient taken through it is wrong in a way nothing else here can
+        # see: same magnitude as the right one, same linear response to a
+        # perturbed weight, every parameter still differentiated. All four
+        # structures carry `REF_energy` and `REF_forces`, and the label-less
+        # isolated atoms are excluded upstream, so this cannot fire on a
+        # legitimately unlabelled configuration.
+        assert float(batch.energy.abs().sum()) > 0.0, "energy labels missing"
+        assert float(batch.forces.abs().sum()) > 0.0, "force labels missing"
         loss_fn = WeightedEnergyForcesLoss(**LOSS_WEIGHTS).to(torch.float64)
         output = model(batch.to_dict(), training=True, compute_force=True)
         loss = loss_fn(batch, output)

--- a/tests/golden/train_step.py
+++ b/tests/golden/train_step.py
@@ -1,0 +1,235 @@
+"""One training step on a committed anchor, reduced to a comparable digest.
+
+A loss-decrease smoke test and a final-error table cannot see a gradient bug
+the size of initialisation noise: both stay green while `d(loss)/d(theta)` is
+wrong in a way that only slows convergence. This module produces the thing
+that can see it -- one forward and one backward of an energy+forces loss on
+the committed anchors, at float64 on CPU, with the committed weights, so the
+result depends on nothing that was randomly drawn.
+
+Energy **and** forces on purpose: the forces term differentiates a quantity
+that is itself a derivative, so the backward runs through the
+`create_graph=True` second-derivative path that force training uses and that
+a first-order-only port would get away with otherwise.
+
+**Why a digest and not the raw gradient vector.** The two anchors have 37,704
+gradient elements between them; committing them as JSON costs about 1.5 MB in
+every clone, more than both checkpoints together, and a reviewer cannot read
+a diff of it. Instead each parameter contributes five numbers, chosen so that
+no plausible corruption survives all of them:
+
+* `sum` catches a sign flip anywhere (`abs_sum` and `sq_sum` do not);
+* `abs_sum` and `sq_sum` catch a magnitude change that cancels in the sum;
+* `projection` = sum_k g_k * cos(k + 1) over the C-order flattening catches a
+  **permutation**, which the other four cannot see at all -- and a permuted
+  gradient is exactly what an irreps-layout mistake produces, which is the
+  single most likely porting bug in this codebase;
+* `count` and `shape` catch a reshape.
+
+The projection uses `cos` of an integer rather than a seeded random vector so
+that a reimplementation in another framework can reproduce it without sharing
+an RNG. It is evaluated in float64; the accumulated libm difference across
+platforms is of order 1e-14 on these magnitudes, four orders under the
+reference row.
+
+Parameter **names** are part of the golden too: a rename shows up here rather
+than as a silently smaller comparison.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import torch
+
+from mace.modules.loss import WeightedEnergyForcesLoss
+from mace.tools import torch_tools
+
+from . import harness
+from .anchors import ANCHORS, anchor_graph, anchor_batch, load_anchor
+from .anchors import load_training_structures
+
+#: anchor -> the committed reference for its gradient digest.
+GRADIENT_REFERENCES = {
+    "tiny_scaleshift": "tiny_scaleshift_train_step_grad_fp64.json",
+    "tiny_mace": "tiny_mace_train_step_grad_fp64.json",
+}
+
+#: the step is defined by these three choices and nothing else.
+SEED = 20260810
+N_STRUCTURES = 4
+LOSS_WEIGHTS = {"energy_weight": 1.0, "forces_weight": 10.0}
+
+#: finite-difference step for the gradcheck pass-flags. Not a tolerance: the
+#: tolerances come from harness.py, like everywhere else here.
+GRADCHECK_EPS = 1e-6
+
+
+def _digest(gradient: torch.Tensor) -> Dict[str, object]:
+    flat = gradient.reshape(-1).to(torch.float64)
+    index = torch.arange(flat.numel(), dtype=torch.float64)
+    return {
+        "shape": list(gradient.shape),
+        "count": int(flat.numel()),
+        "sum": float(flat.sum()),
+        "abs_sum": float(flat.abs().sum()),
+        "sq_sum": float((flat * flat).sum()),
+        "projection": float((flat * torch.cos(index + 1.0)).sum()),
+    }
+
+
+def train_step(anchor: str, perturbation=None) -> dict:
+    """Run the step and return the digest payload for ``anchor``.
+
+    ``perturbation`` is ``(parameter_name, flat_index, delta)``, applied to
+    the weights before the forward. It exists so a test can ask the only
+    question that says whether this golden is worth committing: does a change
+    too small to move any error table move the digest?
+    """
+    torch.manual_seed(SEED)
+    model = load_anchor(anchor, torch.float64)
+    if perturbation is not None:
+        name, index, delta = perturbation
+        with torch.no_grad():
+            dict(model.named_parameters())[name].view(-1)[index] += delta
+    structures = load_training_structures(limit=N_STRUCTURES)
+    with torch_tools.default_dtype("float64"):
+        batch = anchor_batch(model, structures, torch.float64)
+        loss_fn = WeightedEnergyForcesLoss(**LOSS_WEIGHTS).to(torch.float64)
+        output = model(batch.to_dict(), training=True, compute_force=True)
+        loss = loss_fn(batch, output)
+        model.zero_grad(set_to_none=True)
+        loss.backward()
+
+    gradients = {
+        name: parameter.grad
+        for name, parameter in model.named_parameters()
+        if parameter.grad is not None
+    }
+    without_gradient = sorted(
+        name for name, p in model.named_parameters() if p.grad is None
+    )
+    total = float(
+        torch.sqrt(sum((g.to(torch.float64) ** 2).sum() for g in gradients.values()))
+    )
+    return {
+        "loss": float(loss),
+        "global_gradient_norm": total,
+        "n_elements": int(sum(g.numel() for g in gradients.values())),
+        "parameters_without_a_gradient": without_gradient,
+        "parameters": {name: _digest(g) for name, g in sorted(gradients.items())},
+    }
+
+
+def gradcheck_flags(anchor: str) -> Dict[str, bool]:
+    """Coarse model-level gradcheck / gradgradcheck pass-flags.
+
+    Run on the two-atom dimer (positions) and the triclinic cell (strain),
+    which are the smallest fixtures that reach each derivative. `gradcheck`
+    compares the analytic jacobian against a numerical one; `gradgradcheck`
+    does the same one order up, which is the derivative force training
+    actually backpropagates through. Both are asserted at the fp64 reference
+    row rather than at torch's much looser defaults.
+    """
+    tol = harness.FP64_CPU_REFERENCE
+    fixtures = harness.load_fixtures(names=["dimer_short", "triclinic_bulk"])
+    model = load_anchor(anchor, torch.float64)
+
+    with torch_tools.default_dtype("float64"):
+        molecule = anchor_graph(model, fixtures["dimer_short"], torch.float64)
+        crystal = anchor_graph(model, fixtures["triclinic_bulk"], torch.float64)
+
+        def energy_of_positions(positions):
+            graph = dict(molecule)
+            graph["positions"] = positions
+            return model(graph, training=True, compute_force=False)["energy"]
+
+        def energy_of_strain(displacement):
+            graph = dict(crystal)
+            graph["displacement"] = displacement
+            return model(
+                graph, training=True, compute_force=False, compute_stress=True
+            )["energy"]
+
+        positions = molecule["positions"].detach().clone().requires_grad_(True)
+        strain = torch.zeros((1, 3, 3), dtype=torch.float64, requires_grad=True)
+        options = {
+            "eps": GRADCHECK_EPS,
+            "atol": tol.atol,
+            "rtol": tol.rtol,
+        }
+        flags = {
+            "gradcheck_positions": bool(
+                torch.autograd.gradcheck(energy_of_positions, (positions,), **options)
+            ),
+            "gradgradcheck_positions": bool(
+                torch.autograd.gradgradcheck(
+                    energy_of_positions, (positions,), **options
+                )
+            ),
+            "gradcheck_strain": bool(
+                torch.autograd.gradcheck(energy_of_strain, (strain,), **options)
+            ),
+            "gradgradcheck_strain": bool(
+                torch.autograd.gradgradcheck(energy_of_strain, (strain,), **options)
+            ),
+        }
+    return flags
+
+
+def snapshot(anchor: str) -> dict:
+    """The whole committed payload for one anchor."""
+    step = train_step(anchor)
+    return {
+        "schema_version": harness.SCHEMA_VERSION,
+        "kind": "train_step_gradient",
+        "dtype": "float64",
+        "device": "cpu",
+        "backend": "e3nn",
+        "units": {"length": "Ang", "energy": "eV"},
+        "metadata": {
+            "model": ANCHORS[anchor]["model"].name,
+            "model_class": ANCHORS[anchor]["class"],
+            "seed": SEED,
+            "loss": "WeightedEnergyForcesLoss",
+            "loss_weights": LOSS_WEIGHTS,
+            "structures": (
+                f"first {N_STRUCTURES} non-isolated configurations of "
+                "fixtures/tiny_train.xyz"
+            ),
+            "projection": "sum_k g_k * cos(k + 1), C-order flattening",
+        },
+        "gradcheck": gradcheck_flags(anchor),
+        **step,
+    }
+
+
+def deviations(got: dict, reference: dict, tol) -> list:
+    """Every way ``got`` and ``reference`` disagree, as readable lines."""
+    problems = []
+    if set(got["parameters"]) != set(reference["parameters"]):
+        missing = sorted(set(reference["parameters"]) - set(got["parameters"]))
+        extra = sorted(set(got["parameters"]) - set(reference["parameters"]))
+        problems.append(f"parameter names changed: missing {missing}, extra {extra}")
+        return problems
+    for scalar in ("loss", "global_gradient_norm"):
+        if not np.isclose(got[scalar], reference[scalar], atol=tol.atol, rtol=tol.rtol):
+            problems.append(
+                f"{scalar}: {got[scalar]!r} != {reference[scalar]!r} "
+                f"(delta {got[scalar] - reference[scalar]:.3e})"
+            )
+    for name, want in reference["parameters"].items():
+        have = got["parameters"][name]
+        if list(have["shape"]) != list(want["shape"]):
+            problems.append(f"{name}: shape {want['shape']} -> {have['shape']}")
+            continue
+        for field in ("sum", "abs_sum", "sq_sum", "projection"):
+            if not np.isclose(
+                have[field], want[field], atol=tol.atol, rtol=tol.rtol
+            ):
+                problems.append(
+                    f"{name}.{field}: {have[field]!r} != {want[field]!r} "
+                    f"(delta {have[field] - want[field]:.3e})"
+                )
+    return problems

--- a/tests/golden/train_step.py
+++ b/tests/golden/train_step.py
@@ -47,8 +47,13 @@ from mace.modules.loss import WeightedEnergyForcesLoss
 from mace.tools import torch_tools
 
 from . import harness
-from .anchors import ANCHORS, anchor_graph, anchor_batch, load_anchor
-from .anchors import load_training_structures
+from .anchors import (
+    ANCHORS,
+    anchor_batch,
+    anchor_graph,
+    load_anchor,
+    load_training_structures,
+)
 
 #: anchor -> the committed reference for its gradient digest.
 GRADIENT_REFERENCES = {

--- a/tests/unit/test_e0s_characterization.py
+++ b/tests/unit/test_e0s_characterization.py
@@ -3,8 +3,9 @@
 E0s are the largest numbers in a MACE energy by two or three orders of
 magnitude, and they enter in exactly one place: `AtomicEnergiesBlock` looks
 them up with a one-hot matmul and the result is the first term of the readout
-sum (`mace/modules/models.py:359` for plain MACE, `:576` for the scale-shift
-class, where the E0 term sits *outside* the scale and the shift). Everything
+sum (`mace/modules/models.py:359` for plain MACE, `:581` for the scale-shift
+class, where the E0 term is added *outside* the scale and the shift, which
+were applied one line earlier). Everything
 upstream of that lookup -- the four ways a user can supply E0s, and the
 several ways the code quietly supplies its own -- is characterized here.
 

--- a/tests/unit/test_e0s_characterization.py
+++ b/tests/unit/test_e0s_characterization.py
@@ -560,3 +560,255 @@ def test_no_scaling_overrides_even_an_explicit_std():
     model = _configure(["--scaling", "no_scaling", "--std", "7.0", "--mean", "1.5"])
     assert float(model.scale_shift.scale) == pytest.approx(1.0)
     assert float(model.scale_shift.shift) == pytest.approx(1.5)
+
+
+# ---------------------------------------------------------------------------
+# The dataset statistics the scale and the shift come from
+#
+# These are the numbers `--mean` and `--std` replace, and they are computed
+# from the E0s: every one of them subtracts the atomic energies first, so an
+# E0 mistake propagates into the scale as well as into the energies. Each is
+# asserted against the same arithmetic done in numpy on the same structures.
+# ---------------------------------------------------------------------------
+
+
+def _labelled_loader(structures, batch_size=2, cutoff=4.0):
+    keyspec = KeySpecification.from_defaults()
+    with torch_tools.default_dtype("float64"):
+        graphs = [
+            data.AtomicData.from_config(
+                config_from_atoms(atoms, keyspec), z_table=Z_TABLE, cutoff=cutoff
+            )
+            for atoms in structures
+        ]
+        return torch_geometric.dataloader.DataLoader(
+            graphs, batch_size=batch_size, shuffle=False
+        )
+
+
+def _per_atom_interaction_energies(structures, e0s):
+    """The same quantity in numpy: (E - sum_z n_z E0_z) / n_atoms."""
+    values = []
+    for atoms in structures:
+        e0 = sum(e0s[Z_TABLE.z_to_index(int(z))] for z in atoms.get_atomic_numbers())
+        values.append((atoms.info["REF_energy"] - e0) / len(atoms))
+    return np.array(values)
+
+
+def test_the_mean_and_std_scaling_is_the_per_atom_interaction_energy():
+    """`--scaling std_scaling`, which is the default.
+
+    The mean is the mean per-atom interaction energy and the std is its
+    sample standard deviation (Bessel-corrected -- `scatter_std` defaults to
+    `unbiased=True`, which differs from the population value by a factor
+    sqrt(n/(n-1)) and is the kind of detail a port gets wrong silently).
+    """
+    from mace.modules.utils import (  # noqa: PLC0415
+        compute_mean_std_atomic_inter_energy,
+    )
+
+    structures = load_training_structures(limit=6)
+    e0s = np.array([-0.1, -0.2, -0.3])
+    with torch_tools.default_dtype("float64"):
+        mean, std = compute_mean_std_atomic_inter_energy(
+            _labelled_loader(structures), e0s
+        )
+    expected = _per_atom_interaction_energies(structures, e0s)
+    assert float(np.atleast_1d(mean)[0]) == pytest.approx(
+        expected.mean(), abs=TOL.atol
+    )
+    assert float(np.atleast_1d(std)[0]) == pytest.approx(
+        expected.std(ddof=1), abs=TOL.atol
+    )
+    assert float(np.atleast_1d(std)[0]) != pytest.approx(
+        expected.std(ddof=0), abs=TOL.atol
+    ), "ddof=0 would also be plausible; it is not what the code does"
+
+
+def test_the_rms_forces_scaling_is_the_root_mean_square_force_component():
+    """`--scaling rms_forces_scaling`: the shift is an energy, the scale is a force.
+
+    Two different physical quantities in one pair, which is why `--mean` and
+    `--std` have the help strings they do.
+    """
+    from mace.modules.utils import compute_mean_rms_energy_forces  # noqa: PLC0415
+
+    structures = load_training_structures(limit=6)
+    e0s = np.array([-0.1, -0.2, -0.3])
+    with torch_tools.default_dtype("float64"):
+        mean, rms = compute_mean_rms_energy_forces(_labelled_loader(structures), e0s)
+    expected_mean = _per_atom_interaction_energies(structures, e0s).mean()
+    forces = np.concatenate([atoms.arrays["REF_forces"] for atoms in structures])
+    assert float(np.atleast_1d(mean)[0]) == pytest.approx(expected_mean, abs=TOL.atol)
+    assert float(np.atleast_1d(rms)[0]) == pytest.approx(
+        np.sqrt(np.mean(forces**2)), abs=TOL.atol
+    )
+
+
+def test_a_zero_spread_becomes_a_scale_of_one_with_a_warning(caplog):
+    """Silent fallback #4, in the statistics rather than in the E0s.
+
+    A single training configuration has no spread, so the std is 0 and
+    dividing by it would be fatal. `_check_non_zero` replaces it with 1.0 and
+    logs -- so a one-config debug run trains unscaled and looks normal.
+    """
+    from mace.modules.utils import (  # noqa: PLC0415
+        compute_mean_std_atomic_inter_energy,
+    )
+
+    structures = load_training_structures(limit=1)
+    with torch_tools.default_dtype("float64"):
+        with caplog.at_level(logging.WARNING):
+            _, std = compute_mean_std_atomic_inter_energy(
+                _labelled_loader(structures, batch_size=1), np.zeros(3)
+            )
+    assert float(np.atleast_1d(std)[0]) == 1.0
+    assert any("Standard deviation" in record.message for record in caplog.records)
+
+
+def test_the_average_neighbour_count_skips_atoms_that_have_no_neighbours():
+    """A counting convention with a real effect on the model's normalisation.
+
+    `compute_avg_num_neighbors` counts with `torch.unique(receivers)`, so an
+    atom that appears in no edge contributes nothing at all -- it is not
+    counted as a zero. Adding an isolated atom to the batch therefore leaves
+    the average unchanged instead of pulling it down, which is a difference a
+    port that counts per node rather than per edge would get wrong.
+    """
+    from mace.modules.utils import compute_avg_num_neighbors  # noqa: PLC0415
+
+    structures = load_training_structures(limit=3)
+    lonely = Atoms("H", positions=[[0.0, 0.0, 0.0]], cell=np.eye(3) * 50.0, pbc=True)
+    lonely.info["REF_energy"] = 0.0
+    lonely.arrays["REF_forces"] = np.zeros((1, 3))
+
+    with torch_tools.default_dtype("float64"):
+        without = compute_avg_num_neighbors(_labelled_loader(structures))
+        with_lonely = compute_avg_num_neighbors(_labelled_loader(structures + [lonely]))
+    assert without > 1.0
+    assert with_lonely == pytest.approx(without, abs=TOL.atol)
+
+
+def test_compute_statistics_returns_three_numbers_and_the_third_is_not_a_std():
+    """What `mace_prepare_data` writes into statistics.json, and its one lie.
+
+    The signature says `Tuple[float, float, float, float]` and the function
+    returns **three** values; `preprocess_data.py:43` unpacks them as
+    `avg_num_neighbors, mean, std`, but the third is the root-mean-square
+    force component, not a standard deviation of anything. It agrees with
+    `compute_mean_rms_energy_forces`, which is what `--scaling
+    rms_forces_scaling` (the default) uses, so the number is the right one
+    for the default path and misnamed everywhere it is read.
+    """
+    from mace.modules.utils import (  # noqa: PLC0415
+        compute_avg_num_neighbors,
+        compute_mean_rms_energy_forces,
+        compute_mean_std_atomic_inter_energy,
+        compute_statistics,
+    )
+
+    structures = load_training_structures(limit=6)
+    e0s = np.array([-0.1, -0.2, -0.3])
+    with torch_tools.default_dtype("float64"):
+        returned = compute_statistics(_labelled_loader(structures), e0s)
+        expected_neighbors = compute_avg_num_neighbors(_labelled_loader(structures))
+        expected_mean, expected_rms = compute_mean_rms_energy_forces(
+            _labelled_loader(structures), e0s
+        )
+        _, actual_std = compute_mean_std_atomic_inter_energy(
+            _labelled_loader(structures), e0s
+        )
+    assert len(returned) == 3, "the annotation says four; the code returns three"
+    avg_neighbors, mean, third = returned
+    assert avg_neighbors == pytest.approx(expected_neighbors, abs=TOL.atol)
+    assert float(np.atleast_1d(mean)[0]) == pytest.approx(
+        float(np.atleast_1d(expected_mean)[0]), abs=TOL.atol
+    )
+    assert float(np.atleast_1d(third)[0]) == pytest.approx(
+        float(np.atleast_1d(expected_rms)[0]), abs=TOL.atol
+    )
+    assert float(np.atleast_1d(third)[0]) != pytest.approx(
+        float(np.atleast_1d(actual_std)[0]), abs=TOL.atol
+    ), "the two are different quantities; if they coincide the test is vacuous"
+
+
+def test_the_dipole_scaling_entry_cannot_be_used_the_way_the_other_two_are():
+    """`scaling_classes["rms_dipoles_scaling"]` does not have the same shape.
+
+    The other two entries return `(mean, std)` and `configure_model` unpacks
+    the call site as such (mace/tools/model_script_utils.py:81). This one
+    returns a single float, so that unpacking raises TypeError. It is not
+    reachable from `--scaling`, whose choices are the other three, so the
+    entry is only usable through a YAML config -- where it fails. Pinned as
+    characterization: a port that "fixes" the return shape changes what a
+    config file does, and a port that copies the registry faithfully
+    inherits a dead entry it should know about.
+    """
+    from mace.modules import scaling_classes  # noqa: PLC0415
+    from mace.modules.utils import compute_rms_dipoles  # noqa: PLC0415
+
+    structures = load_training_structures(limit=4)
+    for index, atoms in enumerate(structures):
+        atoms.info["dipole"] = np.array([0.5 * (index + 1), 0.0, -1.0])
+    with torch_tools.default_dtype("float64"):
+        returned = compute_rms_dipoles(_labelled_loader(structures))
+    dipoles = np.stack([atoms.info["dipole"] for atoms in structures])
+    assert isinstance(returned, float)
+    assert returned == pytest.approx(np.sqrt(np.mean(dipoles**2)), abs=TOL.atol)
+    assert scaling_classes["rms_dipoles_scaling"] is compute_rms_dipoles
+    with pytest.raises(TypeError):
+        _mean, _std = returned  # what configure_model does
+
+
+def test_the_zero_spread_guard_only_works_on_arrays():
+    """`_check_non_zero` assigns into its argument, so a scalar 0.0 raises.
+
+    The two array-returning statistics reach it safely; `compute_rms_dipoles`
+    hands it a Python float, so the guard that exists to prevent a division
+    by zero is itself a TypeError in exactly the case it was written for.
+    """
+    from mace.modules.utils import _check_non_zero  # noqa: PLC0415
+
+    assert _check_non_zero(np.array([0.0, 2.0])).tolist() == [1.0, 2.0]
+    assert _check_non_zero(3.5) == 3.5
+    with pytest.raises(TypeError):
+        _check_non_zero(0.0)
+
+
+def test_the_per_batch_statistics_helpers_agree_with_the_loader_versions():
+    """`_compute_mean_std_atomic_inter_energy` and its rms sibling.
+
+    They exist so a caller holding one batch can get the same per-graph
+    quantities the loader-level functions reduce -- the HDF5/LMDB
+    preprocessing path is what needs that. Nothing pins them together, so
+    this does: fed the whole dataset as one batch, the private helper's
+    per-graph energies reduce to exactly what the public function returns.
+    """
+    from mace.modules.blocks import AtomicEnergiesBlock  # noqa: PLC0415
+    from mace.modules.utils import (  # noqa: PLC0415
+        _compute_mean_rms_energy_forces,
+        _compute_mean_std_atomic_inter_energy,
+        compute_mean_std_atomic_inter_energy,
+    )
+
+    structures = load_training_structures(limit=6)
+    e0s = np.array([-0.1, -0.2, -0.3])
+    with torch_tools.default_dtype("float64"):
+        loader = _labelled_loader(structures, batch_size=len(structures))
+        batch = next(iter(loader))
+        block = AtomicEnergiesBlock(atomic_energies=e0s)
+        per_graph = _compute_mean_std_atomic_inter_energy(batch, block)
+        also_per_graph, forces = _compute_mean_rms_energy_forces(batch, block)
+        mean, std = compute_mean_std_atomic_inter_energy(
+            _labelled_loader(structures), e0s
+        )
+    expected = _per_atom_interaction_energies(structures, e0s)
+    assert per_graph.detach().numpy() == pytest.approx(expected, abs=TOL.atol)
+    assert torch.equal(per_graph, also_per_graph)
+    assert forces.shape[0] == sum(len(atoms) for atoms in structures)
+    assert float(np.atleast_1d(mean)[0]) == pytest.approx(
+        float(per_graph.mean()), abs=TOL.atol
+    )
+    assert float(np.atleast_1d(std)[0]) == pytest.approx(
+        float(per_graph.std(unbiased=True)), abs=TOL.atol
+    )

--- a/tests/unit/test_e0s_characterization.py
+++ b/tests/unit/test_e0s_characterization.py
@@ -411,6 +411,12 @@ def test_estimated_e0s_fall_back_to_the_foundation_when_nothing_has_an_energy(
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(name="fixtures_water")
+def fixture_water():
+    atoms = harness.load_fixtures(names=["water_cluster"])["water_cluster"]
+    return atoms, load_anchor("tiny_scaleshift", torch.float64)
+
+
 def test_the_e0s_enter_the_total_energy_once_per_atom(fixtures_water):
     """Additive, exact, and outside every scaling.
 
@@ -452,12 +458,6 @@ def test_the_e0_contribution_is_the_composition_dot_the_table(fixtures_water):
             model(anchor_graph(model, atoms), compute_force=False)["energy"]
         )
     assert with_e0s - without == pytest.approx(expected, abs=TOL.atol)
-
-
-@pytest.fixture(name="fixtures_water")
-def fixture_water():
-    atoms = harness.load_fixtures(names=["water_cluster"])["water_cluster"]
-    return atoms, load_anchor("tiny_scaleshift", torch.float64)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_e0s_characterization.py
+++ b/tests/unit/test_e0s_characterization.py
@@ -1,0 +1,562 @@
+"""Where the isolated-atom energies come from, and what happens when they do not.
+
+E0s are the largest numbers in a MACE energy by two or three orders of
+magnitude, and they enter in exactly one place: `AtomicEnergiesBlock` looks
+them up with a one-hot matmul and the result is the first term of the readout
+sum (`mace/modules/models.py:359` for plain MACE, `:576` for the scale-shift
+class, where the E0 term sits *outside* the scale and the shift). Everything
+upstream of that lookup -- the four ways a user can supply E0s, and the
+several ways the code quietly supplies its own -- is characterized here.
+
+Three of the behaviours below are **silent fallbacks**: an isolated-atom
+configuration with no energy becomes E0 = 0.0 with a `logging.warning`; a
+NaN reference energy propagates NaN E0s with no log line at all; and a
+species that never appears in the training set gets whatever the minimum-norm
+least-squares solution hands back, which is 0.0. The rewrite is expected to
+turn these into hard errors. Characterizing them first is the point: a
+behaviour nobody wrote down cannot be deliberately changed.
+
+The `"average"` fit and the foundation-`"estimated"` correction are both
+asserted **exactly** against a hand-built `numpy.linalg.lstsq` on the same
+design matrix -- the hand-built version is the executable specification, and
+neither test involves a random seed.
+"""
+
+import json
+import logging
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+from ase.io import write
+
+from mace import data
+from mace.data.utils import (
+    Configuration,
+    KeySpecification,
+    compute_average_E0s,
+    config_from_atoms,
+    estimate_e0s_from_foundation,
+    load_from_xyz,
+)
+from mace.tools import torch_geometric, torch_tools, utils
+from mace.tools.scripts_utils import get_atomic_energies
+from tests.golden import harness
+from tests.golden.anchors import anchor_graph, load_anchor, load_training_structures
+
+TOL = harness.FP64_CPU_REFERENCE
+
+Z_TABLE = utils.AtomicNumberTable([1, 6, 8])
+
+
+def _config(atomic_numbers, energy):
+    """A Configuration carrying nothing but what the E0 fit reads."""
+    count = len(atomic_numbers)
+    return Configuration(
+        atomic_numbers=np.array(atomic_numbers),
+        positions=np.zeros((count, 3)),
+        properties={"energy": energy},
+        property_weights={"energy": 1.0},
+    )
+
+
+def _design_matrix(configs, z_table):
+    """The A and B a hand-written least squares would build. The spec."""
+    matrix = np.zeros((len(configs), len(z_table)))
+    target = np.zeros(len(configs))
+    for row, config in enumerate(configs):
+        target[row] = config.properties["energy"]
+        for column, z in enumerate(z_table.zs):
+            matrix[row, column] = np.count_nonzero(config.atomic_numbers == z)
+    return matrix, target
+
+
+# ---------------------------------------------------------------------------
+# Isolated atoms in the training file
+# ---------------------------------------------------------------------------
+
+
+def _write_xyz(path, structures):
+    write(path, structures, format="extxyz")
+    return str(path)
+
+
+def _isolated(symbol, energy=None):
+    atoms = Atoms(symbol, positions=[[0.0, 0.0, 0.0]], cell=np.eye(3) * 6.0)
+    atoms.info["config_type"] = "IsolatedAtom"
+    if energy is not None:
+        atoms.info["REF_energy"] = energy
+    return atoms
+
+
+def _molecule(symbols, energy):
+    atoms = Atoms(
+        symbols,
+        positions=np.arange(3 * len(symbols)).reshape(-1, 3) * 0.5,
+        cell=np.eye(3) * 8.0,
+        pbc=True,
+    )
+    atoms.info["REF_energy"] = energy
+    return atoms
+
+
+def test_isolated_atom_configs_become_exact_e0s(tmp_path):
+    """The first and most direct route: one config per element, tagged.
+
+    Both conditions are required (`mace/data/utils.py:325-327`): exactly one
+    atom *and* `config_type == "IsolatedAtom"`. A two-atom config carrying
+    the tag is training data, not an E0.
+    """
+    path = _write_xyz(
+        tmp_path / "train.xyz",
+        [
+            _isolated("H", -13.6),
+            _isolated("O", -432.1),
+            _molecule("H2O", -444.0),
+        ],
+    )
+    e0s, configs = load_from_xyz(
+        path, KeySpecification.from_defaults(), extract_atomic_energies=True
+    )
+    assert e0s == {1: -13.6, 8: -432.1}
+    # and the isolated atoms are dropped from the training configurations
+    assert len(configs) == 1
+
+
+def test_an_isolated_atom_that_carries_no_energy_becomes_zero_with_a_warning(
+    tmp_path, caplog
+):
+    """Silent fallback #1, and the one most likely to be hit by accident.
+
+    A typo in `--energy_key` makes every isolated atom look energy-less, and
+    the run then trains against E0 = 0 for that element -- a shift of
+    hundreds of eV -- having logged one warning.
+    """
+    path = _write_xyz(
+        tmp_path / "train.xyz",
+        [_isolated("H", -13.6), _isolated("O"), _molecule("H2O", -444.0)],
+    )
+    with caplog.at_level(logging.WARNING):
+        e0s, _ = load_from_xyz(
+            path, KeySpecification.from_defaults(), extract_atomic_energies=True
+        )
+    assert e0s == {1: -13.6, 8: 0.0}
+    assert any(
+        "IsolatedAtom" in record.message and "Zero energy" in record.message
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_keep_isolated_atoms_leaves_them_in_the_training_set(tmp_path):
+    path = _write_xyz(
+        tmp_path / "train.xyz",
+        [_isolated("H", -13.6), _isolated("O", -432.1), _molecule("H2O", -444.0)],
+    )
+    keyspec = KeySpecification.from_defaults()
+    _, dropped = load_from_xyz(path, keyspec, extract_atomic_energies=True)
+    _, kept = load_from_xyz(
+        path,
+        KeySpecification.from_defaults(),
+        extract_atomic_energies=True,
+        keep_isolated_atoms=True,
+    )
+    assert len(dropped) == 1
+    assert len(kept) == 3
+
+
+def test_a_single_atom_without_the_tag_is_not_an_e0(tmp_path):
+    lonely = Atoms("H", positions=[[0.0, 0.0, 0.0]], cell=np.eye(3) * 6.0)
+    lonely.info["REF_energy"] = -13.6
+    path = _write_xyz(tmp_path / "train.xyz", [lonely, _molecule("H2O", -444.0)])
+    e0s, configs = load_from_xyz(
+        path, KeySpecification.from_defaults(), extract_atomic_energies=True
+    )
+    assert e0s == {}
+    assert len(configs) == 2
+
+
+# ---------------------------------------------------------------------------
+# "average": least squares over the training set
+# ---------------------------------------------------------------------------
+
+
+def test_average_e0s_are_exactly_a_least_squares_fit():
+    """Not approximately: the same floats, bit for bit.
+
+    `compute_average_E0s` builds a composition matrix and calls
+    `numpy.linalg.lstsq(rcond=None)`. The hand-built version here is the
+    executable specification a port is checked against; there is no seed and
+    no tolerance, because there is nothing stochastic about it.
+    """
+    configs = [
+        _config([1, 1, 8], -10.0),
+        _config([6, 8, 8], -20.0),
+        _config([1, 6, 1, 8], -15.0),
+        _config([6, 6], -7.0),
+    ]
+    matrix, target = _design_matrix(configs, Z_TABLE)
+    expected = np.linalg.lstsq(matrix, target, rcond=None)[0]
+
+    got = compute_average_E0s(configs, Z_TABLE)
+    assert sorted(got) == list(Z_TABLE.zs)
+    for column, z in enumerate(Z_TABLE.zs):
+        assert got[z] == expected[column], z
+
+
+def test_average_e0s_reproduce_an_exactly_determined_system():
+    """A case whose answer can be read off, so the fit is not self-referential.
+
+    Three configurations, three elements, consistent by construction with
+    E0(H) = -1, E0(C) = -2, E0(O) = -3: H2O -> -5, CO2 -> -8, CH4 -> -6.
+    """
+    configs = [
+        _config([1, 1, 8], -5.0),
+        _config([6, 8, 8], -8.0),
+        _config([6, 1, 1, 1, 1], -6.0),
+    ]
+    got = compute_average_E0s(configs, Z_TABLE)
+    assert got[1] == pytest.approx(-1.0, abs=TOL.atol)
+    assert got[6] == pytest.approx(-2.0, abs=TOL.atol)
+    assert got[8] == pytest.approx(-3.0, abs=TOL.atol)
+
+
+def test_an_element_absent_from_the_training_set_gets_zero_silently():
+    """Silent fallback #3. `lstsq` returns the minimum-norm solution.
+
+    A z_table wider than the data -- exactly what `--foundation_model_elements`
+    produces -- therefore yields E0 = 0.0 for the unseen elements, with no
+    warning and no rank report.
+    """
+    configs = [_config([1, 1], -2.0), _config([1, 1, 1], -3.0)]
+    got = compute_average_E0s(configs, Z_TABLE)
+    assert got[6] == 0.0
+    assert got[8] == 0.0
+
+
+def test_a_nan_reference_energy_is_not_caught_by_the_linalgerror_fallback(caplog):
+    """Silent fallback #2, and the platform-dependent one.
+
+    `compute_average_E0s` wraps its `lstsq` in `except LinAlgError` and falls
+    back to zeros. NaN input does not necessarily raise: on macOS/Accelerate
+    it returns NaN E0s and the fallback never runs, so the training starts
+    with NaN atomic energies and the first loss is NaN with nothing in the
+    log to say why.
+
+    The assertion is written so that it pins *this* platform's behaviour
+    without asserting one LAPACK: either outcome is accepted, but the pairing
+    is not -- a NaN result must come with no log line (that is what makes it
+    silent), and a zeroed result must come with the error the fallback logs.
+    """
+    configs = [
+        _config([1, 1, 8], float("nan")),
+        _config([6, 8, 8], -20.0),
+        _config([1, 6, 1, 8], -15.0),
+    ]
+    with caplog.at_level(logging.ERROR):
+        got = compute_average_E0s(configs, Z_TABLE)
+    values = np.array([got[z] for z in Z_TABLE.zs])
+    logged = any("least squares" in record.message for record in caplog.records)
+    if np.isnan(values).any():
+        assert not logged, "a NaN result that logs is not the silent path"
+    else:
+        assert np.array_equal(values, np.zeros(3))
+        assert logged, "the zeros fallback logs; nothing else may reach it"
+
+
+# ---------------------------------------------------------------------------
+# get_atomic_energies: the --E0s command line
+# ---------------------------------------------------------------------------
+
+
+def test_e0s_average_goes_through_the_least_squares_fit():
+    configs = [_config([1, 1, 8], -10.0), _config([6, 8, 8], -20.0)]
+    assert get_atomic_energies("average", configs, Z_TABLE) == compute_average_E0s(
+        configs, Z_TABLE
+    )
+
+
+def test_e0s_average_without_a_training_set_is_a_runtime_error():
+    with pytest.raises(RuntimeError, match="Could not compute average E0s"):
+        get_atomic_energies("average", None, Z_TABLE)
+
+
+def test_e0s_from_a_literal_dict_and_from_a_json_file(tmp_path):
+    literal = get_atomic_energies("{1: -13.6, 8: -432.1}", None, Z_TABLE)
+    assert literal == {1: -13.6, 8: -432.1}
+
+    path = tmp_path / "e0s.json"
+    path.write_text(json.dumps({"1": -13.6, "8": -432.1}), encoding="utf-8")
+    from_json = get_atomic_energies(str(path), None, Z_TABLE)
+    # the JSON route stringifies its keys and the loader casts them back
+    assert from_json == literal
+    assert all(isinstance(key, int) for key in from_json)
+
+
+def test_an_unparseable_e0s_string_is_a_runtime_error():
+    with pytest.raises(RuntimeError, match="E0s specified invalidly"):
+        get_atomic_energies("not a dict", None, Z_TABLE)
+
+
+def test_no_e0s_at_all_is_a_runtime_error():
+    with pytest.raises(RuntimeError, match="E0s not found"):
+        get_atomic_energies(None, None, Z_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# The foundation-model "estimated" path
+# ---------------------------------------------------------------------------
+
+
+def _training_configs(limit=5):
+    keyspec = KeySpecification.from_defaults()
+    return [
+        config_from_atoms(atoms, keyspec)
+        for atoms in load_training_structures(limit=limit)
+    ]
+
+
+def test_estimated_e0s_are_the_foundation_e0s_plus_a_least_squares_correction():
+    """The specification, again hand-built on the same design matrix.
+
+    `estimate_e0s_from_foundation` runs the foundation model on every
+    training configuration, fits the *residual* energy per element, and adds
+    the fit to the foundation's own E0s. The committed anchor stands in for
+    the foundation model, which is what makes this testable with no network
+    and no download.
+    """
+    foundation = load_anchor("tiny_scaleshift", torch.float64)
+    foundation_e0s = {1: -1.0, 6: -2.0, 8: -3.0}
+    with torch_tools.default_dtype("float64"):
+        got = estimate_e0s_from_foundation(
+            foundation, foundation_e0s, _training_configs(), Z_TABLE, device="cpu"
+        )
+
+        configs = _training_configs()
+        matrix = np.zeros((len(configs), len(Z_TABLE)))
+        residual = np.zeros(len(configs))
+        foundation_z_table = utils.AtomicNumberTable(
+            [int(z) for z in foundation.atomic_numbers]
+        )
+        for row, config in enumerate(configs):
+            graph = data.AtomicData.from_config(
+                config, z_table=foundation_z_table, cutoff=float(foundation.r_max)
+            )
+            batch = next(
+                iter(
+                    torch_geometric.dataloader.DataLoader(
+                        [graph], batch_size=1, shuffle=False
+                    )
+                )
+            )
+            with torch.no_grad():
+                predicted = float(
+                    foundation(
+                        batch.to_dict(),
+                        training=False,
+                        compute_force=False,
+                        compute_virials=False,
+                        compute_stress=False,
+                    )["energy"]
+                )
+            residual[row] = config.properties["energy"] - predicted
+            for column, z in enumerate(Z_TABLE.zs):
+                matrix[row, column] = np.sum(config.atomic_numbers == z)
+    corrections = np.linalg.lstsq(matrix, residual, rcond=None)[0]
+
+    for column, z in enumerate(Z_TABLE.zs):
+        assert got[z] == foundation_e0s[z] + corrections[column], z
+
+
+def test_estimated_e0s_are_deterministic_at_cpu_float64():
+    """Two runs on freshly rebuilt config objects: bit-identical.
+
+    Rebuilt rather than reused, so that a path which mutated its inputs
+    would show up as a difference rather than being hidden by the second run
+    reading the first one's leftovers.
+    """
+    foundation = load_anchor("tiny_scaleshift", torch.float64)
+    foundation_e0s = {1: -1.0, 6: -2.0, 8: -3.0}
+    with torch_tools.default_dtype("float64"):
+        first = estimate_e0s_from_foundation(
+            foundation, foundation_e0s, _training_configs(), Z_TABLE, device="cpu"
+        )
+        second = estimate_e0s_from_foundation(
+            foundation, foundation_e0s, _training_configs(), Z_TABLE, device="cpu"
+        )
+    assert set(first) == set(second)
+    for z, value in first.items():
+        assert value == second[z], z
+
+
+def test_estimated_e0s_fall_back_to_the_foundation_when_nothing_has_an_energy(
+    caplog,
+):
+    foundation = load_anchor("tiny_scaleshift", torch.float64)
+    foundation_e0s = {1: -1.0, 6: -2.0, 8: -3.0}
+    configs = _training_configs(limit=2)
+    for config in configs:
+        config.properties["energy"] = None
+    with caplog.at_level(logging.WARNING):
+        got = estimate_e0s_from_foundation(
+            foundation, foundation_e0s, configs, Z_TABLE, device="cpu"
+        )
+    assert got == foundation_e0s
+    assert got is not foundation_e0s, "the fallback returns a copy"
+    assert any("No configurations with energy" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Where the E0s land in the energy
+# ---------------------------------------------------------------------------
+
+
+def test_the_e0s_enter_the_total_energy_once_per_atom(fixtures_water):
+    """Additive, exact, and outside every scaling.
+
+    Adding a constant d to every element's E0 moves the total energy by
+    n_atoms * d and nothing else -- the E0 term is a plain sum over the
+    readout, not something the scale or the shift touches.
+    """
+    atoms, model = fixtures_water
+    with torch_tools.default_dtype("float64"):
+        before = float(model(anchor_graph(model, atoms), compute_force=False)["energy"])
+        delta = 1.25
+        model.atomic_energies_fn.atomic_energies = (
+            model.atomic_energies_fn.atomic_energies + delta
+        )
+        after = float(model(anchor_graph(model, atoms), compute_force=False)["energy"])
+    assert after - before == pytest.approx(len(atoms) * delta, abs=TOL.atol)
+
+
+def test_the_e0_contribution_is_the_composition_dot_the_table(fixtures_water):
+    """Read the whole E0 term off the composition, and subtract it.
+
+    Zeroing the table has to remove exactly `sum_z count(z) * E0(z)`, which
+    is what makes the E0s separable from the fitted part at all -- and what
+    the `"average"` fit above assumes.
+    """
+    atoms, model = fixtures_water
+    table = model.atomic_energies_fn.atomic_energies.detach().clone()
+    numbers = [int(z) for z in model.atomic_numbers]
+    expected = sum(
+        float(torch.atleast_2d(table)[0][numbers.index(z)])
+        for z in atoms.get_atomic_numbers()
+    )
+    with torch_tools.default_dtype("float64"):
+        with_e0s = float(
+            model(anchor_graph(model, atoms), compute_force=False)["energy"]
+        )
+        model.atomic_energies_fn.atomic_energies = torch.zeros_like(table)
+        without = float(
+            model(anchor_graph(model, atoms), compute_force=False)["energy"]
+        )
+    assert with_e0s - without == pytest.approx(expected, abs=TOL.atol)
+
+
+@pytest.fixture(name="fixtures_water")
+def fixture_water():
+    atoms = harness.load_fixtures(names=["water_cluster"])["water_cluster"]
+    return atoms, load_anchor("tiny_scaleshift", torch.float64)
+
+
+# ---------------------------------------------------------------------------
+# --mean / --std as explicit statistics overrides
+#
+# The inventory gap assigned to this ticket. These are the two knobs that
+# bypass the dataset-statistics pass entirely, and all three behaviours below
+# are surprising in the same direction: the flag is accepted and then ignored.
+# ---------------------------------------------------------------------------
+
+
+BASE_ARGV = [
+    "--name",
+    "characterization",
+    "--train_file",
+    "unused.xyz",
+    "--model",
+    "ScaleShiftMACE",
+    "--r_max",
+    "4.0",
+    "--max_L",
+    "0",
+    "--num_channels",
+    "4",
+    "--hidden_irreps",
+    "4x0e",
+    "--num_interactions",
+    "2",
+    "--default_dtype",
+    "float64",
+]
+
+
+def _configure(extra_argv):
+    """Parse a real command line and build the model it asks for.
+
+    `configure_model` is only ever called from `run_train.run()`, which sets
+    the five `compute_*` flags itself before calling (mace/cli/run_train.py:
+    618-620); they are reproduced here rather than faked, so the arguments
+    under test are the parsed ones.
+    """
+    from mace.tools.arg_parser import build_default_arg_parser  # noqa: PLC0415
+    from mace.tools.model_script_utils import configure_model  # noqa: PLC0415
+
+    structures = load_training_structures(limit=4)
+    atomic_energies = np.array([-0.1, -0.2, -0.3])
+    with torch_tools.default_dtype("float64"):
+        graphs = [
+            data.AtomicData.from_config(
+                config_from_atoms(atoms, KeySpecification.from_defaults()),
+                z_table=Z_TABLE,
+                cutoff=4.0,
+            )
+            for atoms in structures
+        ]
+        loader = torch_geometric.dataloader.DataLoader(
+            graphs, batch_size=2, shuffle=False
+        )
+        args = build_default_arg_parser().parse_args(BASE_ARGV + extra_argv)
+        args.compute_energy = True
+        args.compute_dipole = False
+        args.compute_polarizability = False
+        args.compute_magforces = False
+        model, _ = configure_model(
+            args, loader, atomic_energies, heads=["Default"], z_table=Z_TABLE
+        )
+    return model
+
+
+def test_mean_and_std_together_override_the_dataset_statistics():
+    """`--std` becomes the scale and `--mean` the shift, verbatim."""
+    model = _configure(["--mean", "1.5", "--std", "2.5"])
+    assert float(model.scale_shift.scale) == pytest.approx(2.5)
+    assert float(model.scale_shift.shift) == pytest.approx(1.5)
+    # and they are not what the data would have produced
+    computed = _configure([])
+    assert float(computed.scale_shift.shift) != pytest.approx(1.5)
+
+
+def test_mean_without_std_is_accepted_and_then_discarded():
+    """Both are recomputed unless *both* are given.
+
+    The guard is `if args.mean is None or args.std is None` (mace/tools/
+    model_script_utils.py:78), so a run that sets only one of them silently
+    gets the dataset statistics for both. Measured here: `--mean 1.5` gives a
+    shift of 0.175, which is the fitted value.
+    """
+    partial = _configure(["--mean", "1.5"])
+    computed = _configure([])
+    assert float(partial.scale_shift.shift) == float(computed.scale_shift.shift)
+    assert float(partial.scale_shift.shift) != pytest.approx(1.5)
+
+
+def test_no_scaling_overrides_even_an_explicit_std():
+    """`--scaling no_scaling` sets std to 1.0 before anything else looks.
+
+    So `--scaling no_scaling --std 7.0` trains with a scale of 1.0 and no
+    warning. The mean is untouched, which is the asymmetry.
+    """
+    model = _configure(["--scaling", "no_scaling", "--std", "7.0", "--mean", "1.5"])
+    assert float(model.scale_shift.scale) == pytest.approx(1.0)
+    assert float(model.scale_shift.shift) == pytest.approx(1.5)

--- a/tests/unit/test_loss.py
+++ b/tests/unit/test_loss.py
@@ -10,8 +10,11 @@ weight, energy_weight, forces_weight, stress_weight, virials_weight. A
 minimal stand-in object providing both access styles is enough.
 """
 
+import argparse
+
 import pytest
 import torch
+import torch.distributed as dist
 
 from mace.modules.loss import (
     DipolePolarLoss,
@@ -26,11 +29,15 @@ from mace.modules.loss import (
     WeightedHuberEnergyForcesStressLoss,
     conditional_huber_forces,
     conditional_mse_forces,
+    is_ddp_enabled,
+    mean_normed_error_forces,
     mean_squared_error_energy,
     mean_squared_error_forces,
     reduce_loss,
+    weighted_mean_absolute_error_energy,
     weighted_mean_squared_error_dipole,
     weighted_mean_squared_error_energy,
+    weighted_mean_squared_error_polarizability,
     weighted_mean_squared_stress,
     weighted_mean_squared_virials,
 )
@@ -76,6 +83,7 @@ def make_ref(num_atoms_per_graph=(2,), **overrides):
         "virials": torch.zeros(n_graphs, 3, 3),
         "dipole": torch.zeros(n_graphs, 3),
         "polarizability": torch.zeros(n_graphs, 3, 3),
+        "magforces": torch.zeros(total_atoms, 3),
     }
     fields.update(overrides)
     return FakeBatch(**fields)
@@ -472,3 +480,394 @@ def test_loss_repr_contains_weights():
     rep = repr(WeightedEnergyForcesLoss(energy_weight=1.0, forces_weight=100.0))
     assert "energy_weight=1.000" in rep
     assert "forces_weight=100.000" in rep
+
+
+# ---------------------------------------------------------------------------
+# UniversalLoss: the magforces term
+#
+# This is the branch that carries most of the file's uncovered arithmetic. It
+# is guarded three ways -- the key has to be in `pred`, and neither
+# `pred["magforces"]` nor `ref["magforces"]` may be None -- so "the model does
+# not predict magnetic forces" is expressed as a silently dropped term rather
+# than as an error. All three guards are pinned below, because a port that
+# turns one of them into a KeyError changes what a non-magnetic training run
+# does.
+# ---------------------------------------------------------------------------
+
+
+def test_universal_loss_magforces_hand_value():
+    # 1 config, 2 atoms, huber_delta = 1.0, every weight 1.
+    # magforces: one component off by 0.5, |0.5| <= delta -> 0.5 * 0.5^2 =
+    # 0.125, meaned over the 6 elements -> 0.125 / 6.
+    ref = make_ref(num_atoms_per_graph=(2,))
+    pred = clone_pred(ref)
+    pred["magforces"] = torch.zeros(2, 3)
+    pred["magforces"][1, 2] = 0.5
+    loss = UniversalLoss(huber_delta=1.0)
+    assert loss(ref, pred).item() == pytest.approx(0.125 / 6.0)
+
+    # the global magforces_weight is a plain linear factor on that term
+    loss_w = UniversalLoss(huber_delta=1.0, magforces_weight=6.0)
+    assert loss_w(ref, pred).item() == pytest.approx(0.125)
+
+
+def test_universal_loss_magforces_per_config_weight_multiplies_the_arguments():
+    """Not the term: the *inputs* of the huber, which is not the same thing.
+
+    `configs_magforces_weight` multiplies ref and pred before the huber
+    (mace/modules/loss.py:486-491), so the error it sees is scaled and the
+    regime it lands in can change. With weight 2 the 0.5 deviation above
+    becomes 1.0, which is exactly at delta: 0.5 * 1.0^2 = 0.5, meaned over 6
+    -> 0.5 / 6, i.e. four times the unweighted value, not twice.
+    """
+    ref = make_ref(num_atoms_per_graph=(2,), magforces_weight=torch.tensor([2.0]))
+    pred = clone_pred(ref)
+    pred["magforces"] = torch.zeros(2, 3)
+    pred["magforces"][1, 2] = 0.5
+    loss = UniversalLoss(huber_delta=1.0)
+    assert loss(ref, pred).item() == pytest.approx(0.5 / 6.0)
+
+
+@pytest.mark.parametrize(
+    "make_pred_entry",
+    [
+        pytest.param(lambda: None, id="pred_is_none"),
+        pytest.param(lambda: "absent", id="key_absent"),
+    ],
+)
+def test_universal_loss_drops_the_magforces_term_when_it_is_not_predicted(
+    make_pred_entry,
+):
+    ref = make_ref(num_atoms_per_graph=(2,), energy=torch.tensor([1.0]))
+    pred = clone_pred(ref)
+    entry = make_pred_entry()
+    if entry != "absent":
+        pred["magforces"] = entry
+    loss = UniversalLoss(huber_delta=1.0, magforces_weight=1000.0)
+    # nothing deviates and the magforces term is skipped: exactly zero, and
+    # in particular not a TypeError from huber_loss(None, ...).
+    assert loss(ref, pred).item() == pytest.approx(0.0)
+
+
+def test_universal_loss_drops_the_magforces_term_when_the_reference_is_none():
+    ref = make_ref(num_atoms_per_graph=(2,), magforces=None)
+    pred = clone_pred(ref)
+    pred["magforces"] = torch.ones(2, 3)
+    loss = UniversalLoss(huber_delta=1.0, magforces_weight=1000.0)
+    assert loss(ref, pred).item() == pytest.approx(0.0)
+
+
+def test_universal_loss_full_hand_value_over_all_four_terms():
+    # 1 config, 2 atoms, huber_delta = 1.0, all per-config weights 1.
+    #   energy:     (12 - 10) / 2 = 1.0 = delta -> 0.5 * 1^2       = 0.5
+    #   forces:     |F_ref| = 0 -> factor 1.0 -> delta 1.0; error 2.0 is in
+    #               the linear regime: 1 * (2 - 0.5) = 1.5, / 6     = 0.25
+    #   stress:     error 3.0, linear: 1 * (3 - 0.5) = 2.5, / 9     = 2.5/9
+    #   magforces:  error 0.5, quadratic: 0.5 * 0.25 = 0.125, / 6   = 0.125/6
+    ref = make_ref(num_atoms_per_graph=(2,), energy=torch.tensor([10.0]))
+    pred = clone_pred(ref)
+    pred["energy"] = torch.tensor([12.0])
+    pred["forces"][1, 2] = 2.0
+    pred["stress"][0, 0, 0] = 3.0
+    pred["magforces"] = torch.zeros(2, 3)
+    pred["magforces"][0, 1] = 0.5
+    expected = 0.5 + 0.25 + 2.5 / 9.0 + 0.125 / 6.0
+    loss = UniversalLoss(huber_delta=1.0)
+    assert loss(ref, pred).item() == pytest.approx(expected)
+
+    # the four global weights are a plain linear combination of those terms
+    loss_w = UniversalLoss(
+        energy_weight=2.0,
+        forces_weight=4.0,
+        stress_weight=9.0,
+        magforces_weight=6.0,
+        huber_delta=1.0,
+    )
+    assert loss_w(ref, pred).item() == pytest.approx(
+        2.0 * 0.5 + 4.0 * 0.25 + 9.0 * (2.5 / 9.0) + 6.0 * (0.125 / 6.0)
+    )
+
+
+def test_universal_loss_per_config_energy_weight_is_not_a_linear_factor():
+    """Doubling it tripled this loss. Measured, and pinned so a port keeps it.
+
+    `configs_energy_weight` multiplies both sides *inside* the huber
+    (mace/modules/loss.py:464-469), so it rescales the error and can push it
+    from the quadratic branch into the linear one. Deviation 2.0 over 2
+    atoms: at weight 1 the argument is 1.0 = delta -> 0.5; at weight 2 it is
+    2.0 -> 1 * (2 - 0.5) = 1.5.
+    """
+    pred_energy = torch.tensor([2.0])
+    plain = make_ref(num_atoms_per_graph=(2,))
+    doubled = make_ref(
+        num_atoms_per_graph=(2,), energy_weight=torch.tensor([2.0])
+    )
+    loss = UniversalLoss(huber_delta=1.0)
+
+    pred = clone_pred(plain)
+    pred["energy"] = pred_energy
+    assert loss(plain, pred).item() == pytest.approx(0.5)
+    assert loss(doubled, pred).item() == pytest.approx(1.5)
+
+
+def test_universal_loss_per_config_forces_weight_can_change_the_huber_regime():
+    """The same rescaling, but on the *regime selector* as well.
+
+    `conditional_huber_forces` picks its delta from `torch.norm(ref_forces)`
+    -- and what it is handed is the already-weighted reference. A 60 eV/Ang
+    reference force sits in regime 1 (delta = 1.0 * huber_delta); at
+    forces_weight 2 it is 120 and lands in regime 2 (delta = 0.7 *
+    huber_delta), so the loss changes by 2.31x rather than by 2x or 4x.
+    """
+    base_forces = torch.tensor([[60.0, 0.0, 0.0]])
+    plain = make_ref(num_atoms_per_graph=(1,), forces=base_forces)
+    doubled = make_ref(
+        num_atoms_per_graph=(1,),
+        forces=base_forces,
+        forces_weight=torch.tensor([2.0]),
+    )
+    pred = clone_pred(plain)
+    pred["forces"] = torch.tensor([[61.0, 0.0, 0.0]])
+    loss = UniversalLoss(huber_delta=1.0)
+
+    # weight 1: |F| = 60 -> delta 1.0, error 1.0 -> 0.5 * 1^2 = 0.5, / 3
+    assert loss(plain, pred).item() == pytest.approx(1.0 / 6.0)
+    # weight 2: |F| = 120 -> delta 0.7, error 2.0 -> 0.7 * (2 - 0.35) = 1.155
+    assert loss(doubled, pred).item() == pytest.approx(1.155 / 3.0)
+
+
+# ---------------------------------------------------------------------------
+# The ddp=True branches
+#
+# Two loss modules keep a whole second copy of their arithmetic under
+# `if ddp:` -- reduction="none" followed by reduce_loss instead of
+# reduction="mean". With no process group initialised, reduce_loss falls
+# through to a plain mean, so the two branches must agree exactly. That
+# equality is the only thing that makes the single-process test suite say
+# anything at all about the distributed path.
+# ---------------------------------------------------------------------------
+
+
+def _deviating_pair():
+    ref = make_ref(num_atoms_per_graph=(2, 3), energy=torch.tensor([10.0, -4.0]))
+    pred = clone_pred(ref)
+    pred["energy"] = torch.tensor([11.0, -6.5])
+    pred["forces"][0, 0] = 2.0
+    pred["forces"][3, 1] = -0.25
+    pred["stress"][0, 0, 0] = 3.0
+    pred["stress"][1, 1, 2] = -0.5
+    pred["magforces"] = torch.zeros(5, 3)
+    pred["magforces"][2, 1] = 0.75
+    return ref, pred
+
+
+@pytest.mark.parametrize(
+    "loss_fn",
+    [
+        WeightedHuberEnergyForcesStressLoss(huber_delta=1.0),
+        UniversalLoss(huber_delta=1.0),
+    ],
+    ids=["huber", "universal"],
+)
+def test_the_ddp_branch_is_the_same_arithmetic_without_a_process_group(loss_fn):
+    ref, pred = _deviating_pair()
+    assert loss_fn(ref, pred, ddp=True).item() == loss_fn(ref, pred, ddp=False).item()
+
+
+def test_is_ddp_enabled_is_false_without_a_process_group():
+    assert is_ddp_enabled() is False
+
+
+def test_reduce_loss_ddp_formula_in_a_world_of_one(tmp_path):
+    """The one path a single-process test can still reach exactly.
+
+    `reduce_loss` under ddp does not take a mean: it computes
+    `local_sum * world_size / global_num_elements`, which is the mean only
+    because every rank contributes its own element count to the all_reduce.
+    With a world of one that reduces to the plain mean, which is what makes
+    it checkable here -- and the formula, not the mean, is what a port has to
+    reproduce, because the two disagree the moment ranks hold different
+    numbers of atoms.
+    """
+    store = tmp_path / "gloo_store"
+    dist.init_process_group(
+        backend="gloo", init_method=f"file://{store}", rank=0, world_size=1
+    )
+    try:
+        raw = torch.tensor([1.0, 2.0, 6.0])
+        assert dist.get_world_size() == 1
+        # world_size 1 means is_ddp_enabled() stays False even here: the
+        # helper asks for > 1, so a one-rank run takes the plain-mean path
+        # unless a caller passes ddp=True explicitly.
+        assert is_ddp_enabled() is False
+        assert reduce_loss(raw, ddp=True).item() == pytest.approx(3.0)
+        assert reduce_loss(raw, ddp=None).item() == pytest.approx(3.0)
+    finally:
+        dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# The remaining elementary functions
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_mean_absolute_error_energy():
+    # 2 configs of 2 atoms; deviations 3.0 and -1.0 -> |3/2| and |-1/2|
+    # weights [1, 3] -> raw = [1.5, 1.5] -> mean = 1.5
+    ref = make_ref(num_atoms_per_graph=(2, 2), weight=torch.tensor([1.0, 3.0]))
+    pred = clone_pred(ref)
+    pred["energy"] = torch.tensor([3.0, -1.0])
+    assert weighted_mean_absolute_error_energy(ref, pred).item() == pytest.approx(1.5)
+
+
+def test_mean_normed_error_forces_is_unweighted():
+    """The L1L2 forces term ignores every weight, unlike every other one.
+
+    `mean_normed_error_forces` takes the per-atom error norm and means it,
+    with no `ref.weight` and no `ref.forces_weight` anywhere
+    (mace/modules/loss.py:138-142). Pinned because it is the single
+    exception, and a port that "regularises" it changes what
+    `--loss l1l2energyforces` fits.
+    """
+    ref = make_ref(num_atoms_per_graph=(2,), weight=torch.tensor([7.0]))
+    pred = clone_pred(ref)
+    pred["forces"][0] = torch.tensor([3.0, 4.0, 0.0])  # norm 5
+    pred["forces"][1] = torch.tensor([0.0, 0.0, 1.0])  # norm 1
+    assert mean_normed_error_forces(ref, pred).item() == pytest.approx(3.0)
+
+
+def test_weighted_mean_squared_error_polarizability_reshapes_only_the_reference():
+    """An asymmetry worth pinning: `.view(-1, 3, 3)` is applied to `ref` only.
+
+    A reference stored flat as [n_graphs, 9] is accepted and reshaped
+    (mace/modules/loss.py:174); a prediction stored flat is not, and would
+    broadcast into nonsense instead of failing. Both sides are pinned.
+    """
+    ref = make_ref(
+        num_atoms_per_graph=(2,), polarizability=torch.zeros(1, 9)
+    )
+    pred = clone_pred(ref)
+    pred["polarizability"] = torch.zeros(1, 3, 3)
+    pred["polarizability"][0, 2, 0] = 6.0
+    # (6 / 2)^2 = 9 in one of nine components -> 1.0
+    assert weighted_mean_squared_error_polarizability(
+        ref, pred
+    ).item() == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Every class renders its weights, and every CLI name reaches a class
+# ---------------------------------------------------------------------------
+
+
+ALL_LOSS_CLASSES = (
+    (WeightedEnergyForcesLoss, ("energy_weight", "forces_weight")),
+    (WeightedForcesLoss, ("forces_weight",)),
+    (WeightedEnergyForcesStressLoss, ("energy_weight", "forces_weight", "stress_weight")),
+    (
+        WeightedHuberEnergyForcesStressLoss,
+        ("energy_weight", "forces_weight", "stress_weight"),
+    ),
+    (
+        UniversalLoss,
+        ("energy_weight", "forces_weight", "stress_weight", "magforces_weight"),
+    ),
+    (
+        WeightedEnergyForcesVirialsLoss,
+        ("energy_weight", "forces_weight", "virials_weight"),
+    ),
+    (DipoleSingleLoss, ("dipole_weight",)),
+    (DipolePolarLoss, ("dipole_weight", "polarizability_weight")),
+    (
+        WeightedEnergyForcesDipoleLoss,
+        ("energy_weight", "forces_weight", "dipole_weight"),
+    ),
+    (WeightedEnergyForcesL1L2Loss, ("energy_weight", "forces_weight")),
+)
+
+
+@pytest.mark.parametrize(
+    "cls,weight_names", ALL_LOSS_CLASSES, ids=lambda v: getattr(v, "__name__", "")
+)
+def test_every_loss_class_renders_its_weights(cls, weight_names):
+    """`__repr__` is what the training log records the loss as.
+
+    It is the only record of which weights a finished run used, so every
+    class has to name all of its own, at three decimals.
+    """
+    loss = cls(**{name: 2.5 for name in weight_names})
+    rep = repr(loss)
+    assert rep.startswith(cls.__name__ + "(")
+    for name in weight_names:
+        assert f"{name}=2.500" in rep, rep
+
+
+LOSS_CLI_NAMES = {
+    "weighted": WeightedEnergyForcesLoss,
+    "forces_only": WeightedForcesLoss,
+    "virials": WeightedEnergyForcesVirialsLoss,
+    "stress": WeightedEnergyForcesStressLoss,
+    "huber": WeightedHuberEnergyForcesStressLoss,
+    "universal": UniversalLoss,
+    "l1l2energyforces": WeightedEnergyForcesL1L2Loss,
+    "dipole": DipoleSingleLoss,
+    "dipole_polar": DipolePolarLoss,
+    "energy_forces_dipole": WeightedEnergyForcesDipoleLoss,
+}
+
+
+def _loss_args(name):
+    return argparse.Namespace(
+        loss=name,
+        energy_weight=2.0,
+        forces_weight=3.0,
+        stress_weight=4.0,
+        virials_weight=5.0,
+        dipole_weight=6.0,
+        polarizability_weight=7.0,
+        magforces_weight=8.0,
+        huber_delta=0.5,
+    )
+
+
+@pytest.mark.parametrize("name,cls", sorted(LOSS_CLI_NAMES.items()))
+def test_every_cli_loss_name_reaches_its_class_with_its_weights(name, cls):
+    """`--loss <name>` is the only way a user selects any of this.
+
+    The mapping lives in `get_loss_fn` and is otherwise untested; a rename
+    there is silent, because the `else` branch hands back a default
+    WeightedEnergyForcesLoss rather than refusing.
+    """
+    from mace.tools.scripts_utils import get_loss_fn  # noqa: PLC0415
+
+    args = _loss_args(name)
+    loss = get_loss_fn(
+        args, dipole_only=(name == "dipole"), compute_dipole=("dipole" in name)
+    )
+    assert isinstance(loss, cls)
+    for attr, value in (
+        ("energy_weight", 2.0),
+        ("forces_weight", 3.0),
+        ("stress_weight", 4.0),
+        ("virials_weight", 5.0),
+        ("dipole_weight", 6.0),
+        ("polarizability_weight", 7.0),
+        ("magforces_weight", 8.0),
+    ):
+        if hasattr(loss, attr):
+            assert float(getattr(loss, attr)) == value
+    if hasattr(loss, "huber_delta"):
+        assert loss.huber_delta == 0.5
+
+
+def test_an_unknown_cli_loss_name_falls_back_instead_of_failing():
+    """Characterization, not endorsement: a typo silently trains `weighted`."""
+    from mace.tools.scripts_utils import get_loss_fn  # noqa: PLC0415
+
+    loss = get_loss_fn(
+        _loss_args("universl"), dipole_only=False, compute_dipole=False
+    )
+    assert isinstance(loss, WeightedEnergyForcesLoss)
+    # and with the *default* weights, not the ones on the command line
+    assert float(loss.energy_weight) == 1.0
+    assert float(loss.forces_weight) == 1.0

--- a/tests/unit/test_loss.py
+++ b/tests/unit/test_loss.py
@@ -871,3 +871,47 @@ def test_an_unknown_cli_loss_name_falls_back_instead_of_failing():
     # and with the *default* weights, not the ones on the command line
     assert float(loss.energy_weight) == 1.0
     assert float(loss.forces_weight) == 1.0
+
+
+def test_a_zero_config_weight_dilutes_rather_than_renormalizing():
+    """Masking semantics: weight 0 removes a config's contribution, but the
+    mean keeps its elements in the denominator.
+
+    So the remaining loss is *halved*, not preserved. Stated as its own test
+    because the plausible-looking alternative -- renormalising over the
+    non-zero weights -- differs by exactly the factor a rewrite would not
+    notice: every individual term is still right, and only the total moves.
+    """
+    ref = make_ref(num_atoms_per_graph=(1, 1), energy=torch.zeros(2))
+    pred = clone_pred(ref)
+    pred["energy"] = torch.tensor([1.0, 1.0])
+    both = weighted_mean_squared_error_energy(ref, pred).item()
+
+    ref.weight = torch.tensor([1.0, 0.0])
+    masked = weighted_mean_squared_error_energy(ref, pred).item()
+    assert masked == pytest.approx(both / 2)
+
+
+def test_the_weighted_huber_loss_ignores_config_and_property_weights():
+    """Unlike every other class here, this one drops the per-config weights.
+
+    Pinned because it is surprising: the constructor takes global weights and
+    honours them, so the natural assumption is that the per-config ones apply
+    too. They do not, and a test that only ever passes weights of 1.0 -- as
+    the hand-value test above does -- cannot tell the difference.
+    """
+    ref = make_ref(num_atoms_per_graph=(2,))
+    pred = clone_pred(ref)
+    pred["energy"] = torch.tensor([0.004])
+    pred["forces"][0, 0] = 0.002
+    pred["forces"][1, 0] = 0.002
+    pred["stress"][0, 0, 0] = 0.001
+
+    loss = WeightedHuberEnergyForcesStressLoss(
+        energy_weight=1.0, forces_weight=1.0, stress_weight=1.0, huber_delta=0.01
+    )
+    unweighted = loss(ref, pred).item()
+
+    for field in ("weight", "energy_weight", "forces_weight", "stress_weight"):
+        setattr(ref, field, torch.tensor([9.0]))
+    assert loss(ref, pred).item() == pytest.approx(unweighted)

--- a/tests/unit/test_physics_glue.py
+++ b/tests/unit/test_physics_glue.py
@@ -121,7 +121,7 @@ def test_the_reported_force_is_the_gradient_of_the_energy_the_model_returns(fixt
 
     ScaleShiftMACE differentiates the *interaction* energy
     (mace/modules/models.py:585) while plain MACE differentiates the total
-    (`:590`), and the two are only interchangeable because the E0 branch has
+    (`:403`), and the two are only interchangeable because the E0 branch has
     no autograd path to the positions at all. That is a property of the
     model, not an identity, so it is measured: if a future E0 term ever
     became position dependent, the ScaleShiftMACE forces would silently stop
@@ -424,7 +424,7 @@ def test_prepare_graph_rewrites_the_callers_positions_and_shifts(fixtures):
 
     `prepare_graph` sets `requires_grad_` on the caller's positions tensor
     and, in the stress branch, replaces `data["positions"]` and
-    `data["shifts"]` with the strained ones (mace/modules/utils.py:781).
+    `data["shifts"]` with the strained ones (mace/modules/utils.py:783).
     The edge vectors are then built from the *replacement*, so a port that
     treats the input dict as read-only computes the unstrained vectors and
     gets a zero stress with no error anywhere.

--- a/tests/unit/test_physics_glue.py
+++ b/tests/unit/test_physics_glue.py
@@ -1,0 +1,565 @@
+"""The differentiable physics glue, characterized against finite differences.
+
+**These docstrings are normative.** CORE-3 copies the three sign conventions
+below verbatim into the rewrite's units module, and every one of them is
+asserted by a test in this file rather than assumed:
+
+* **forces** = -dE/d(positions), in eV/Ang.
+* **stress** = (1/V) dE/d(strain), in eV/Ang^3, with V = |det(cell)|.
+* **virials** = -stress * V = -dE/d(strain), in eV.
+
+All three come out of one function, `compute_forces_virials`
+(mace/modules/utils.py:52-80): it takes the raw autograd gradients of the
+energy with respect to the positions and to the injected strain, divides the
+strain gradient by |det(cell)| to form the stress, and negates *both* raw
+gradients on the way out. So the returned stress is the only one of the three
+that is **not** negated, and the virial is the negative of the same quantity
+the stress is built from. That asymmetry is the single most likely thing for
+a port to normalise away, which is why the relation is pinned twice here --
+once against a finite-difference derivative and once against a synthetic
+energy whose gradient is known exactly and by hand.
+
+Everything runs on the committed fp64 anchors on CPU, with no capability
+marker: this is the specification the new derivative code is written against,
+so it may not be a test that can skip.
+
+Tolerances come from the one table in `tests/golden/harness.py`. The
+finite-difference comparisons use the fp64 CPU row (1e-6 absolute), and they
+clear it by four to five orders of magnitude -- measured on this tree, the
+worst deviation is 2.2e-11 eV/Ang for the forces and 2.5e-13 eV/Ang^3 for the
+stress. The budget at h = 1e-4 Ang is dominated by cancellation, not by the
+5-point stencil's O(h^4) truncation: roughly eps * |E| / h ~ 1e-16 * 40 / 1e-4
+= 4e-11, which is what is actually observed.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from mace.modules.utils import (
+    compute_forces,
+    compute_forces_virials,
+    get_edge_vectors_and_lengths,
+    prepare_graph,
+)
+from mace.tools import torch_tools
+from tests.golden import harness
+from tests.golden.anchors import ANCHORS, anchor_graph, load_anchor
+
+TOL = harness.FP64_CPU_REFERENCE
+
+#: 5-point central difference step. Large enough that cancellation at fp64
+#: stays ~1e-11 eV/Ang, small enough that the O(h^4) truncation term is far
+#: below that.
+STEP = 1e-4
+
+#: strain increment for the stress differences, in dimensionless strain.
+STRAIN_STEP = 1e-5
+
+
+@pytest.fixture(name="fixtures", scope="module")
+def fixture_fixtures():
+    return harness.load_fixtures()
+
+
+def _five_point(values, step):
+    """(f(-2h), f(-h), f(+h), f(+2h)) -> df/dx, error O(h^4)."""
+    minus2, minus1, plus1, plus2 = values
+    return (minus2 - 8.0 * minus1 + 8.0 * plus1 - plus2) / (12.0 * step)
+
+
+def _energy(model, atoms):
+    return float(
+        model(anchor_graph(model, atoms), compute_force=False)["energy"].detach()
+    )
+
+
+# ---------------------------------------------------------------------------
+# forces = -dE/dx
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("anchor", sorted(ANCHORS))
+def test_forces_are_minus_the_energy_gradient(anchor, fixtures):
+    """Five-point central differences on every degree of freedom.
+
+    The cluster fixture is used rather than a periodic one so that only the
+    position derivative is in play; the strain derivative gets its own test.
+    """
+    atoms = fixtures["water_cluster"]
+    model = load_anchor(anchor)
+    with torch_tools.default_dtype("float64"):
+        forces = (
+            model(anchor_graph(model, atoms), compute_force=True)["forces"]
+            .detach()
+            .numpy()
+        )
+        reference_positions = atoms.get_positions().copy()
+        gradient = np.zeros_like(reference_positions)
+        for atom in range(len(atoms)):
+            for axis in range(3):
+                energies = []
+                for multiple in (-2, -1, 1, 2):
+                    moved = atoms.copy()
+                    positions = reference_positions.copy()
+                    positions[atom, axis] += multiple * STEP
+                    moved.set_positions(positions)
+                    energies.append(_energy(model, moved))
+                gradient[atom, axis] = _five_point(energies, STEP)
+
+    assert np.abs(forces).max() > 1e-3, "a vanishing force makes this vacuous"
+    deviation = np.abs(forces - (-gradient)).max()
+    assert deviation < TOL.atol, f"max |F + dE/dx| = {deviation:.3e}"
+    # and the sign is asserted, not assumed: the other choice is wrong by
+    # twice the force, which is orders of magnitude outside the row.
+    assert np.abs(forces - gradient).max() > TOL.atol
+
+
+def test_the_reported_force_is_the_gradient_of_the_energy_the_model_returns(fixtures):
+    """`d(total_energy)/dx` is bit-for-bit the force, in both classes.
+
+    ScaleShiftMACE differentiates the *interaction* energy
+    (mace/modules/models.py:585) while plain MACE differentiates the total
+    (`:590`), and the two are only interchangeable because the E0 branch has
+    no autograd path to the positions at all. That is a property of the
+    model, not an identity, so it is measured: if a future E0 term ever
+    became position dependent, the ScaleShiftMACE forces would silently stop
+    being the gradient of the energy it reports.
+    """
+    atoms = fixtures["water_cluster"]
+    for anchor in ANCHORS:
+        model = load_anchor(anchor)
+        with torch_tools.default_dtype("float64"):
+            graph = anchor_graph(model, atoms)
+            out = model(graph, training=True, compute_force=True)
+            gradient = torch.autograd.grad(
+                out["energy"].sum(), graph["positions"], retain_graph=True
+            )[0]
+        assert torch.equal(out["forces"], -gradient), anchor
+
+
+def test_a_structure_with_no_edges_gets_zero_forces(fixtures):
+    model = load_anchor("tiny_scaleshift")
+    with torch_tools.default_dtype("float64"):
+        graph = anchor_graph(model, fixtures["isolated_atom"])
+        assert graph["edge_index"].shape[1] == 0
+        forces = model(graph, compute_force=True)["forces"]
+    assert torch.equal(forces, torch.zeros_like(forces))
+
+
+def test_compute_forces_returns_zeros_when_the_energy_is_unconnected():
+    """The `allow_unused` branch, which no fixture reaches.
+
+    A single-atom structure still returns a *computed* zero (autograd walks
+    an empty edge set and produces 0.0, which the trailing `-1 *` turns into
+    -0.0). The None branch is only reached when the energy shares no graph
+    with the positions at all, and it returns a fresh +0.0 -- so the two are
+    distinguishable, and only this one is a stand-in for "there was nothing
+    to differentiate".
+    """
+    positions = torch.zeros((3, 3), dtype=torch.float64, requires_grad=True)
+    unrelated = torch.ones(1, dtype=torch.float64, requires_grad=True) * 2.0
+    forces = compute_forces(unrelated, positions, training=False)
+    assert forces.shape == positions.shape
+    assert torch.equal(forces, torch.zeros_like(forces))
+    assert not torch.signbit(forces).any(), "the None branch returns +0.0"
+
+
+# ---------------------------------------------------------------------------
+# stress = (1/V) dE/d(strain), virials = -stress * V
+# ---------------------------------------------------------------------------
+
+
+def _strained_energy(model, atoms, strain):
+    """Energy of `atoms` under the linear deformation (I + strain).
+
+    Both the cell and the positions are deformed, which is what the model's
+    own strain injection does: `get_symmetric_displacement` adds
+    `positions @ symmetric_displacement` to the positions and
+    `cell @ symmetric_displacement` to the cell.
+    """
+    deformed = atoms.copy()
+    deformation = np.eye(3) + strain
+    deformed.set_cell(np.array(atoms.get_cell()) @ deformation.T, scale_atoms=False)
+    deformed.set_positions(atoms.get_positions() @ deformation.T)
+    return _energy(model, deformed)
+
+
+@pytest.mark.parametrize("anchor", sorted(ANCHORS))
+def test_stress_is_the_strain_derivative_over_the_volume(anchor, fixtures):
+    """All six independent components, by finite strains of +-1e-5.
+
+    The strain applied for component (i, j) is symmetric by construction, so
+    what is differentiated is exactly the symmetrised strain the model
+    injects -- an antisymmetric perturbation is a rotation and must not
+    change the energy at all (asserted separately below).
+    """
+    atoms = fixtures["triclinic_bulk"]
+    model = load_anchor(anchor)
+    volume = float(abs(np.linalg.det(np.array(atoms.get_cell()))))
+    with torch_tools.default_dtype("float64"):
+        stress = (
+            model(anchor_graph(model, atoms), compute_stress=True)["stress"]
+            .detach()
+            .numpy()[0]
+        )
+        finite_difference = np.zeros((3, 3))
+        for i, j in ((0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1)):
+            direction = np.zeros((3, 3))
+            if i == j:
+                direction[i, i] = 1.0
+            else:
+                direction[i, j] = direction[j, i] = 0.5
+            energies = [
+                _strained_energy(model, atoms, multiple * STRAIN_STEP * direction)
+                for multiple in (-2, -1, 1, 2)
+            ]
+            value = _five_point(energies, STRAIN_STEP) / volume
+            finite_difference[i, j] = finite_difference[j, i] = value
+
+    assert np.abs(stress).max() > 1e-5, "a vanishing stress makes this vacuous"
+    deviation = np.abs(stress - finite_difference).max()
+    assert deviation < TOL.atol, f"max |stress - dE/de / V| = {deviation:.3e}"
+    # the opposite sign convention is wrong by twice the stress
+    assert np.abs(stress + finite_difference).max() > TOL.atol
+
+
+@pytest.mark.parametrize("anchor", sorted(ANCHORS))
+def test_virials_are_minus_the_stress_times_the_volume(anchor, fixtures):
+    """The relation both come out of, asserted rather than assumed."""
+    atoms = fixtures["triclinic_bulk"]
+    model = load_anchor(anchor)
+    volume = float(abs(np.linalg.det(np.array(atoms.get_cell()))))
+    with torch_tools.default_dtype("float64"):
+        out = model(anchor_graph(model, atoms), compute_stress=True, compute_virials=True)
+    stress = out["stress"].detach().numpy()[0]
+    virials = out["virials"].detach().numpy()[0]
+    assert np.abs(virials).max() > 1e-3, "a vanishing virial makes this vacuous"
+    assert np.abs(virials + stress * volume).max() < TOL.atol
+
+
+def test_the_sign_of_every_derivative_against_a_hand_differentiable_energy():
+    """The conventions with no model in the way.
+
+    E = a . x  (summed over atoms) + c * tr(displacement) has
+    dE/dx = a and dE/d(eps) = c * I by inspection, so the three returned
+    quantities can be read off:
+
+        forces  = -a
+        stress  = +c * I / V
+        virials = -c * I
+
+    A model-based test can only ever compare two computed things; this one
+    compares against arithmetic.
+    """
+    a = torch.tensor([[2.0, -3.0, 0.5]], dtype=torch.float64)
+    c = 7.0
+    volume = 8.0
+    identity = torch.eye(3, dtype=torch.float64).unsqueeze(0)
+
+    def evaluate(cell):
+        positions = torch.zeros((1, 3), dtype=torch.float64, requires_grad=True)
+        displacement = torch.zeros((1, 3, 3), dtype=torch.float64, requires_grad=True)
+        energy = (a * positions).sum() + c * torch.einsum(
+            "bii->b", displacement
+        ).sum()
+        return compute_forces_virials(
+            energy=energy,
+            positions=positions,
+            displacement=displacement,
+            cell=cell,
+            training=False,
+            compute_stress=True,
+        )
+
+    cell = identity * 2.0  # det = 8
+    forces, virials, stress = evaluate(cell)
+    assert torch.allclose(forces, -a, atol=TOL.atol, rtol=TOL.rtol)
+    assert torch.allclose(virials, -c * identity, atol=TOL.atol, rtol=TOL.rtol)
+    expected_stress = c * identity / volume
+    assert torch.allclose(stress, expected_stress, atol=TOL.atol, rtol=TOL.rtol)
+    # the volume is |det(cell)|, so a left-handed cell gives the same stress
+    _, _, mirrored = evaluate(-cell)
+    assert torch.allclose(mirrored, expected_stress, atol=TOL.atol, rtol=TOL.rtol)
+
+
+def test_a_blown_up_stress_component_is_silently_zeroed():
+    """`torch.where(|stress| < 1e10, stress, 0)` (mace/modules/utils.py:74).
+
+    A stress that overflows the threshold is replaced by zero, not clipped
+    and not propagated, and nothing is logged. Characterization, emphatically
+    not endorsement: downstream this reads as "this structure has no stress".
+    The trigger in practice is a near-degenerate cell, so the test uses one.
+    """
+    def evaluate(cell):
+        displacement = torch.zeros((1, 3, 3), dtype=torch.float64, requires_grad=True)
+        positions = torch.zeros((1, 3), dtype=torch.float64, requires_grad=True)
+        energy = torch.einsum("bii->b", displacement) * 1.0 + positions.sum()
+        return compute_forces_virials(
+            energy=energy,
+            positions=positions,
+            displacement=displacement,
+            cell=cell,
+            training=False,
+            compute_stress=True,
+        )
+
+    tiny = torch.eye(3, dtype=torch.float64).unsqueeze(0)
+    tiny[0, 2, 2] = 1e-11  # volume 1e-11 -> stress 1e11, over the threshold
+    _, virials, stress = evaluate(tiny)
+    assert torch.equal(
+        torch.diagonal(stress, dim1=-2, dim2=-1),
+        torch.zeros(1, 3, dtype=torch.float64),
+    )
+    # the virial is *not* clamped: only the stress passes through the where.
+    assert torch.allclose(
+        torch.diagonal(virials, dim1=-2, dim2=-1),
+        -torch.ones(1, 3, dtype=torch.float64),
+        atol=TOL.atol,
+        rtol=TOL.rtol,
+    )
+
+    # just under the threshold the same component survives untouched
+    survivable = tiny.clone()
+    survivable[0, 2, 2] = 1e-9  # volume 1e-9 -> stress 1e9
+    _, _, kept = evaluate(survivable)
+    assert float(kept[0, 0, 0]) == pytest.approx(1e9)
+
+
+# ---------------------------------------------------------------------------
+# prepare_graph: the strain handle, and what it mutates
+# ---------------------------------------------------------------------------
+
+
+def _graph_for(fixture_name, fixtures, model):
+    with torch_tools.default_dtype("float64"):
+        return anchor_graph(model, fixtures[fixture_name])
+
+
+def test_prepare_graph_injects_a_differentiable_strain_handle(fixtures):
+    """No `displacement`, no stress: this is where the strain enters at all.
+
+    `get_symmetric_displacement` builds a zero 3x3 per graph and ties it to
+    the graph with `displacement + positions.sum() * 0.0`, so it is a
+    non-leaf tensor that carries a gradient path while contributing exactly
+    nothing to the energy. Both halves matter: without the path there is no
+    stress, and with any contribution the energy would be wrong.
+    """
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    context = prepare_graph(graph, compute_stress=True)
+    assert context.displacement is not None
+    assert context.displacement.shape == (1, 3, 3)
+    assert context.displacement.requires_grad
+    assert torch.count_nonzero(context.displacement) == 0
+
+
+def test_prepare_graph_without_stress_leaves_an_inert_displacement(fixtures):
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    context = prepare_graph(graph)
+    assert context.displacement is not None
+    assert not context.displacement.requires_grad
+
+
+def test_prepare_graph_rewrites_the_callers_positions_and_shifts(fixtures):
+    """A mutation the port has to keep: `data` is written back into.
+
+    `prepare_graph` sets `requires_grad_` on the caller's positions tensor
+    and, in the stress branch, replaces `data["positions"]` and
+    `data["shifts"]` with the strained ones (mace/modules/utils.py:781).
+    The edge vectors are then built from the *replacement*, so a port that
+    treats the input dict as read-only computes the unstrained vectors and
+    gets a zero stress with no error anywhere.
+    """
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    positions_before = graph["positions"].detach().clone()
+    shifts_before = graph["shifts"].detach().clone()
+    assert not graph["positions"].requires_grad
+
+    context = prepare_graph(graph, compute_stress=True)
+
+    assert graph["positions"].requires_grad
+    assert graph["positions"] is not positions_before
+    # at zero strain the replacement is numerically the same structure ...
+    assert torch.allclose(
+        graph["positions"], positions_before, atol=TOL.atol, rtol=TOL.rtol
+    )
+    assert torch.allclose(graph["shifts"], shifts_before, atol=TOL.atol, rtol=TOL.rtol)
+    # ... but it is a different tensor, and it is what the vectors came from
+    vectors, _ = get_edge_vectors_and_lengths(
+        positions=graph["positions"],
+        edge_index=graph["edge_index"],
+        shifts=graph["shifts"],
+    )
+    assert torch.equal(context.vectors, vectors)
+
+
+def test_prepare_graph_leaves_the_shifts_alone_without_a_strain(fixtures):
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    shifts_before = graph["shifts"]
+    prepare_graph(graph)
+    assert graph["shifts"] is shifts_before
+
+
+def test_an_antisymmetric_strain_is_a_rotation_and_changes_no_energy(fixtures):
+    """Why the displacement is symmetrised before it is applied.
+
+    `get_symmetric_displacement` uses 0.5 * (d + d^T). Feeding it a purely
+    antisymmetric handle therefore applies nothing at all, which is the
+    infinitesimal statement that the energy is rotation invariant.
+    """
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    with torch_tools.default_dtype("float64"):
+        plain = float(model(dict(graph), compute_force=False)["energy"].detach())
+        antisymmetric = torch.zeros((1, 3, 3), dtype=torch.float64)
+        antisymmetric[0, 0, 1] = 1e-3
+        antisymmetric[0, 1, 0] = -1e-3
+        antisymmetric.requires_grad_(True)
+        rotated_graph = dict(graph)
+        rotated_graph["displacement"] = antisymmetric
+        rotated = float(
+            model(rotated_graph, compute_force=False, compute_stress=True)[
+                "energy"
+            ].detach()
+        )
+    assert rotated == pytest.approx(plain, abs=TOL.atol)
+
+
+# ---------------------------------------------------------------------------
+# get_edge_vectors_and_lengths
+# ---------------------------------------------------------------------------
+
+
+def test_edge_vectors_are_the_periodic_images_they_claim_to_be(fixtures):
+    """Every edge vector reproduced by hand from the cell and the unit shift.
+
+    This is the assembly step -- `positions[receiver] - positions[sender] +
+    shifts` -- checked against an independent construction from the integer
+    unit shifts, together with the two properties that make the edge set a
+    neighbour list at all: nothing longer than the cutoff, and every pair of
+    atoms within the cutoff present exactly once.
+
+    (The neighbour list *itself* has a dedicated brute-force oracle in P0-7,
+    which is the general tool; what is pinned here is the vector arithmetic
+    the physics glue does on top of it.)
+    """
+    model = load_anchor("tiny_scaleshift")
+    atoms = fixtures["triclinic_bulk"]
+    cutoff = float(model.r_max)
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+
+    vectors, lengths = get_edge_vectors_and_lengths(
+        positions=graph["positions"],
+        edge_index=graph["edge_index"],
+        shifts=graph["shifts"],
+    )
+    cell = graph["cell"].view(3, 3).numpy()
+    positions = graph["positions"].detach().numpy()
+    unit_shifts = graph["unit_shifts"].numpy()
+    senders, receivers = graph["edge_index"].numpy()
+
+    by_hand = (
+        positions[receivers] - positions[senders] + unit_shifts @ cell
+    )
+    assert np.abs(vectors.detach().numpy() - by_hand).max() < TOL.atol
+    assert np.abs(
+        lengths.detach().numpy().ravel() - np.linalg.norm(by_hand, axis=1)
+    ).max() < TOL.atol
+    assert lengths.max() < cutoff
+
+    # every image within the cutoff is present, exactly once
+    found = {
+        (int(s), int(r), *(int(n) for n in shift))
+        for s, r, shift in zip(senders, receivers, unit_shifts)
+    }
+    assert len(found) == len(senders), "the edge list repeats an image"
+    expected = set()
+    reach = 2
+    for i in range(len(atoms)):
+        for j in range(len(atoms)):
+            for n0 in range(-reach, reach + 1):
+                for n1 in range(-reach, reach + 1):
+                    for n2 in range(-reach, reach + 1):
+                        shift = np.array([n0, n1, n2]) @ cell
+                        delta = positions[j] - positions[i] + shift
+                        distance = float(np.linalg.norm(delta))
+                        if 0.0 < distance < cutoff:
+                            expected.add((i, j, n0, n1, n2))
+    assert found == expected
+
+
+def test_normalising_the_edge_vectors_divides_by_the_length_plus_eps():
+    positions = torch.tensor([[0.0, 0.0, 0.0], [3.0, 4.0, 0.0]], dtype=torch.float64)
+    edge_index = torch.tensor([[0], [1]])
+    shifts = torch.zeros((1, 3), dtype=torch.float64)
+    eps = 1e-9
+    vectors, lengths = get_edge_vectors_and_lengths(
+        positions, edge_index, shifts, normalize=True, eps=eps
+    )
+    assert float(lengths[0, 0]) == pytest.approx(5.0)
+    # the eps is inside the denominator, so the normed vector is slightly
+    # short -- by 2e-10 here, which no unit vector consumer notices and which
+    # a port that divides by the bare length will not reproduce bit for bit.
+    assert torch.allclose(
+        vectors,
+        torch.tensor([[3.0, 4.0, 0.0]], dtype=torch.float64) / (5.0 + eps),
+        atol=TOL.atol,
+        rtol=TOL.rtol,
+    )
+    assert float(torch.linalg.norm(vectors)) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# get_outputs: which quantities exist under which flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flags,present",
+    [
+        ({}, {"forces"}),
+        ({"compute_force": False}, set()),
+        ({"compute_stress": True}, {"forces", "stress", "virials"}),
+        ({"compute_virials": True}, {"forces", "stress", "virials"}),
+        ({"compute_edge_forces": True}, {"forces", "edge_forces"}),
+        ({"compute_hessian": True}, {"forces", "hessian"}),
+    ],
+)
+def test_which_derivatives_a_flag_combination_produces(flags, present, fixtures):
+    """The dispatcher's contract, as a table.
+
+    Two entries are not what the flag names suggest, and both are load
+    bearing: asking for a stress also returns a virial (they come out of one
+    autograd call), and `compute_virials` alone hands back a stress too --
+    `compute_stress` gates only the division by the volume, and the returned
+    `stress` is a zeros tensor of the displacement's shape when it is off.
+    """
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    with torch_tools.default_dtype("float64"):
+        out = model(graph, **flags)
+    for name in ("forces", "virials", "stress", "hessian", "edge_forces"):
+        if name in present:
+            assert out[name] is not None, f"{name} missing with {flags}"
+        else:
+            assert out[name] is None, f"{name} unexpectedly present with {flags}"
+
+
+def test_asking_for_a_virial_without_a_stress_still_divides_by_nothing(fixtures):
+    """`compute_virials=True, compute_stress=False` returns a zero stress.
+
+    Not `None`, and not the real stress: `compute_forces_virials` seeds
+    `stress = torch.zeros_like(displacement)` and only overwrites it inside
+    `if compute_stress`. A consumer that trusts a non-None stress gets zeros.
+    """
+    model = load_anchor("tiny_scaleshift")
+    graph = _graph_for("triclinic_bulk", fixtures, model)
+    with torch_tools.default_dtype("float64"):
+        out = model(graph, compute_virials=True, compute_stress=False)
+    assert out["virials"] is not None
+    assert torch.count_nonzero(out["virials"]) > 0
+    assert torch.count_nonzero(out["stress"]) == 0

--- a/tests/unit/test_physics_glue.py
+++ b/tests/unit/test_physics_glue.py
@@ -40,6 +40,7 @@ from mace.modules.utils import (
     compute_forces,
     compute_forces_virials,
     get_edge_vectors_and_lengths,
+    get_symmetric_displacement,
     prepare_graph,
 )
 from mace.tools import torch_tools
@@ -281,6 +282,62 @@ def test_the_sign_of_every_derivative_against_a_hand_differentiable_energy():
     # the volume is |det(cell)|, so a left-handed cell gives the same stress
     _, _, mirrored = evaluate(-cell)
     assert torch.allclose(mirrored, expected_stress, atol=TOL.atol, rtol=TOL.rtol)
+
+
+def test_an_unconnected_energy_gives_zero_forces_and_a_zero_virial():
+    """The two `is None` guards in `compute_forces_virials` (`:75-78`).
+
+    They are what a fully dissociated structure hits. Note the shapes they
+    fall back to: the forces match the positions, but the virial is
+    `torch.zeros((1, 3, 3))` regardless of how many graphs were in the batch
+    -- and in the default dtype rather than the energy's. A batch of four
+    structures that reaches this branch gets one virial back.
+    """
+    positions = torch.zeros((2, 3), dtype=torch.float64, requires_grad=True)
+    displacement = torch.zeros((3, 3, 3), dtype=torch.float64, requires_grad=True)
+    unrelated = torch.ones(1, dtype=torch.float64, requires_grad=True) * 5.0
+    cell = torch.eye(3, dtype=torch.float64).repeat(3, 1, 1)
+
+    forces, virials, stress = compute_forces_virials(
+        energy=unrelated,
+        positions=positions,
+        displacement=displacement,
+        cell=cell,
+        training=False,
+        compute_stress=True,
+    )
+    assert torch.equal(forces, torch.zeros_like(positions))
+    assert virials.shape == (1, 3, 3)
+    assert torch.count_nonzero(virials) == 0
+    # the stress keeps the displacement's shape, because it was seeded from it
+    assert stress.shape == (3, 3, 3)
+
+
+def test_get_symmetric_displacement_invents_a_cell_when_there_is_none():
+    """`cell=None` becomes a `(3 * n_graphs, 3)` block of zeros (`:92-98`).
+
+    A zero cell makes every shift zero, so an aperiodic batch that reaches
+    this path gets the right edge vectors and a meaningless volume -- which
+    is why the neighbour list hands back a fabricated cell for aperiodic
+    structures rather than letting this one be used for a stress.
+    """
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=torch.float64, requires_grad=True
+    )
+    unit_shifts = torch.zeros((1, 3), dtype=torch.float64)
+    edge_index = torch.tensor([[0], [1]])
+    moved, shifts, displacement = get_symmetric_displacement(
+        positions=positions,
+        unit_shifts=unit_shifts,
+        cell=None,
+        edge_index=edge_index,
+        num_graphs=2,
+        batch=torch.tensor([0, 1]),
+    )
+    assert torch.equal(shifts, torch.zeros((1, 3), dtype=torch.float64))
+    assert displacement.shape == (2, 3, 3)
+    assert displacement.requires_grad
+    assert torch.allclose(moved, positions, atol=TOL.atol, rtol=TOL.rtol)
 
 
 def test_a_blown_up_stress_component_is_silently_zeroed():

--- a/tests/unit/test_physics_glue.py
+++ b/tests/unit/test_physics_glue.py
@@ -126,17 +126,40 @@ def test_the_reported_force_is_the_gradient_of_the_energy_the_model_returns(fixt
     model, not an identity, so it is measured: if a future E0 term ever
     became position dependent, the ScaleShiftMACE forces would silently stop
     being the gradient of the energy it reports.
+
+    **Bit-for-bit is a claim about the seed.** Differentiating `energy.sum()`
+    seeds the shared backward with a stride-0 `expand` of a scalar instead of
+    the materialized `grad_outputs=ones` that `compute_forces` passes
+    (mace/modules/utils.py:36-46), and the broadcast path that takes lands on
+    different last bits: measured on Viper-CPU (EPYC Genoa, torch 2.13+rocm7.1,
+    MKL) the two disagree by 7.3e-17 for ScaleShiftMACE and 5.6e-17 for MACE,
+    about a third of an ulp, while on macOS/Accelerate both are exactly zero.
+    Matching the seed and `create_graph` makes this the same computation run
+    twice rather than two computations of one quantity, which is the only kind
+    of comparison bit-exactness belongs in; both platforms then give zero.
+
+    The deviations are collected over the anchors and asserted once, because
+    an assertion inside the loop stops at the first: when only ScaleShiftMACE
+    was reported, plain MACE was not passing, it was unreached.
     """
     atoms = fixtures["water_cluster"]
+    disagreed = []
     for anchor in ANCHORS:
         model = load_anchor(anchor)
         with torch_tools.default_dtype("float64"):
             graph = anchor_graph(model, atoms)
             out = model(graph, training=True, compute_force=True)
             gradient = torch.autograd.grad(
-                out["energy"].sum(), graph["positions"], retain_graph=True
+                outputs=[out["energy"]],
+                inputs=[graph["positions"]],
+                grad_outputs=[torch.ones_like(out["energy"])],
+                retain_graph=True,
+                create_graph=True,
             )[0]
-        assert torch.equal(out["forces"], -gradient), anchor
+        if not torch.equal(out["forces"], -gradient):
+            deviation = float((out["forces"] + gradient).abs().max())
+            disagreed.append(f"{anchor}: max |F + dE/dx| = {deviation:.3e}")
+    assert not disagreed, "; ".join(disagreed)
 
 
 def test_a_structure_with_no_edges_gets_zero_forces(fixtures):

--- a/tests/unit/test_scale_shift_dtype.py
+++ b/tests/unit/test_scale_shift_dtype.py
@@ -1,0 +1,486 @@
+"""One forward, two energies, two dtypes: the legacy split, pinned.
+
+`ScaleShiftMACE.forward` returns `total_energy` in the model's dtype and
+`node_energy` in float64 (`mace/modules/models.py:581-582`), because the
+per-atom quantity is assembled through `safe_double`. Plain `MACE` does not
+(`:399`). So a `--default_dtype float32` run emits a float32 total and a
+float64 per-atom decomposition **from the same call**, and no single dtype
+policy reproduces both. This file turns that into committed characterization
+rather than leaving it to be discovered by whoever writes the rewrite's
+precision configuration -- it is the per-quantity specification BKD-2's
+reduction dtype is written against.
+
+**The MPS carve-out.** `safe_double` returns the tensor unchanged on Apple's
+MPS backend, which has no float64 (`mace/modules/utils.py:22-31`). So the
+`node_energy` dtype assertions below are CPU/CUDA statements: on MPS the same
+model returns float32 for both quantities, and that is the documented
+behaviour rather than a failure. Nothing here runs on MPS.
+
+**Which classes widen is not a rule, it is a list.** `ScaleShiftMACE`,
+`MACELES` and `PolarMACE` widen; `MagneticScaleShiftMACE` -- also a
+scale-shift subclass -- does not, and neither does `EnergyDipolesMACE`. The
+table below is checked against the package rather than remembered, so a new
+model class that returns a `node_energy` has to be classified before this
+suite passes.
+
+**Reductions here use `scatter_sum`, never `.sum()`**, per the rule this file
+also pins: `index_add_` accumulates sequentially, and at float32 with
+realistic E0s the difference between summing before and after adding the E0s
+is whole eV -- which torch's blocked-pairwise `.sum()` hides.
+"""
+
+import ast
+import inspect
+import io
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from mace.modules import extensions, models
+from mace.modules.blocks import AtomicEnergiesBlock, ScaleShiftBlock
+from mace.modules.utils import safe_double
+from mace.tools import torch_tools
+from mace.tools.scatter import scatter_sum
+from tests.golden import harness
+from tests.golden.anchors import anchor_graph, anchor_path, load_anchor
+
+TOL = harness.FP64_CPU_REFERENCE
+
+#: model class -> does its forward build `node_energy` through safe_double.
+#: Measured off the source below, and confirmed at runtime for the two
+#: classes with a committed anchor.
+WIDENS_NODE_ENERGY = {
+    "MACE": False,
+    "ScaleShiftMACE": True,
+    "EnergyDipolesMACE": False,
+    "MACELES": True,
+    "PolarMACE": True,
+    "MagneticScaleShiftMACE": False,
+}
+
+
+@pytest.fixture(name="fixtures", scope="module")
+def fixture_fixtures():
+    return harness.load_fixtures()
+
+
+# ---------------------------------------------------------------------------
+# The dtype matrix: 2 quantities x 2 dtypes x 2 model classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("anchor", ["tiny_mace", "tiny_scaleshift"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_the_two_energies_come_back_in_the_dtypes_the_legacy_stack_gives_them(
+    anchor, dtype, fixtures
+):
+    """The whole matrix in one assertion table.
+
+    `total_energy` is always the model's dtype. `node_energy` is float64
+    whenever the class widens, *including* in a float32 run -- that is the
+    inconsistency, and it is reproduced rather than fixed.
+    """
+    model = load_anchor(anchor, dtype)
+    widens = WIDENS_NODE_ENERGY[type(model).__name__]
+    with torch_tools.default_dtype(
+        "float32" if dtype is torch.float32 else "float64"
+    ):
+        out = model(anchor_graph(model, fixtures["water_cluster"], dtype))
+    assert out["energy"].dtype is dtype
+    assert out["node_energy"].dtype is (torch.float64 if widens else dtype)
+    assert out["forces"].dtype is dtype
+
+
+@pytest.mark.parametrize("anchor", ["tiny_mace", "tiny_scaleshift"])
+def test_the_two_energies_agree_at_fp64_and_disagree_at_fp32(anchor, fixtures):
+    """The consequence of the split, as a number rather than as a warning.
+
+    At float64 the total and the reduced per-atom energies are the same
+    quantity computed twice and agree to the reference row. At float32 they
+    are not: for the widening class they are not even the same dtype, and the
+    difference is real -- 1.1e-8 eV on this fixture for the scale-shift
+    anchor and 3.8e-6 eV for the plain one, both far above the float32
+    round-off of the individual node energies. A rewrite that reports one of
+    them as "the" energy has changed the other.
+    """
+    atoms = fixtures["water_cluster"]
+    gaps = {}
+    for dtype, name in ((torch.float64, "float64"), (torch.float32, "float32")):
+        model = load_anchor(anchor, dtype)
+        with torch_tools.default_dtype(name):
+            graph = anchor_graph(model, atoms, dtype)
+            out = model(graph, compute_force=False)
+        reduced = scatter_sum(
+            out["node_energy"], graph["batch"], dim=0, dim_size=1
+        )
+        gaps[name] = abs(float(reduced) - float(out["energy"]))
+    assert gaps["float64"] < TOL.atol
+    assert gaps["float32"] > 0.0
+
+
+def test_the_widening_survives_the_reduction_and_the_narrow_total_does_not(
+    fixtures,
+):
+    """Why the split is not merely cosmetic.
+
+    Reducing the float64 `node_energy` of a float32 ScaleShiftMACE run gives
+    a *different, and here closer*, answer than the float32 `total_energy`:
+    measured against the float64 reference on the triclinic fixture, 5.8e-9
+    eV against 7.9e-8 eV. So the two quantities are not two spellings of one
+    number even in the mean.
+    """
+    atoms = fixtures["triclinic_bulk"]
+    model64 = load_anchor("tiny_scaleshift", torch.float64)
+    with torch_tools.default_dtype("float64"):
+        exact = float(
+            model64(
+                anchor_graph(model64, atoms, torch.float64), compute_force=False
+            )["energy"].detach()
+        )
+    model32 = load_anchor("tiny_scaleshift", torch.float32)
+    with torch_tools.default_dtype("float32"):
+        graph = anchor_graph(model32, atoms, torch.float32)
+        out = model32(graph, compute_force=False)
+    total_error = abs(float(out["energy"].detach()) - exact)
+    reduced = float(
+        scatter_sum(out["node_energy"].detach(), graph["batch"], dim=0, dim_size=1)
+    )
+    assert out["node_energy"].dtype is torch.float64
+    assert abs(reduced - exact) < total_error
+
+
+# ---------------------------------------------------------------------------
+# Which classes widen: read out of the package, not remembered
+# ---------------------------------------------------------------------------
+
+
+def _node_energy_expressions(cls):
+    """Every expression in `cls.forward` that produces `node_energy`.
+
+    Two forms exist in the tree: an assignment to a local named
+    `node_energy`, and a `"node_energy": ...` entry built directly in the
+    returned dict (PolarMACE does the latter). A class that does both -- the
+    common case, where the dict entry is just the local -- is read from its
+    assignments, and the entry is required to be that bare local so nothing
+    can be hidden in the second form.
+    """
+    source = textwrap.dedent(inspect.getsource(cls.forward))
+    tree = ast.parse(source)
+    assignments, entries = [], []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "node_energy":
+                    assignments.append(node.value)
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and key.value == "node_energy":
+                    entries.append(value)
+    if not assignments:
+        return entries
+    for entry in entries:
+        assert (
+            isinstance(entry, ast.Name) and entry.id == "node_energy"
+        ), f"{cls.__name__} builds a second node_energy in its return dict"
+    return assignments
+
+
+def _calls_safe_double(expression):
+    return any(
+        isinstance(node, ast.Name) and node.id == "safe_double"
+        for node in ast.walk(expression)
+    )
+
+
+def _model_classes_returning_a_node_energy():
+    classes = {}
+    for module in (models, extensions):
+        for name, obj in vars(module).items():
+            if not (isinstance(obj, type) and issubclass(obj, torch.nn.Module)):
+                continue
+            if obj.__module__ != module.__name__ or not hasattr(obj, "forward"):
+                continue
+            if _node_energy_expressions(obj):
+                classes[name] = obj
+    return classes
+
+
+def test_every_class_that_reports_a_node_energy_is_classified():
+    """A new model class has to declare which side of the split it is on.
+
+    The table is not a comment: it is asserted against the set of classes
+    that actually build a `node_energy`, so adding a seventh without deciding
+    fails here rather than surfacing as an unexplained dtype downstream.
+    """
+    discovered = set(_model_classes_returning_a_node_energy())
+    assert discovered == set(WIDENS_NODE_ENERGY), (
+        "model classes returning node_energy have changed; classify the new "
+        f"ones: {sorted(discovered ^ set(WIDENS_NODE_ENERGY))}"
+    )
+
+
+@pytest.mark.parametrize("name,widens", sorted(WIDENS_NODE_ENERGY.items()))
+def test_the_widening_table_matches_the_source(name, widens):
+    """Including the two counterexamples the audit turned up.
+
+    `MagneticScaleShiftMACE` is a scale-shift subclass and does *not* widen,
+    while `MACELES` and `PolarMACE` do -- so "scale-shift implies float64
+    node energies" is a false rule that a port would otherwise be tempted to
+    apply uniformly.
+    """
+    cls = _model_classes_returning_a_node_energy()[name]
+    expressions = _node_energy_expressions(cls)
+    assert expressions, name
+    assert all(_calls_safe_double(e) for e in expressions) is widens
+
+
+def test_safe_double_is_a_no_op_on_mps_by_construction():
+    """The carve-out itself, on the only device this laptop has.
+
+    `safe_double` branches on `t.device.type`, so the CPU behaviour is a
+    widening and the MPS behaviour is documented in the source. Asserting the
+    CPU half here means the branch is not silently deleted; the MPS half is
+    what the module docstring above warns a future MPS run about.
+    """
+    tensor = torch.ones(3, dtype=torch.float32)
+    assert safe_double(tensor).dtype is torch.float64
+    assert torch.ones(3, dtype=torch.float64).dtype is safe_double(tensor).dtype
+
+
+# ---------------------------------------------------------------------------
+# The reduction primitive
+# ---------------------------------------------------------------------------
+
+
+def test_scatter_sum_exposes_a_float32_split_that_torch_sum_hides():
+    """Why test arithmetic here uses `scatter_sum` and never `.sum()`.
+
+    `scatter_sum` is `index_add_`: a sequential accumulation, which is what
+    the model does to turn per-atom energies into a total. Torch's `.sum()`
+    is blocked pairwise and is roughly a thousand times more accurate on the
+    same data, so a test that reduces with `.sum()` measures a reduction the
+    model never performs.
+
+    Measured with 1,000 atoms at E0 = 1234.5678 eV against interaction
+    energies of order 0.1 eV, in float32: adding the E0s and the interaction
+    energies as two separate scatters, versus one scatter over their sum,
+    differ by 5.0 eV. The same comparison through `.sum()` differs by 0.125.
+    """
+    n_atoms = 1000
+    e0 = torch.full((n_atoms,), 1234.5678, dtype=torch.float32)
+    generator = torch.Generator().manual_seed(20260810)
+    interaction = (torch.rand(n_atoms, generator=generator, dtype=torch.float64) - 0.5) * 0.2
+    interaction32 = interaction.to(torch.float32)
+    index = torch.zeros(n_atoms, dtype=torch.long)
+
+    split = scatter_sum(e0, index, dim=0, dim_size=1) + scatter_sum(
+        interaction32, index, dim=0, dim_size=1
+    )
+    joint = scatter_sum(e0 + interaction32, index, dim=0, dim_size=1)
+    scatter_gap = abs(float(split) - float(joint))
+
+    pairwise_gap = abs(
+        float(e0.sum() + interaction32.sum()) - float((e0 + interaction32).sum())
+    )
+    exact = float(e0.to(torch.float64).sum() + interaction.sum())
+
+    assert scatter_gap > 1.0, f"measured 5.0 eV, got {scatter_gap}"
+    assert pairwise_gap < scatter_gap / 10.0
+    # and the order that adds first is the accurate one, which is what the
+    # model does -- E0 enters per node, before the reduction.
+    assert abs(float(joint) - exact) < abs(float(split) - exact)
+
+
+# ---------------------------------------------------------------------------
+# AtomicEnergiesBlock: where the E0s enter, and in which dtype
+# ---------------------------------------------------------------------------
+
+E0_VALUES = np.array([-13.6, -1023.123456789012345, 0.1])
+
+
+def _block(values, dtype_name):
+    with torch_tools.default_dtype(dtype_name):
+        return AtomicEnergiesBlock(values)
+
+
+def test_the_e0_buffer_is_rounded_once_at_construction():
+    """Under whatever the global default dtype was at that moment.
+
+    Nothing re-rounds it afterwards, so a float32-built model carries
+    float32-rounded E0s forever, even when it is later run in float64.
+    """
+    float32_block = _block(E0_VALUES, "float32")
+    float64_block = _block(E0_VALUES, "float64")
+    assert float32_block.atomic_energies.dtype is torch.float32
+    assert float64_block.atomic_energies.dtype is torch.float64
+    assert float64_block.atomic_energies.tolist() == E0_VALUES.tolist()
+    assert float32_block.atomic_energies.tolist() != E0_VALUES.tolist()
+
+
+def test_the_forward_casts_the_buffer_to_the_inputs_dtype_in_both_directions():
+    """`.to(dtype=x.dtype)` on every call (mace/modules/blocks.py:378-380).
+
+    The *input* dtype wins, not the buffer's. Two consequences, both pinned:
+    a float32 buffer under a float64 forward is **widened, not re-rounded**
+    -- the returned values are the float32 approximations carried in a
+    float64 tensor -- and, in the other direction, a float64 buffer under a
+    float32 forward is silently narrowed. The second is the one that costs
+    precision, and it is the direction a reader of the buffer's dtype would
+    not expect.
+    """
+    float32_block = _block(E0_VALUES, "float32")
+    widened = float32_block(torch.eye(3, dtype=torch.float64))
+    assert widened.dtype is torch.float64
+    assert widened.flatten().tolist() == [
+        float(np.float32(value)) for value in E0_VALUES
+    ]
+    assert widened.flatten().tolist() != E0_VALUES.tolist()
+
+    float64_block = _block(E0_VALUES, "float64")
+    narrowed = float64_block(torch.eye(3, dtype=torch.float32))
+    assert narrowed.dtype is torch.float32
+    assert float64_block.atomic_energies.dtype is torch.float64, "buffer untouched"
+
+
+@pytest.mark.parametrize("dtype_name", ["float32", "float64"])
+def test_the_one_hot_matmul_is_bit_identical_to_a_gather(dtype_name):
+    """The E0 lookup is a matmul against a one-hot, and could be an index.
+
+    On CPU the two are bitwise equal at both dtypes, which is what lets a
+    port replace one with the other. The caveat is TF32 on CUDA, which
+    perturbs a matmul bitwise and would break the equality -- so the flag is
+    asserted rather than assumed. It is off by default on the torch this
+    project builds against, and this test is the tripwire if that changes.
+    """
+    assert torch.backends.cuda.matmul.allow_tf32 is False
+    dtype = getattr(torch, dtype_name)
+    block = _block(E0_VALUES, dtype_name)
+    index = torch.tensor([0, 1, 2, 1, 0])
+    one_hot = torch.zeros(5, 3, dtype=dtype)
+    one_hot[torch.arange(5), index] = 1.0
+    by_matmul = block(one_hot)
+    by_gather = torch.atleast_2d(block.atomic_energies).T.to(dtype)[index]
+    assert torch.equal(by_matmul, by_gather)
+
+
+def test_where_the_e0s_enter_the_model(fixtures):
+    """The readout sum, per node -- and for ScaleShiftMACE, outside the scale.
+
+    `node_energy = node_e0 + scale_shift(everything else)`, so shifting the
+    shift buffer by d moves every node energy by exactly d and the total by
+    n_atoms * d, while the E0 contribution is untouched by either buffer.
+    This is the application order that differs between the two classes, and
+    the reason `--E0s` and `--mean`/`--std` are not interchangeable knobs.
+    """
+    atoms = fixtures["water_cluster"]
+    model = load_anchor("tiny_scaleshift")
+    with torch_tools.default_dtype("float64"):
+        graph = anchor_graph(model, atoms)
+        before = model(graph, compute_force=False)
+        delta = 0.25
+        model.scale_shift.shift = model.scale_shift.shift + delta
+        after = model(anchor_graph(model, atoms), compute_force=False)
+    per_node = (after["node_energy"] - before["node_energy"]).detach()
+    assert torch.allclose(
+        per_node,
+        torch.full_like(per_node, delta),
+        atol=TOL.atol,
+        rtol=TOL.rtol,
+    )
+    assert float(after["energy"] - before["energy"]) == pytest.approx(
+        len(atoms) * delta, abs=TOL.atol
+    )
+
+
+# ---------------------------------------------------------------------------
+# The load paths, and what they do to the buffers
+# ---------------------------------------------------------------------------
+
+
+BUFFER_NAMES = ("atomic_energies_fn.atomic_energies", "scale_shift.scale", "scale_shift.shift")
+
+
+def _buffers(model):
+    named = dict(model.named_buffers())
+    return {name: named[name] for name in BUFFER_NAMES if name in named}
+
+
+def test_a_full_pickle_round_trip_preserves_every_buffer_bit_for_bit():
+    model = load_anchor("tiny_scaleshift", torch.float32)
+    stream = io.BytesIO()
+    torch.save(model, stream)
+    stream.seek(0)
+    # deliberately loaded under the *other* global default dtype: nothing in
+    # the load path consults it, so the buffers must come back float32.
+    with torch_tools.default_dtype("float64"):
+        restored = torch.load(stream, weights_only=False)
+    original, reloaded = _buffers(model), _buffers(restored)
+    assert set(original) == set(reloaded) and original
+    for name, tensor in original.items():
+        assert reloaded[name].dtype is tensor.dtype, name
+        assert torch.equal(reloaded[name], tensor), name
+
+
+def test_a_same_dtype_state_dict_resume_preserves_every_buffer():
+    model = load_anchor("tiny_scaleshift", torch.float64)
+    rebuilt = load_anchor("tiny_scaleshift", torch.float64)
+    rebuilt.scale_shift.scale = rebuilt.scale_shift.scale * 3.0
+    rebuilt.load_state_dict(model.state_dict())
+    for name, tensor in _buffers(model).items():
+        assert torch.equal(dict(rebuilt.named_buffers())[name], tensor), name
+
+
+def test_the_rebuild_dtype_wins_on_a_cross_dtype_state_dict_load():
+    """The only re-cast in the tree, and it is explicit.
+
+    Loading a float32 state dict into a float64 model gives float64 tensors
+    holding the float32 values -- widened, never recovered. Pinned because it
+    is the one place a dtype changes on a load, and a port that instead keeps
+    the checkpoint's dtype produces a model whose buffers disagree with its
+    parameters.
+    """
+    narrow = load_anchor("tiny_scaleshift", torch.float32)
+    wide = load_anchor("tiny_scaleshift", torch.float64)
+    wide.load_state_dict(narrow.state_dict())
+    for name, tensor in _buffers(narrow).items():
+        loaded = dict(wide.named_buffers())[name]
+        assert loaded.dtype is torch.float64, name
+        assert torch.equal(loaded, tensor.to(torch.float64)), name
+
+
+def test_the_convert_device_cli_preserves_the_buffers(tmp_path, monkeypatch):
+    """`mace_convert_device` is torch.load -> .to(device) -> torch.save.
+
+    Exercised here for cpu -> cpu, which is the only hop this machine can
+    make; what it pins is that the round trip through the CLI is value- and
+    dtype-preserving, so a cross-device conversion that changes a buffer is
+    changing it on the `.to()`, not on the serialisation.
+    """
+    from mace.cli.convert_device import main  # noqa: PLC0415
+
+    source = tmp_path / "anchor.model"
+    source.write_bytes(Path(anchor_path("tiny_scaleshift")).read_bytes())
+    output = tmp_path / "converted.model"
+    monkeypatch.setattr(
+        "sys.argv",
+        ["mace_convert_device", "-t", "cpu", "-o", str(output), str(source)],
+    )
+    main()
+
+    original = torch.load(source, weights_only=False, map_location="cpu")
+    converted = torch.load(output, weights_only=False, map_location="cpu")
+    for name, tensor in _buffers(original).items():
+        assert torch.equal(dict(converted.named_buffers())[name], tensor), name
+        assert dict(converted.named_buffers())[name].dtype is tensor.dtype, name
+
+
+@pytest.mark.parametrize("dtype_name", ["float32", "float64"])
+def test_the_scale_shift_buffers_are_also_frozen_at_construction(dtype_name):
+    with torch_tools.default_dtype(dtype_name):
+        block = ScaleShiftBlock(scale=0.1234567890123456789, shift=-1.5)
+    expected = getattr(torch, dtype_name)
+    assert block.scale.dtype is expected
+    assert block.shift.dtype is expected

--- a/tests/unit/test_scale_shift_dtype.py
+++ b/tests/unit/test_scale_shift_dtype.py
@@ -321,7 +321,7 @@ def test_the_e0_buffer_is_rounded_once_at_construction():
 
 
 def test_the_forward_casts_the_buffer_to_the_inputs_dtype_in_both_directions():
-    """`.to(dtype=x.dtype)` on every call (mace/modules/blocks.py:378-380).
+    """`.to(dtype=x.dtype)` on every call (mace/modules/blocks.py:379-381).
 
     The *input* dtype wins, not the buffer's. Two consequences, both pinned:
     a float32 buffer under a float64 forward is **widened, not re-rounded**


### PR DESCRIPTION
Characterization tests for the numerical core, so a rewrite has something to be checked against. No product changes: this branch is tests only.

Four unit files. The loss branches reachable in a single process. The force, stress and virial sign conventions, checked against finite differences rather than against themselves. The per-quantity energy dtypes, which are not consistent today, pinned as they are instead of averaged into one claim. The E0 paths, including three cases that produce a number and no error: an element absent from the training set gets zero silently, an isolated atom carrying no energy becomes zero with only a warning, and a NaN reference energy passes straight through the LinAlgError fallback. And the statistics the scale and shift come from, with their fallbacks, where a zero spread becomes a scale of one and the guard for it only works on arrays.

One golden: a single training step's gradient, committed for both tiny anchors. It also runs gradcheck and gradgradcheck, checks the backward really went through the second derivative path, and shows that the digest resolves a weight change six orders below the weights.

The anchor loader moves out of the anchors test into tests/golden/anchors.py, since three files now need it.

145 tests in the four unit files. Whole suite locally: tests/unit 569 passed, tests/golden and tests/integrations 143 passed.

Worth merging before #1661. Three of the per-file coverage floors that branch enforces are below their bars without these tests: mace/modules/loss.py at 87 against 90, mace/modules/utils.py at 74 against 85, and mace/data/utils.py at 76 against 85.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with committed reference JSON; no runtime or training behavior is modified.
> 
> **Overview**
> Adds **characterization tests only** (no production code changes) so a numerical rewrite can be checked against the current stack.
> 
> **Shared golden infrastructure:** Anchor loading and graph/batch construction move into `tests/golden/anchors.py` (fp64 graph build inside `default_dtype`, `KeySpecification.from_defaults()` for labelled training data). `test_tiny_anchors.py` imports that module instead of duplicating helpers.
> 
> **Train-step gradient goldens:** New `train_step.py`, `test_train_step_gradient.py`, `targets/gradients.py`, docs, and committed fp64 digests for both tiny anchors. One energy+forces backward step is reduced per parameter (`sum`, `abs_sum`, `sq_sum`, cosine projection) rather than storing full vectors; tests also pin gradcheck/gradgradcheck, forces-weight sensitivity, digest resolution, and permutation detection.
> 
> **Unit characterization:** Large expansions cover loss branches (UniversalLoss magforces, DDP `reduce_loss`, CLI mapping), physics glue (forces/stress/virial signs vs finite differences), per-quantity energy dtypes and `scatter_sum` vs `.sum()`, and E0 / scale-shift statistics paths including documented silent fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b282a5c2511654f73743c4e47b44a03f93a683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->