### PR TITLE
Create all three atoms in the LAMMPS real tier

### DIFF
--- a/tests/integrations/lammps/test_lammps_real.py
+++ b/tests/integrations/lammps/test_lammps_real.py
@@ -48,7 +48,12 @@ def test_lammps_mliap_energy_matches_python(mliap_artifact):
     import lammps
     from lammps.mliap import activate_mliappy
 
+    # `create_atoms ... single` silently discards a point that falls outside
+    # the box, and the cell's oxygen sits at y=-2. The cell is periodic, so
+    # wrapping moves it to y=2 without changing the energy either side
+    # computes -- it only keeps both sides on the same three atoms.
     atoms = water_unit_cell()
+    atoms.wrap()
 
     lmp = lammps.lammps(cmdargs=["-log", "none", "-screen", "none"])
     assert lmp.has_style("pair", "mliap"), "LAMMPS build lacks the ML-IAP package"
@@ -72,6 +77,10 @@ def test_lammps_mliap_energy_matches_python(mliap_artifact):
             f"create_atoms {type_of[num]} single {pos[0]} {pos[1]} {pos[2]} "
             "units box"
         )
+    assert lmp.get_natoms() == len(atoms), (
+        f"LAMMPS created {lmp.get_natoms()} of the {len(atoms)} atoms; a "
+        "dropped atom shows up only as a wrong energy further down"
+    )
     lmp.command(f"pair_style mliap unified {mliap_artifact} 0")
     lmp.command("pair_coeff * * O H")
     lmp.command("run 0")


### PR DESCRIPTION
The real tier LAMMPS test has been failing in the nightly since #1658 made its assertion reachable for the first time.

The harness water cell puts the oxygen at y = -2. The test builds `region box block 0 4 0 4 0 4`, so that atom falls outside the box, and `create_atoms ... single` silently discards a point outside the box. It only remaps with `remap yes`. So LAMMPS was running two atoms against the python reference's three, and the only symptom was a wrong energy:

    LAMMPS pe=0.04016276608130766 vs python -0.04665882833752667

Wrapping the cell is free. The cell is periodic, so the python reference is identical either way, and both sides then hold the same three atoms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a95595a62e80e1d100964a9ea6a16b1771d0be53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->