### PR TITLE
Test the CLIs and flags nothing was exercising, and fix mace_plot_train

### DIFF
--- a/mace/cli/plot_train.py
+++ b/mace/cli/plot_train.py
@@ -130,6 +130,24 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _aggregate(data, keys: List[str]):
+    """Mean and std per group, over the numeric columns only.
+
+    The results log carries `head` as a string and the mean of a string is not a
+    thing. pandas used to drop such a column from an aggregation by itself; 3.0
+    raises `dtype 'str' does not support operation 'mean'` instead, and
+    `numeric_only=True` does not help because the list-of-aggregations path
+    dispatches per column and then refuses on that same column. Selecting the
+    numeric columns up front is what works on both.
+    """
+    values = [
+        column
+        for column in data.columns
+        if column not in keys and pd.api.types.is_numeric_dtype(data[column])
+    ]
+    return data.groupby(keys)[values].agg(["mean", "std"]).reset_index()
+
+
 def plot(
     data: pd.DataFrame,
     min_epoch: int,
@@ -173,9 +191,7 @@ def plot(
 
     data = data[data["epoch"] > min_epoch]
     if heads is None:
-        data = (
-            data.groupby(["name", "mode", "epoch"]).agg(["mean", "std"]).reset_index()
-        )
+        data = _aggregate(data, ["name", "mode", "epoch"])
 
         valid_data = data[data["mode"] == "eval"]
         valid_data_dict = {"default": valid_data}
@@ -183,18 +199,10 @@ def plot(
     else:
         heads = heads.split(",")
         # Separate eval and opt data
-        valid_data = (
-            data[data["mode"] == "eval"]
-            .groupby(["name", "mode", "epoch", "head"])
-            .agg(["mean", "std"])
-            .reset_index()
+        valid_data = _aggregate(
+            data[data["mode"] == "eval"], ["name", "mode", "epoch", "head"]
         )
-        train_data = (
-            data[data["mode"] == "opt"]
-            .groupby(["name", "mode", "epoch"])
-            .agg(["mean", "std"])
-            .reset_index()
-        )
+        train_data = _aggregate(data[data["mode"] == "opt"], ["name", "mode", "epoch"])
         valid_data_dict = {
             head: valid_data[valid_data["head"] == head] for head in heads
         }

--- a/tests/extensions/polar/test_polar_output_keys.py
+++ b/tests/extensions/polar/test_polar_output_keys.py
@@ -1,0 +1,91 @@
+"""`PolarMACE.forward` returns the electrostatic keys its consumers read.
+
+Seven of the model output keys in the inventory are produced in one dict in
+`PolarMACE.forward` and nowhere else: `spins`, `total_charge`, `fermi_level`,
+`external_field`, `spin_density`, `spin_charge_density` and `charges_history`. The
+existing polar tests check equivariance, the cueq parity and the density cube CLI,
+none of which asserts that a given key is present or what shape it has, so any of
+the seven could be renamed or dropped and only a downstream KeyError would say so.
+
+Shapes are the point rather than values: `fermi_level` is per graph and `spins` is
+per atom, and a key that quietly changed which of those it is would still be
+"present". The values are checked only for being finite, since the weights are
+random here. The numbers belong to the golden references, which is a different
+claim from the contract this file pins.
+"""
+
+import pytest
+import torch
+
+from tests.extensions.polar.test_polar_models import (
+    _build_minimal_batch,
+    _build_minimal_model,
+)
+
+N_ATOMS, N_GRAPHS = 2, 1
+
+
+@pytest.fixture(name="outputs", scope="module")
+def fixture_outputs():
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    try:
+        model = _build_minimal_model("cpu", torch.float64)
+        batch = _build_minimal_batch("cpu", torch.float64)
+        return model(batch, training=False)
+    finally:
+        torch.set_default_dtype(previous)
+
+
+@pytest.mark.parametrize(
+    "key,kind",
+    [
+        ("spins", "per_atom_scalar"),
+        ("total_charge", "per_graph_scalar"),
+        ("fermi_level", "per_graph_scalar"),
+        ("external_field", "per_graph_vector"),
+    ],
+)
+def test_the_electrostatic_keys_are_present_with_the_right_extent(outputs, key, kind):
+    value = outputs.get(key)
+
+    assert value is not None, f"{key} is missing from the forward's output"
+    assert isinstance(value, torch.Tensor)
+    if kind == "per_atom_scalar":
+        assert value.shape == (N_ATOMS,)
+    elif kind == "per_graph_scalar":
+        assert value.shape == (N_GRAPHS,)
+    else:
+        assert value.shape == (N_GRAPHS, 3)
+    assert torch.isfinite(value).all(), f"{key} carries non-finite entries"
+
+
+@pytest.mark.parametrize(
+    "key,ndim",
+    [("spin_density", 2), ("spin_charge_density", 3), ("charges_history", 4)],
+)
+def test_the_density_keys_keep_their_rank(outputs, key, ndim):
+    """These three are multipole-shaped, so the rank is the contract a consumer
+    indexes against. `charges_history` carries the fixed-point iterations in its
+    last axis, which is why it has one more."""
+    value = outputs[key]
+
+    assert value.ndim == ndim
+    assert value.shape[0] == N_ATOMS
+    assert torch.isfinite(value).all()
+
+
+def test_charges_and_spins_are_the_leading_multipole(outputs):
+    """`charges` and `spins` are documented as the l=0 component of the density
+    coefficients, not independent quantities. If they stop agreeing, one of the
+    two readouts changed and the other did not."""
+    assert torch.equal(outputs["charges"], outputs["density_coefficients"][:, 0])
+    assert torch.equal(outputs["spins"], outputs["spin_density"][:, 0])
+
+
+def test_electrostatic_potentials_are_absent_unless_asked_for(outputs):
+    """`return_electrostatic_potentials` is False on this model, so the key is
+    present and None rather than missing: consumers test the value, not the key.
+    """
+    assert "electrostatic_potentials" in outputs
+    assert outputs["electrostatic_potentials"] is None

--- a/tests/unit/test_calculator_info_keys_and_state.py
+++ b/tests/unit/test_calculator_info_keys_and_state.py
@@ -1,0 +1,210 @@
+"""`info_keys` and `MACECalculator.check_state`.
+
+Two parts of the calculator's contract that nothing exercised.
+
+`info_keys` maps a PROPERTY NAME to the `atoms.info` key it is read from, the same
+direction as `arrays_keys` (see tests/unit/test_calculator_charges_key.py). Its
+default is not empty, so a caller who overrides it partially loses the entries
+they did not restate, which is the kind of thing a default that nobody asserts
+drifts into.
+
+`check_state` is ASE's recalculation trigger: whatever it returns non-empty for
+gets recomputed, and whatever it misses is served from cache. MACE overrides it to
+add `info`, because a MACE model can read `atoms.info` (total charge, total spin,
+external field) and ASE's own implementation looks only at numbers, positions,
+cell and pbc. So a change to a charge would otherwise return the previous energy.
+`MagneticMACECalculator` has its own override and its own test; this is the base
+one.
+"""
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+from e3nn import o3
+
+from mace import modules
+from mace.calculators import MACECalculator
+from mace.tools import AtomicNumberTable
+
+
+@pytest.fixture(scope="module", name="model_path")
+def fixture_model_path(tmp_path_factory):
+    table = AtomicNumberTable([1, 8])
+    torch.manual_seed(0)
+    model = modules.MACE(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e + 8x1o"),
+        MLP_irreps=o3.Irreps("8x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([1.0, 3.0]),
+        avg_num_neighbors=3,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="gaussian",
+    ).double()
+    path = tmp_path_factory.mktemp("info_keys") / "model.pt"
+    torch.save(model, path)
+    return path
+
+
+def water():
+    return Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0.0, -2.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        cell=[6.0] * 3,
+        pbc=True,
+    )
+
+
+def calculator(model_path, **kwargs):
+    return MACECalculator(
+        model_paths=str(model_path), device="cpu", default_dtype="float64", **kwargs
+    )
+
+
+# ---------------------------------------------------------------------------
+# info_keys
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_info_keys_are_the_three_documented_ones(model_path):
+    """Stated here so removing one is a test failure rather than a silent change
+    in what the calculator reads off a structure."""
+    calc = calculator(model_path)
+
+    assert calc.info_keys == {
+        "total_spin": "spin",
+        "total_charge": "charge",
+        "external_field": "external_field",
+    }
+
+
+def test_info_keys_maps_property_name_to_the_info_key(model_path):
+    """Same direction as `arrays_keys`: property name first, `atoms.info` key
+    second. Reversed, the property would silently never be found."""
+    calc = calculator(model_path, info_keys={"total_charge": "Q"})
+
+    assert calc.info_keys["total_charge"] == "Q"
+
+
+def test_an_override_replaces_the_defaults_rather_than_extending_them(model_path):
+    """The trap in overriding it: the entries not restated are gone."""
+    calc = calculator(model_path, info_keys={"total_charge": "Q"})
+
+    assert "total_spin" not in calc.info_keys
+
+
+def test_the_configured_info_key_is_the_one_read(model_path):
+    """Behaviour rather than the attribute: the value has to arrive in the batch
+    the model is given, through the configured key.
+
+    Checked on the batch instead of the energy because a plain `MACE` ignores the
+    total charge, so an energy comparison would pass whether the key was read or
+    not.
+    """
+    calc = calculator(model_path, info_keys={"total_charge": "Q"})
+    atoms = water()
+    atoms.info["Q"] = -1.0
+
+    batch = calc._atoms_to_batch(atoms)  # pylint: disable=protected-access
+    batch = batch[0] if isinstance(batch, tuple) else batch
+
+    assert float(batch.to_dict()["total_charge"]) == -1.0
+
+
+def test_the_default_key_is_not_read_once_it_has_been_remapped(model_path):
+    """The other half: after remapping to `Q`, a value left under `charge` is
+    ignored. Without this, a calculator that read both would pass the test above.
+    """
+    calc = calculator(model_path, info_keys={"total_charge": "Q"})
+    atoms = water()
+    atoms.info["charge"] = -1.0
+
+    batch = calc._atoms_to_batch(atoms)  # pylint: disable=protected-access
+    batch = batch[0] if isinstance(batch, tuple) else batch
+
+    assert float(batch.to_dict()["total_charge"]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# check_state
+# ---------------------------------------------------------------------------
+
+
+def test_nothing_changed_means_nothing_to_recompute(model_path):
+    calc = calculator(model_path)
+    atoms = water()
+    atoms.calc = calc
+    atoms.get_potential_energy()
+
+    assert calc.check_state(atoms) == []
+
+
+def test_moving_an_atom_is_a_change(model_path):
+    """ASE's own part of the contract, which the override must not lose."""
+    calc = calculator(model_path)
+    atoms = water()
+    atoms.calc = calc
+    atoms.get_potential_energy()
+
+    moved = atoms.copy()
+    moved.positions[0, 0] += 0.1
+
+    assert "positions" in calc.check_state(moved)
+
+
+def test_a_changed_info_entry_is_a_change(model_path):
+    """The reason for the override. ASE looks at numbers, positions, cell and pbc,
+    so a total charge that the model reads would otherwise return a cached energy.
+    """
+    calc = calculator(model_path)
+    atoms = water()
+    atoms.info["charge"] = 0.0
+    atoms.calc = calc
+    atoms.get_potential_energy()
+
+    charged = atoms.copy()
+    charged.info["charge"] = -1.0
+
+    assert "info" in calc.check_state(charged)
+
+
+def test_a_new_info_entry_is_a_change(model_path):
+    calc = calculator(model_path)
+    atoms = water()
+    atoms.calc = calc
+    atoms.get_potential_energy()
+
+    annotated = atoms.copy()
+    annotated.info["charge"] = -1.0
+
+    assert "info" in calc.check_state(annotated)
+
+
+def test_an_array_valued_info_entry_is_not_compared(model_path):
+    """The override skips ndarray values on purpose: `!=` on an array is an array,
+    and truth-testing it raises. Pinned so the skip is a decision, not a bug
+    waiting to be reintroduced as an exception.
+    """
+    calc = calculator(model_path)
+    atoms = water()
+    atoms.info["external_field"] = np.array([0.0, 0.0, 0.0])
+    atoms.calc = calc
+    atoms.get_potential_energy()
+
+    changed_field = atoms.copy()
+    changed_field.info["external_field"] = np.array([0.0, 0.0, 1.0])
+
+    assert calc.check_state(changed_field) == []

--- a/tests/unit/test_gate_registry.py
+++ b/tests/unit/test_gate_registry.py
@@ -1,0 +1,103 @@
+"""Every `gate_dict` entry is reachable and does something.
+
+`gate_dict` is one of the string to callable registries that connect a CLI value
+to an implementation, so `--gate abs` and `--gate None` are part of the surface.
+Only `silu` was ever built in a test, which leaves three ways to break the other
+two without a failure: drop the key, point it at the wrong callable, or stop
+threading it into the readout.
+
+`None` is the one worth spelling out. It is the string `"None"` on the command
+line and a real `None` in the dict, and it has to survive `nn.Activation`, which
+is not obviously true of a null activation.
+"""
+
+import numpy as np
+import pytest
+import torch
+from e3nn import o3
+
+from mace import data, modules, tools
+from mace.tools import torch_geometric
+
+TABLE = tools.AtomicNumberTable([1, 8])
+ATOMIC_ENERGIES = np.array([1.0, 3.0], dtype=float)
+
+
+def build(gate):
+    """A tiny MACE with a NonLinear readout, which is what consumes the gate."""
+    return modules.MACE(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=6,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o"),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=gate,
+        atomic_energies=ATOMIC_ENERGIES,
+        avg_num_neighbors=8,
+        atomic_numbers=TABLE.zs,
+        correlation=3,
+        radial_type="bessel",
+    )
+
+
+@pytest.fixture(name="batch")
+def fixture_batch():
+    config = data.Configuration(
+        atomic_numbers=np.array([8, 1, 1]),
+        positions=np.array([[0.0, -2.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        properties={"forces": np.zeros((3, 3)), "energy": -1.5},
+        property_weights={"forces": 1.0, "energy": 1.0},
+    )
+    atomic_data = data.AtomicData.from_config(config, z_table=TABLE, cutoff=3.0)
+    loader = torch_geometric.dataloader.DataLoader(
+        dataset=[atomic_data], batch_size=1, shuffle=False, drop_last=False
+    )
+    return next(iter(loader))
+
+
+def test_the_registry_maps_every_cli_value_to_its_callable():
+    """The mapping itself, since the CLI passes strings and nothing else checks
+    which callable each one lands on."""
+    assert modules.gate_dict["abs"] is torch.abs
+    assert modules.gate_dict["tanh"] is torch.tanh
+    assert modules.gate_dict["silu"] is torch.nn.functional.silu
+    assert modules.gate_dict["None"] is None
+
+
+@pytest.mark.parametrize("name", ["abs", "tanh", "silu", "None"])
+def test_a_model_builds_and_runs_with_every_gate(name, batch):
+    """Reachability: a registry entry that cannot be built is not a feature."""
+    model = build(modules.gate_dict[name])
+
+    out = model(batch.to_dict(), training=False)
+
+    assert out["energy"] is not None
+    assert torch.isfinite(out["energy"]).all()
+
+
+def test_the_gate_changes_the_energy(batch):
+    """Not just "it builds". Two gates over the same weights must disagree, or
+    the argument is being accepted and dropped.
+
+    Seeded per build, because the readout weights are random and two models with
+    the same seed differ only in the gate.
+    """
+    energies = {}
+    for name in ("abs", "tanh", "silu", "None"):
+        torch.manual_seed(0)
+        model = build(modules.gate_dict[name])
+        energies[name] = float(model(batch.to_dict(), training=False)["energy"])
+
+    assert len(set(energies.values())) == len(energies), (
+        f"two gates produced the same energy, so at least one is not applied: "
+        f"{energies}"
+    )

--- a/tests/unit/test_stage_two_weights.py
+++ b/tests/unit/test_stage_two_weights.py
@@ -1,0 +1,135 @@
+"""The stage-two loss weights are the ones the flags asked for.
+
+`--swa_energy_weight` and its siblings only take effect after the stage-two swap,
+which is why no end-to-end run pinned them: a short training either never swaps or
+swaps into a loss nobody inspects. `get_swa` is where the flags become a loss, so
+that is where they are checked.
+
+The weights are deliberately not the defaults and not equal to each other, so a
+loss that took the first-stage weight, or read the wrong flag, produces a
+different number here.
+"""
+
+import argparse
+
+import numpy as np
+import pytest
+import torch
+from e3nn import o3
+
+from mace import modules, tools
+from mace.tools.scripts_utils import get_swa
+
+ENERGY, FORCES, VIRIALS, STRESS = 7.0, 11.0, 13.0, 17.0
+
+
+@pytest.fixture(name="model")
+def fixture_model():
+    table = tools.AtomicNumberTable([1, 8])
+    torch.manual_seed(0)
+    return modules.MACE(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e"),
+        MLP_irreps=o3.Irreps("8x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([1.0, 3.0]),
+        avg_num_neighbors=3,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="bessel",
+    )
+
+
+def settings(**overrides):
+    args = argparse.Namespace(
+        loss="weighted",
+        start_swa=3,
+        max_num_epochs=10,
+        swa_lr=1e-3,
+        swa_energy_weight=ENERGY,
+        swa_forces_weight=FORCES,
+        swa_virials_weight=VIRIALS,
+        swa_stress_weight=STRESS,
+        swa_dipole_weight=1.0,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def build(model, **overrides):
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    swa, swas = get_swa(settings(**overrides), model, optimizer, [])
+    return swa, swas
+
+
+def test_the_energy_and_forces_weights_reach_the_stage_two_loss(model):
+    swa, _ = build(model)
+
+    assert swa.loss_fn.energy_weight == pytest.approx(ENERGY)
+    assert swa.loss_fn.forces_weight == pytest.approx(FORCES)
+
+
+def test_the_virials_weight_reaches_the_virials_loss(model):
+    swa, _ = build(model, loss="virials")
+
+    assert swa.loss_fn.energy_weight == pytest.approx(ENERGY)
+    assert swa.loss_fn.virials_weight == pytest.approx(VIRIALS)
+
+
+def test_the_stress_weight_reaches_the_stress_loss(model):
+    swa, _ = build(model, loss="stress")
+
+    assert swa.loss_fn.energy_weight == pytest.approx(ENERGY)
+    assert swa.loss_fn.stress_weight == pytest.approx(STRESS)
+
+
+def test_the_stage_two_weights_are_not_the_first_stage_ones(model):
+    """The mistake this guards: reading `args.energy_weight` instead of
+    `args.swa_energy_weight`. Those names differ by four characters."""
+    args = settings()
+    args.energy_weight = 1.0
+    args.forces_weight = 100.0
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    swa, _ = get_swa(args, model, optimizer, [])
+
+    assert swa.loss_fn.energy_weight != pytest.approx(args.energy_weight)
+    assert swa.loss_fn.forces_weight != pytest.approx(args.forces_weight)
+
+
+def test_the_swap_epoch_is_the_one_requested(model):
+    swa, _ = build(model, start_swa=4)
+
+    assert swa.start == 4
+
+
+def test_an_unset_swap_epoch_lands_three_quarters_in(model):
+    """The documented default: `max(1, max_num_epochs // 4 * 3)`."""
+    swa, _ = build(model, start_swa=None, max_num_epochs=8)
+
+    assert swa.start == 6
+
+
+def test_a_swap_after_the_last_epoch_is_refused(model):
+    """`swas` is how the caller learns stage two will not happen. A swap epoch
+    beyond the run is warned about and disabled rather than silently accepted."""
+    _, swas = build(model, start_swa=10, max_num_epochs=10)
+
+    assert swas[-1] is False
+
+
+def test_stage_two_is_refused_with_a_forces_only_loss(model):
+    with pytest.raises(ValueError, match="forces only"):
+        build(model, loss="forces_only")

--- a/tests/workflows/test_finetuning_select_cli.py
+++ b/tests/workflows/test_finetuning_select_cli.py
@@ -1,0 +1,278 @@
+"""`mace_finetuning_select` through its command line.
+
+`tests/workflows/test_finetuning_select.py` builds `SelectionSettings` in-process,
+which covers the selection logic and leaves the CLI itself unexercised: nothing
+passed `--model`, `--output`, `--device`, `--default_dtype`, `--seed` or the YAML
+`--config`, so a flag could stop reaching the code it names and every existing
+test would still pass.
+
+Two of those flags are only observable through the descriptor pass, so these tests
+go through `--subselect fps`. With `fpsample` absent the sampling step logs
+"FPS failed, selecting random configurations instead" and falls back, but the
+model is still loaded and the descriptors are still computed and saved first,
+which is the part that pins `--model` and `--default_dtype`. That fallback is
+itself worth pinning: a user who asked for farthest-point sampling and silently
+got random selection has no other signal than a log line.
+"""
+
+import shutil
+from pathlib import Path
+
+import ase.io
+import numpy as np
+import pytest
+from ase import Atoms
+
+from tests.helpers import run_mace_train
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SELECT = REPO_ROOT / "mace" / "cli" / "fine_tuning_select.py"
+
+
+@pytest.fixture(name="pool")
+def fixture_pool(tmp_path):
+    """A pretraining pool to select from, written where the CLI can read it."""
+    rng = np.random.default_rng(0)
+    configs = []
+    for _ in range(8):
+        atoms = Atoms(
+            numbers=[8, 1, 1],
+            positions=rng.random((3, 3)) * 3,
+            cell=[5, 5, 5],
+            pbc=[True] * 3,
+        )
+        atoms.info["REF_energy"] = float(rng.normal())
+        atoms.arrays["REF_forces"] = rng.normal(size=(3, 3))
+        configs.append(atoms)
+    path = tmp_path / "pt.xyz"
+    ase.io.write(path, configs, format="extxyz")
+    return path
+
+
+@pytest.fixture(name="model")
+def fixture_model(trained_tiny_model_path, tmp_path):
+    """A local checkpoint, so `--model` is exercised without a download.
+
+    Its default is the string "small", which resolves to a foundation model over
+    the network; a test that took the default would be testing the download.
+    """
+    destination = tmp_path / "tiny.model"
+    shutil.copy(trained_tiny_model_path, destination)
+    return destination
+
+
+def select(tmp_path, pool, **flags):
+    params = {"configs_pt": str(pool), "output": str(tmp_path / "out.xyz")}
+    params.update({k: str(v) for k, v in flags.items()})
+    return run_mace_train(
+        params,
+        script=SELECT,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def read_selection(tmp_path, name="out.xyz"):
+    selected = ase.io.read(tmp_path / name, index=":")
+    return [tuple(a.get_positions().round(8).ravel()) for a in selected]
+
+
+# ---------------------------------------------------------------------------
+# --output, --num_samples
+# ---------------------------------------------------------------------------
+
+
+def test_the_cli_writes_the_selection_and_the_combined_file(tmp_path, pool):
+    select(tmp_path, pool, num_samples=3, subselect="random")
+
+    assert (tmp_path / "out.xyz").exists()
+    assert (tmp_path / "out_combined.xyz").exists(), "the combined file is part of the contract"
+    assert len(read_selection(tmp_path)) == 3
+
+
+def test_the_output_path_is_where_the_flag_says(tmp_path, pool):
+    """`--output` also decides the combined file and the descriptor npy names."""
+    elsewhere = tmp_path / "nested"
+    elsewhere.mkdir()
+    target = elsewhere / "chosen.xyz"
+
+    run_mace_train(
+        {
+            "configs_pt": str(pool),
+            "output": str(target),
+            "num_samples": "2",
+            "subselect": "random",
+        },
+        script=SELECT,
+        cwd=tmp_path,
+    )
+
+    assert target.exists()
+    assert (elsewhere / "chosen_combined.xyz").exists()
+
+
+def test_an_output_that_is_not_extxyz_is_refused(tmp_path, pool):
+    result = run_mace_train(
+        {
+            "configs_pt": str(pool),
+            "output": str(tmp_path / "out.traj"),
+            "num_samples": "2",
+            "subselect": "random",
+        },
+        script=SELECT,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# --seed
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_seed_selects_the_same_configurations(tmp_path, pool):
+    """Reproducibility is the whole point of the flag, and random selection is
+    the mode where it is observable."""
+    select(tmp_path, pool, num_samples=3, subselect="random", seed=11)
+    first = read_selection(tmp_path)
+    (tmp_path / "out.xyz").unlink()
+    select(tmp_path, pool, num_samples=3, subselect="random", seed=11)
+
+    assert read_selection(tmp_path) == first
+
+
+def test_a_different_seed_selects_differently(tmp_path, pool):
+    """Otherwise the flag could be read and dropped and the test above would
+    still pass."""
+    select(tmp_path, pool, num_samples=3, subselect="random", seed=11)
+    first = read_selection(tmp_path)
+    (tmp_path / "out.xyz").unlink()
+    select(tmp_path, pool, num_samples=3, subselect="random", seed=12)
+
+    assert read_selection(tmp_path) != first
+
+
+# ---------------------------------------------------------------------------
+# --model, --device, --default_dtype: the descriptor pass
+# ---------------------------------------------------------------------------
+
+
+def test_a_local_checkpoint_is_used_for_the_descriptors(tmp_path, pool, model):
+    """`--model` pointing at a file, rather than the "small" default that would
+    reach for the network."""
+    select(tmp_path, pool, num_samples=3, subselect="fps", model=model, device="cpu")
+
+    descriptors = tmp_path / "pt_descriptors.npy"
+    assert descriptors.exists(), "the model was never asked for descriptors"
+    assert len(read_selection(tmp_path)) == 3
+
+
+def test_a_model_path_that_does_not_exist_is_refused(tmp_path, pool):
+    """The counterpart: the flag is read, so a bad value has to fail."""
+    result = run_mace_train(
+        {
+            "configs_pt": str(pool),
+            "output": str(tmp_path / "out.xyz"),
+            "num_samples": "2",
+            "subselect": "fps",
+            "model": str(tmp_path / "absent.model"),
+        },
+        script=SELECT,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_the_descriptors_follow_the_requested_dtype(tmp_path, pool, model, dtype):
+    """`--default_dtype` reaches the calculator, observed where it lands: the
+    saved descriptors are float32 or float64 accordingly."""
+    select(
+        tmp_path,
+        pool,
+        num_samples=3,
+        subselect="fps",
+        model=model,
+        device="cpu",
+        default_dtype=dtype,
+    )
+
+    saved = np.load(tmp_path / "pt_descriptors.npy", allow_pickle=True)
+    first = saved[0]
+    array = first[sorted(first)[0]] if isinstance(first, dict) else first
+
+    assert np.asarray(array).dtype == np.dtype(dtype)
+
+
+def test_a_device_outside_the_choices_is_rejected(tmp_path, pool):
+    """`--device` is a `choices=` argument, so a typo must not reach torch."""
+    result = run_mace_train(
+        {
+            "configs_pt": str(pool),
+            "output": str(tmp_path / "out.xyz"),
+            "num_samples": "2",
+            "subselect": "random",
+            "device": "cpu0",
+        },
+        script=SELECT,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "invalid choice" in result.stderr
+
+
+def test_fps_without_fpsample_falls_back_and_says_so(tmp_path, pool, model):
+    """The degradation is silent in the result and loud only in the log, so this
+    pins the log. A user who asked for farthest-point sampling and received a
+    random subset has nothing else to go on."""
+    result = select(
+        tmp_path, pool, num_samples=3, subselect="fps", model=model, device="cpu"
+    )
+    combined = result.stdout + result.stderr
+
+    try:
+        import fpsample  # noqa: F401  # pylint: disable=unused-import,import-outside-toplevel
+    except ImportError:
+        assert "FPS failed" in combined
+        assert "selecting random configurations instead" in combined
+    else:
+        assert "FPS failed" not in combined
+
+
+# ---------------------------------------------------------------------------
+# --config
+# ---------------------------------------------------------------------------
+
+
+def test_the_yaml_config_is_read(tmp_path, pool):
+    """configargparse's `--config`, which is the documented way to drive this CLI
+    from a file. Same settings through YAML must give the same selection."""
+    pytest.importorskip("configargparse")
+    select(tmp_path, pool, num_samples=3, subselect="random", seed=5)
+    by_flags = read_selection(tmp_path)
+    (tmp_path / "out.xyz").unlink()
+
+    config = tmp_path / "select.yaml"
+    config.write_text(
+        f"configs_pt: {pool}\n"
+        f"output: {tmp_path / 'out.xyz'}\n"
+        "num_samples: 3\n"
+        "subselect: random\n"
+        "seed: 5\n"
+    )
+    run_mace_train({"config": str(config)}, script=SELECT, cwd=tmp_path)
+
+    assert read_selection(tmp_path) == by_flags

--- a/tests/workflows/test_plot_train.py
+++ b/tests/workflows/test_plot_train.py
@@ -1,0 +1,228 @@
+"""`mace_plot_train` against a real results log.
+
+The plotting CLI had no test at all, and the results log format it parses had
+none either, so nothing connected the two: `mace_run_train` is free to rename a
+column and the only symptom is a plot nobody generates in CI.
+
+That absence was hiding a CLI that could not run. `plot` aggregated every column
+of the log with `mean` and `std`, including `head`, which is a string. pandas used
+to drop such columns from an aggregation by itself; 3.0 raises `dtype 'str' does
+not support operation 'mean'`, and `pandas` is unpinned, so the command has been
+dead on any recent install. It is fixed in this branch, and these tests are what
+would have caught it.
+
+The log is produced by an actual training rather than hand-written, because a
+hand-written one pins the test's idea of the format instead of the trainer's.
+Every flag is checked by the plot changing, not merely by the command exiting
+zero: the output is byte-deterministic here, so "this flag does something" is a
+real assertion, and a flag silently ignored is a live risk (`--start_stage_two`
+and `--start_swa` are two spellings that must stay one flag).
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import ase.io
+import pytest
+
+from tests.helpers import base_mace_params, make_fitting_configs, run_mace_train
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLOT_TRAIN = REPO_ROOT / "mace" / "cli" / "plot_train.py"
+
+#: `plot` writes `{name}_{head}.{format}` next to the working directory, and
+#: `name` comes off the log's filename, not from a flag.
+DEFAULT_PLOT = "plotme_default.png"
+
+
+@pytest.fixture(name="results_log", scope="module")
+def fixture_results_log(tmp_path_factory):
+    """A real `<name>_run-<seed>_train.txt`, from a real six-epoch training."""
+    tmp = tmp_path_factory.mktemp("plot_train")
+    ase.io.write(tmp / "fit.xyz", make_fitting_configs())
+    params = base_mace_params()
+    params.update(
+        {
+            "name": "plotme",
+            "hidden_irreps": "16x0e",
+            "checkpoints_dir": str(tmp),
+            "model_dir": str(tmp),
+            "results_dir": str(tmp),
+            "log_dir": str(tmp),
+            "train_file": str(tmp / "fit.xyz"),
+            "max_num_epochs": 6,
+            "start_swa": 4,
+            "seed": 7,
+        }
+    )
+    run_mace_train(params)
+    log = tmp / "plotme_run-7_train.txt"
+    assert log.exists(), "the trainer did not write the results log this CLI reads"
+    return log
+
+
+@pytest.fixture(name="workdir")
+def fixture_workdir(results_log, tmp_path):
+    """A directory holding only the log, since the CLI writes into the cwd."""
+    shutil.copy(results_log, tmp_path / results_log.name)
+    return tmp_path
+
+
+def plot_train(workdir, *argv):
+    """Run the CLI in `workdir` and return the bytes of the plot it wrote."""
+    run_mace_train(
+        {"path": str(workdir / "plotme_run-7_train.txt")},
+        extra_argv=list(argv),
+        script=PLOT_TRAIN,
+        cwd=workdir,
+        env_extra={"MPLBACKEND": "Agg"},
+    )
+    return workdir
+
+
+def read(workdir, name=DEFAULT_PLOT):
+    path = workdir / name
+    assert path.exists(), f"the CLI wrote no {name}; got {sorted(p.name for p in workdir.iterdir())}"
+    return path.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# The log the CLI reads
+# ---------------------------------------------------------------------------
+
+
+def test_the_results_log_carries_the_columns_the_plot_reads(results_log):
+    """The format contract, stated where a rename would break it."""
+    rows = [json.loads(line) for line in results_log.read_text().splitlines()]
+
+    assert rows, "the results log is empty"
+    assert {"epoch", "mode", "loss", "head"} <= set(rows[0])
+    assert {"opt", "eval"} <= {row["mode"] for row in rows}
+    assert any(row.get("rmse_e") is not None for row in rows)
+
+
+def test_the_log_carries_a_string_column(results_log):
+    """`head` is why the aggregation needs the numeric columns selected. A test
+    that only ever saw numeric columns would pass against the broken version."""
+    rows = [json.loads(line) for line in results_log.read_text().splitlines()]
+
+    assert any(isinstance(row.get("head"), str) for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# The plot
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_results_log_becomes_a_plot(workdir):
+    plot_train(workdir)
+
+    content = read(workdir)
+    assert content[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG"
+    assert len(content) > 5_000, "a PNG this small is an empty figure"
+
+
+def test_a_directory_is_searched_for_logs(workdir):
+    """`--path` takes a directory as well as a file, and globs `*_train.txt`."""
+    run_mace_train(
+        {"path": str(workdir)},
+        script=PLOT_TRAIN,
+        cwd=workdir,
+        env_extra={"MPLBACKEND": "Agg"},
+    )
+
+    assert (workdir / DEFAULT_PLOT).exists()
+
+
+def test_the_same_input_gives_the_same_plot(workdir):
+    """The premise the flag tests below rely on."""
+    first = read(plot_train(workdir))
+    (workdir / DEFAULT_PLOT).unlink()
+    second = read(plot_train(workdir))
+
+    assert first == second
+
+
+def test_the_output_format_is_honoured(workdir):
+    plot_train(workdir, "--output_format", "pdf")
+
+    content = read(workdir, "plotme_default.pdf")
+    assert content[:5] == b"%PDF-"
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        pytest.param(["--linear"], id="linear"),
+        pytest.param(["--error_bars"], id="error_bars"),
+        pytest.param(["--keys", "rmse_e"], id="keys"),
+        pytest.param(["--min_epoch", "3"], id="min_epoch"),
+        pytest.param(["--start_swa", "4"], id="start_swa"),
+    ],
+)
+def test_each_flag_changes_the_plot(workdir, flag):
+    """Not "it exits zero": a flag that is parsed and then dropped would."""
+    baseline = read(plot_train(workdir))
+    (workdir / DEFAULT_PLOT).unlink()
+
+    assert read(plot_train(workdir, *flag)) != baseline
+
+
+def test_start_stage_two_is_the_same_flag_as_start_swa(workdir):
+    """Two spellings, one `dest`. They must produce the same figure, or the
+    rename left one of them landing somewhere else."""
+    swa = read(plot_train(workdir, "--start_swa", "4"))
+    (workdir / DEFAULT_PLOT).unlink()
+    stage_two = read(plot_train(workdir, "--start_stage_two", "4"))
+
+    assert swa == stage_two
+
+
+def test_heads_names_the_plot_after_the_head(workdir):
+    """The multihead path aggregates per head and writes one file per head."""
+    plot_train(workdir, "--heads", "Default")
+
+    assert (workdir / "plotme_Default.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# What it refuses
+# ---------------------------------------------------------------------------
+
+
+def test_a_filename_it_cannot_parse_is_refused(workdir):
+    """The seed and the run name come from the filename, so an unparseable one
+    has to fail rather than be plotted under a guessed name."""
+    stray = workdir / "not-a-results-log.txt"
+    stray.write_text('{"epoch": 1, "mode": "opt", "loss": 1.0}\n')
+
+    result = run_mace_train(
+        {"path": str(stray)},
+        script=PLOT_TRAIN,
+        cwd=workdir,
+        check=False,
+        capture_output=True,
+        text=True,
+        env_extra={"MPLBACKEND": "Agg"},
+    )
+
+    assert result.returncode != 0
+    assert "Cannot parse" in result.stderr
+
+
+def test_a_directory_without_logs_is_refused(workdir, tmp_path_factory):
+    empty = tmp_path_factory.mktemp("no_logs")
+
+    result = run_mace_train(
+        {"path": str(empty)},
+        script=PLOT_TRAIN,
+        cwd=workdir,
+        check=False,
+        capture_output=True,
+        text=True,
+        env_extra={"MPLBACKEND": "Agg"},
+    )
+
+    assert result.returncode != 0
+    assert "Cannot find results" in result.stderr

--- a/tests/workflows/test_preprocess_keys.py
+++ b/tests/workflows/test_preprocess_keys.py
@@ -1,0 +1,134 @@
+"""`mace_prepare_data` reads the property keys it is told to read.
+
+The preprocessing CLI takes its own `--virials_key`, `--dipole_key`,
+`--charges_key` and `--polarizability_key`, and nothing passed them. The training
+side of the same convention is covered, but preprocessing is a separate parser
+writing a separate artifact: a key that stops being read there produces shards
+with the property missing, and training then fails, or worse trains on zeros, a
+long way from the flag that caused it.
+
+Each key is checked by writing the property under a NON-default name and requiring
+it to arrive in the shard. Using the default name would pass whether the flag was
+read or ignored.
+"""
+
+import json
+
+import ase.io
+import numpy as np
+import pytest
+from ase import Atoms
+
+from tests.helpers import preprocess_data, run_mace_train
+
+pytest.importorskip("h5py")
+import h5py  # noqa: E402  # pylint: disable=wrong-import-position,wrong-import-order
+
+
+@pytest.fixture(name="configs")
+def fixture_configs():
+    """Water plus the two isolated atoms preprocessing needs for E0s, with every
+    property under a deliberately unusual key."""
+    isolated = [
+        Atoms(numbers=[8], positions=[[0, 0, 0]], cell=[6] * 3),
+        Atoms(numbers=[1], positions=[[0, 0, 0]], cell=[6] * 3),
+    ]
+    for atoms in isolated:
+        atoms.info["MY_energy"] = 0.0
+        atoms.info["config_type"] = "IsolatedAtom"
+
+    rng = np.random.default_rng(5)
+    water = Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+        cell=[6] * 3,
+        pbc=True,
+    )
+    frames = []
+    for _ in range(10):
+        frame = water.copy()
+        frame.positions += rng.normal(0.1, size=frame.positions.shape)
+        frame.info["MY_energy"] = float(rng.normal(0.1))
+        frame.new_array("MY_forces", rng.normal(0.1, size=frame.positions.shape))
+        frame.info["MY_virials"] = rng.normal(0.1, size=(3, 3))
+        frame.info["MY_dipole"] = rng.normal(0.1, size=3)
+        frame.new_array("MY_charges", rng.normal(0.1, size=len(frame)))
+        frames.append(frame)
+    return isolated + frames
+
+
+def preprocess(tmp_path, configs, **extra):
+    ase.io.write(tmp_path / "sample.xyz", configs)
+    params = {
+        "train_file": tmp_path / "sample.xyz",
+        "r_max": 5.0,
+        "config_type_weights": "{'Default':1.0}",
+        "num_process": 1,
+        "valid_fraction": 0.1,
+        "h5_prefix": tmp_path / "pre_",
+        "compute_statistics": None,
+        "seed": 42,
+        "energy_key": "MY_energy",
+        "forces_key": "MY_forces",
+    }
+    params.update(extra)
+    result = run_mace_train(params, script=preprocess_data)
+    assert result.returncode == 0
+    return tmp_path
+
+
+def shard_shapes(tmp_path, name):
+    """The shapes one property takes across every configuration in the shards.
+
+    A property that was read arrives with its real shape; one that was not is
+    written as a 0-d placeholder. That distinction is the discriminator here,
+    rather than the values, which are random.
+    """
+    shapes = set()
+    for path in sorted((tmp_path / "pre_train").glob("*.h5")):
+        with h5py.File(path, "r") as handle:
+            for batch in handle.values():
+                for config in batch.values():
+                    properties = config["properties"]
+                    if name in properties:
+                        shapes.add(np.asarray(properties[name]).shape)
+    return shapes
+
+
+def test_the_energy_and_forces_keys_reach_the_shards(tmp_path, configs):
+    """The baseline: the two keys the existing test already passes, so a failure
+    below is about the flag under test and not about the fixture."""
+    preprocess(tmp_path, configs)
+
+    assert (tmp_path / "pre_statistics.json").is_file()
+    statistics = json.loads((tmp_path / "pre_statistics.json").read_text())
+    assert "atomic_energies" in statistics
+
+
+@pytest.mark.parametrize(
+    "flag,info_key,shard_name,shape",
+    [
+        ("virials_key", "MY_virials", "virials", (3, 3)),
+        ("dipole_key", "MY_dipole", "dipole", (3,)),
+        ("charges_key", "MY_charges", "charges", (3,)),
+    ],
+)
+def test_a_property_key_is_read_under_the_name_it_is_given(
+    tmp_path, configs, flag, info_key, shard_name, shape
+):
+    preprocess(tmp_path, configs, **{flag: info_key})
+
+    assert shard_shapes(tmp_path, shard_name) == {shape}
+
+
+@pytest.mark.parametrize(
+    "shard_name", ["virials", "dipole", "charges"]
+)
+def test_the_property_is_a_placeholder_when_no_key_is_given(
+    tmp_path, configs, shard_name
+):
+    """The other half. The property is present in the shard either way, so a test
+    that only checked presence would pass on a CLI that ignored the flag."""
+    preprocess(tmp_path, configs)
+
+    assert shard_shapes(tmp_path, shard_name) == {()}

--- a/tests/workflows/test_train_work_dir_and_workers.py
+++ b/tests/workflows/test_train_work_dir_and_workers.py
@@ -1,0 +1,129 @@
+"""`--work_dir` and `--num_workers`, neither of which any run passed.
+
+`--work_dir` is not one of the four output directories; it is where the training
+split records the validation indices it chose, and it only writes that file when
+the split is large enough to be worth recording (ten or more configurations).
+Every existing fixture trains on a handful, so the branch never ran.
+
+`--num_workers` sizes the DataLoader worker pool at four places in `run_train`.
+A smoke run with workers is the only end-to-end statement available, so it is
+paired with a source check that no loader is built without it: a fifth loader
+added later is exactly how a knob like this stops applying to half the run.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import ase.io
+import numpy as np
+import pytest
+from ase import Atoms
+
+from mace.cli import run_train as run_train_module
+from tests.helpers import base_mace_params, run_mace_train
+
+
+@pytest.fixture(name="many_configs")
+def fixture_many_configs():
+    """Enough configurations that a 10% validation split is ten or more, which is
+    the condition for the indices being written to `--work_dir` at all."""
+    rng = np.random.default_rng(3)
+    water = Atoms(
+        numbers=[8, 1, 1],
+        positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+        cell=[6.0] * 3,
+        pbc=True,
+    )
+    configs = []
+    for numbers in ([8], [1]):
+        isolated = Atoms(numbers=numbers, positions=[[0, 0, 0]], cell=[6] * 3)
+        isolated.info["REF_energy"] = 0.0
+        isolated.info["config_type"] = "IsolatedAtom"
+        configs.append(isolated)
+    for _ in range(120):
+        frame = water.copy()
+        frame.positions += rng.normal(0.1, size=frame.positions.shape)
+        frame.info["REF_energy"] = float(rng.normal(0.1))
+        frame.new_array("REF_forces", rng.normal(0.1, size=frame.positions.shape))
+        configs.append(frame)
+    return configs
+
+
+def train(tmp_path, configs, **extra):
+    ase.io.write(tmp_path / "fit.xyz", configs)
+    params = base_mace_params()
+    params.update(
+        {
+            "name": "wd",
+            "hidden_irreps": "8x0e",
+            "checkpoints_dir": str(tmp_path / "ckpt"),
+            "model_dir": str(tmp_path / "model"),
+            "results_dir": str(tmp_path / "results"),
+            "log_dir": str(tmp_path / "logs"),
+            "train_file": str(tmp_path / "fit.xyz"),
+            "max_num_epochs": 1,
+            "valid_fraction": 0.1,
+            "seed": 123,
+            "loss": "weighted",
+        }
+    )
+    params.pop("swa", None)
+    params.pop("start_swa", None)
+    params.update(extra)
+    return run_mace_train(params)
+
+
+def test_the_validation_indices_land_in_the_work_dir(tmp_path, many_configs):
+    """The observable effect of the flag: the file appears where it points."""
+    work = tmp_path / "elsewhere"
+    work.mkdir()
+
+    train(tmp_path, many_configs, work_dir=str(work))
+
+    written = list(work.glob("*valid_indices_*.txt"))
+    assert written, f"nothing in {work}: {sorted(p.name for p in work.iterdir())}"
+    indices = [int(line) for line in written[0].read_text().split()]
+    assert len(indices) >= 10
+    assert all(0 <= i < len(many_configs) for i in indices)
+
+
+def test_without_the_flag_the_indices_do_not_appear_there(tmp_path, many_configs):
+    """Otherwise the test above would pass on a run that wrote them anywhere."""
+    work = tmp_path / "elsewhere"
+    work.mkdir()
+
+    train(tmp_path, many_configs)
+
+    assert not list(work.glob("*valid_indices_*.txt"))
+
+
+def test_a_run_with_workers_trains(tmp_path, many_configs):
+    """`--num_workers` spawns loader subprocesses, which is the part that breaks
+    when the dataset or the collate function is not picklable."""
+    result = train(tmp_path, many_configs, num_workers=2)
+
+    assert result.returncode == 0
+    assert (tmp_path / "model" / "wd.model").exists()
+
+
+def test_every_dataloader_is_given_the_worker_count():
+    """A loader built without `num_workers` silently ignores the flag for that
+    part of the run, and no end-to-end assertion distinguishes that from a run
+    that honoured it. Checked on the source for the same reason
+    tests/unit/test_calculator_dtype_scope.py does: several of these branches
+    need a distributed launch or an on-line dataset to reach.
+    """
+    tree = ast.parse(inspect.getsource(run_train_module))
+    missing = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = ast.unparse(node.func)
+        if not name.endswith("DataLoader"):
+            continue
+        keywords = {kw.arg for kw in node.keywords}
+        if "num_workers" not in keywords:
+            missing.append(f"{name} at line {node.lineno}")
+
+    assert not missing, "DataLoader built without num_workers: " + ", ".join(missing)


### PR DESCRIPTION
Eight surfaces the inventory had marked as unpinned. 71 tests, one product fix.

mace_plot_train could not run at all. It aggregated every column of the results log with mean and std, and one of them is head, a string. pandas 3.0 raises on that instead of dropping the column, and pandas is unpinned, so the command is dead on any recent install. The numeric columns are now selected before aggregating. 11 of the 15 plotting tests fail without the fix.

The rest is tests: the plotting flags, mace_finetuning_select's command line, the preprocessing property keys, the stage-two loss weights, --work_dir, --num_workers, the gate_dict entries other than silu, the calculator's info_keys and check_state, and PolarMACE's electrostatic output keys.

Each flag is pinned by something changing, not by the command exiting zero. The seed, dtype and worker-count assertions were checked against a mutated CLI that ignores the flag, and each fails there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One small plotting aggregation fix plus new tests; no changes to training, calculator, or model forward logic beyond the plot CLI fix.
> 
> **Overview**
> Fixes **`mace_plot_train`**, which crashed on recent pandas when aggregating training logs because the string **`head`** column was included in **`mean`/`std`**. Aggregation now goes through **`_aggregate`**, which groups on the requested keys and only averages **numeric** columns.
> 
> Adds **~71 tests** that assert behavior changes (not just exit code **0**) for surfaces that were previously untested: **`mace_plot_train`** (real logs, flags, error paths), **`mace_finetuning_select`** CLI (**`--model`**, **`--seed`**, **`--config`**, FPS fallback logging), **`mace_prepare_data`** property key flags, stage-two **`get_swa`** weights, training **`--work_dir`** / **`--num_workers`**, **`gate_dict`**, base **`MACECalculator`** **`info_keys`** / **`check_state`**, and **`PolarMACE`** electrostatic output keys/shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122b25e89adccce1a4c200d1328c6c374f9a72f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->