### PR TITLE
Add inventory coverage for the block, radial, contraction, transform and calculator classes

### DIFF
--- a/tests/golden/check_inventory.py
+++ b/tests/golden/check_inventory.py
@@ -461,6 +461,54 @@ def source_calculator_exports() -> dict[str, Decl]:
     raise SystemExit("mace/calculators/__init__.py has no __all__")
 
 
+def source_radial_classes() -> dict[str, Decl]:
+    """Radial bases, cutoffs and distance transforms.
+
+    `--radial_type` selects among them by string, but the string list and the
+    classes are not the same set: `ZBLBasis`, `AgnesiTransform` and `RadialMLP`
+    are reached by other flags or by construction, so counting the choices does
+    not account for the file.
+    """
+    return _classes(REPO / "mace" / "modules" / "radial.py")
+
+
+def source_block_classes() -> dict[str, Decl]:
+    """The message-passing building blocks.
+
+    Most are reachable through `interaction_classes` / `readout_classes`, which
+    the registry set already covers, but that covers the *string* a user passes.
+    A block class added without a registry entry is reachable from Python and
+    from a checkpoint, and was invisible here until this set existed.
+    """
+    out = _classes(REPO / "mace" / "modules" / "blocks.py")
+    out.update(_classes(REPO / "mace" / "modules" / "gate.py"))
+    return out
+
+
+def source_contraction_classes() -> dict[str, Decl]:
+    """The many-body contraction, which the accelerated backends replace."""
+    return _classes(REPO / "mace" / "modules" / "symmetric_contraction.py")
+
+
+def source_data_transforms() -> dict[str, Decl]:
+    """Training-data transforms. `--data_aug_magmom` is one flag over a class
+    that could gain siblings, and a second transform would arrive unlisted."""
+    return _classes(REPO / "mace" / "data" / "augmentation.py")
+
+
+def source_calculator_classes() -> dict[str, Decl]:
+    """The runtime backends: the ASE calculators and the deployment wrappers.
+
+    `calc.param.*` and `calc.export.*` cover `MACECalculator`'s signature and
+    what `mace/calculators/__init__.py` exports; neither accounts for a new
+    class in these files.
+    """
+    out: dict[str, Decl] = {}
+    for name in ("mace.py", "lammps_mace.py", "lammps_mliap_mace.py", "mace_torchsim.py"):
+        out.update(_classes(REPO / "mace" / "calculators" / name))
+    return out
+
+
 def source_model_output_keys() -> dict[str, Decl]:
     """Keys of the dicts the model `forward`s return — the contract every
     consumer (calculator, eval CLI, LAMMPS, training loop) reads."""
@@ -674,6 +722,15 @@ def collect_sources() -> list[SourceSet]:
         SourceSet("--model choices", "choice.", "choices", source_model_choices()),
         SourceSet("model-level classes", "model.", "classes", source_model_classes()),
         SourceSet("registry entries", "reg.", "entries", source_registries()),
+        SourceSet("radial classes", "radial.", "classes", source_radial_classes()),
+        SourceSet("block classes", "block.", "classes", source_block_classes()),
+        SourceSet(
+            "contraction classes", "contraction.", "classes", source_contraction_classes()
+        ),
+        SourceSet("data transforms", "transform.", "transforms", source_data_transforms()),
+        SourceSet(
+            "calculator classes", "calc.class.", "classes", source_calculator_classes()
+        ),
         SourceSet("loss classes", "loss.", "classes", source_loss_classes()),
         SourceSet("calculator params", "calc.param.", "params", source_calculator_params()),
         SourceSet("calculator exports", "calc.export.", "exports", source_calculator_exports()),

--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -698,6 +698,64 @@ surface.
 | `reg.abs` | `abs` — gate_dict | `mace/modules/__init__.py:97` | KEEP | `tests/unit/test_gate_registry.py::test_the_registry_maps_every_cli_value_to_its_callable` |
 | `reg.None` | `None` — gate_dict | `mace/modules/__init__.py:100` | KEEP — the string `"None"`, meaning no gate | `tests/unit/test_gate_registry.py::test_a_model_builds_and_runs_with_every_gate` |
 
+
+## 7b. Blocks, radial bases, contractions, transforms and calculator classes (46)
+
+The classes the registries do not account for. A registry entry is the *string* a
+user passes; these are the classes themselves, and one added without a registry
+entry is still reachable from Python and from a checkpoint. Adding these five sets
+to the checker was prompted by a mutation test: a new class in any of these files
+used to pass the gate in silence.
+
+| id | feature | source | disposition | pinned by |
+| --- | --- | --- | --- | --- |
+| `radial.BesselBasis` | `BesselBasis` | `mace/modules/radial.py:18` | KEEP — the default radial basis | `tests/unit/test_modules.py::test_bessel_basis` |
+| `radial.ChebychevBasis` | `ChebychevBasis` | `mace/modules/radial.py:61` | KEEP — `--radial_type chebyshev` | `tests/unit/test_radial.py::test_chebychev_basis_values` |
+| `radial.GaussianBasis` | `GaussianBasis` | `mace/modules/radial.py:89` | KEEP — `--radial_type gaussian` | `tests/unit/test_radial.py::test_gaussian_basis_values` |
+| `radial.PolynomialCutoff` | `PolynomialCutoff` | `mace/modules/radial.py:113` | KEEP — the envelope every basis is multiplied by | `tests/unit/test_modules.py::test_polynomial_cutoff` |
+| `radial.ZBLBasis` | `ZBLBasis` | `mace/modules/radial.py:149` | KEEP — `--pair_repulsion`, a physics term rather than a basis | `tests/unit/test_radial.py::test_zbl_buffers_and_trainability` |
+| `radial.AgnesiTransform` | `AgnesiTransform` | `mace/modules/radial.py:225` | KEEP — `--distance_transform agnesi` | `tests/unit/test_radial.py::test_agnesi_transform_values` |
+| `radial.SoftTransform` | `SoftTransform` | `mace/modules/radial.py:285` | KEEP — `--distance_transform soft` | `tests/unit/test_radial.py::test_soft_transform_values` |
+| `radial.RadialMLP` | `RadialMLP` | `mace/modules/radial.py:361` | KEEP — the MLP over the basis, sized by `--radial_MLP` | `tests/unit/test_radial.py::test_radial_mlp_structure_and_shapes` |
+| `block.LinearNodeEmbeddingBlock` | `LinearNodeEmbeddingBlock` | `mace/modules/blocks.py:45` | KEEP — one-hot elements to node features, in every model | `tests/unit/test_models.py::test_mace` |
+| `block.RadialEmbeddingBlock` | `RadialEmbeddingBlock` | `mace/modules/blocks.py:395` | KEEP — basis x cutoff, in every model | `tests/unit/test_radial.py::test_the_basis_sees_the_transformed_lengths` |
+| `block.AtomicEnergiesBlock` | `AtomicEnergiesBlock` | `mace/modules/blocks.py:364` | KEEP — the E0 term | `tests/unit/test_modules.py::test_atomic_energies` |
+| `block.ScaleShiftBlock` | `ScaleShiftBlock` | `mace/modules/blocks.py:1942` | KEEP — the dataset scale and shift | `tests/unit/test_scale_shift_dtype.py::test_the_scale_shift_buffers_are_also_frozen_at_construction` |
+| `block.EquivariantProductBasisBlock` | `EquivariantProductBasisBlock` | `mace/modules/blocks.py:440` | KEEP — the many-body product basis | `tests/golden/test_tiny_dipoles.py::test_the_committed_anchor_carries_the_plain_e3nn_basis` |
+| `block.InteractionBlock` | `InteractionBlock` | `mace/modules/blocks.py:639` | KEEP — the abstract base every interaction subclasses | `tests/unit/test_models.py::test_mace` |
+| `block.GatedEquivariantBlock` | `GatedEquivariantBlock` | `mace/modules/gate.py:39` | KEEP — the gate the nonlinear readouts apply | `tests/unit/test_gate.py::test_forward_matches_e3nn` |
+| `block.LinearReadoutBlock` | `LinearReadoutBlock` | `mace/modules/blocks.py:65` | KEEP — the per-layer site-energy readout | `tests/unit/test_models.py::test_mace` |
+| `block.NonLinearReadoutBlock` | `NonLinearReadoutBlock` | `mace/modules/blocks.py:87` | KEEP — the last-layer readout when `--MLP_irreps` is set | `tests/unit/test_models.py::test_mace` |
+| `block.LinearDipoleReadoutBlock` | `LinearDipoleReadoutBlock` | `mace/modules/blocks.py:163` | KEEP — the dipole family's readout | `tests/unit/test_models.py::test_dipole_mace` |
+| `block.NonLinearDipoleReadoutBlock` | `NonLinearDipoleReadoutBlock` | `mace/modules/blocks.py:185` | KEEP — idem, nonlinear | `tests/unit/test_models.py::test_dipole_mace` |
+| `block.LinearDipolePolarReadoutBlock` | `LinearDipolePolarReadoutBlock` | `mace/modules/blocks.py:233` | KEEP — dipole and polarizability together | `tests/unit/test_models.py::test_dipole_polar_mace` |
+| `block.NonLinearDipolePolarReadoutBlock` | `NonLinearDipolePolarReadoutBlock` | `mace/modules/blocks.py:262` | KEEP — idem, nonlinear | `tests/unit/test_models.py::test_dipole_polar_mace` |
+| `block.LinearLesReadoutBlock` | `LinearLesReadoutBlock` | `mace/modules/blocks.py:1974` | KEEP — the LES latent-multipole readout | `tests/extensions/les/test_maceles.py::test_les_readout_equivariance` |
+| `block.NonLinearLesReadoutBlock` | `NonLinearLesReadoutBlock` | `mace/modules/blocks.py:2084` | KEEP — idem, nonlinear | `tests/extensions/les/test_maceles.py::test_les_readout_equivariance` |
+| `block.NonLinearBiasReadoutBlock` | `NonLinearBiasReadoutBlock` | `mace/modules/blocks.py:123` | KEEP — the biased readout the field models use | ⚠️ gap (registered in `readout_classes` and used from `mace/modules/extensions.py`; no test names it) |
+| `block.GeneralNonLinearBiasReadoutBlock` | `GeneralNonLinearBiasReadoutBlock` | `mace/modules/blocks.py:314` | KEEP — idem, for `mace/modules/field_blocks.py` | ⚠️ gap (registered and reachable; no test names it) |
+| `block.RealAgnosticInteractionBlock` | `RealAgnosticInteractionBlock` | `mace/modules/blocks.py:835` | MERGE — one of five interaction variants that collapse into a configured convolution | `tests/backends/backend_parity.py::test_bidirectional_conversion` |
+| `block.RealAgnosticResidualInteractionBlock` | `RealAgnosticResidualInteractionBlock` | `mace/modules/blocks.py:938` | KEEP — the default | `tests/unit/test_models.py::test_mace` |
+| `block.RealAgnosticDensityInteractionBlock` | `RealAgnosticDensityInteractionBlock` | `mace/modules/blocks.py:1041` | MERGE — idem | `tests/backends/backend_parity.py::test_bidirectional_conversion` |
+| `block.RealAgnosticDensityResidualInteractionBlock` | `RealAgnosticDensityResidualInteractionBlock` | `mace/modules/blocks.py:1162` | MERGE — idem | `tests/integrations/lammps/test_mliap_exchange.py::test_mliap_exchange_density_residual` |
+| `block.RealAgnosticResidualNonLinearInteractionBlock` | `RealAgnosticResidualNonLinearInteractionBlock` | `mace/modules/blocks.py:1412` | KEEP — the PolarMACE interaction | `tests/backends/backend_parity.py::test_bidirectional_conversion` |
+| `block.RealAgnosticAttResidualInteractionBlock` | `RealAgnosticAttResidualInteractionBlock` | `mace/modules/blocks.py:1286` | MERGE — idem | ⚠️ gap (registered in `interaction_classes`, so reachable from `--interaction`; nothing builds it) |
+| `block.MagneticInteractionBlock` | `MagneticInteractionBlock` | `mace/modules/blocks.py:1602` | KEEP — the magnetic interactions' base class | `tests/extensions/magnetic/test_magmace.py::test_run_train_magnetic_mace` |
+| `block.MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock` | `MagneticRealAgnosticSpinOrbitCoupledDensityInteractionBlock` | `mace/modules/blocks.py:1632` | KEEP — the SOC magnetic interaction | `tests/extensions/magnetic/test_magmace.py::test_run_magnetic_scf` |
+| `block.MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock` | `MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock` | `mace/modules/blocks.py:1785` | MERGE — the residual SOC variant | ⚠️ gap (registered and reachable from `--interaction`; nothing builds it) |
+| `block.EquivariantProductBasisWithSelfMagmomBlock` | `EquivariantProductBasisWithSelfMagmomBlock` | `mace/modules/blocks.py:517` | KEEP — the product basis that carries the site's own moment | ⚠️ gap (used from `mace/modules/extensions.py`; no test names it) |
+| `contraction.SymmetricContraction` | `SymmetricContraction` | `mace/modules/symmetric_contraction.py:26` | KEEP — the many-body contraction the accelerated backends replace | `tests/unit/test_modules.py::test_symmetric_contraction` |
+| `contraction.Contraction` | `Contraction` | `mace/modules/symmetric_contraction.py:91` | KEEP — one correlation order of it | `tests/unit/test_modules.py::test_symmetric_contraction_zeroes_the_unreachable_correlation_order` |
+| `contraction.EmptyParam` | `EmptyParam` | `mace/modules/symmetric_contraction.py:269` | MERGE — weight bookkeeping for an unreachable order, not a feature | `tests/unit/test_modules.py::test_symmetric_contraction_zeroes_the_unreachable_correlation_order` |
+| `transform.Random3DRotation` | `Random3DRotation` | `mace/data/augmentation.py:24` | MERGE — the `--data_aug_magmom` transform, which travels with the flag | `tests/extensions/magnetic/test_magmom_augmentation.py::test_non_soc_mode_samples_the_full_o3` |
+| `calc.class.MACECalculator` | `MACECalculator` | `mace/calculators/mace.py:77` | KEEP — the ASE calculator | `tests/workflows/test_calculator.py::test_calculator_forces` |
+| `calc.class.MagneticMACECalculator` | `MagneticMACECalculator` | `mace/calculators/mace.py:964` | KEEP — the magnetic ASE calculator | `tests/extensions/magnetic/test_magmace.py::test_run_train_magnetic_mace` |
+| `calc.class.LAMMPS_MACE` | `LAMMPS_MACE` | `mace/calculators/lammps_mace.py:10` | KEEP — the libtorch deployment wrapper | `tests/integrations/lammps/test_ghost_parity.py::test_virials_path_runs` |
+| `calc.class.LAMMPS_MLIAP_MACE` | `LAMMPS_MLIAP_MACE` | `mace/calculators/lammps_mliap_mace.py:125` | KEEP — the ML-IAP deployment wrapper | `tests/integrations/lammps/test_mliap_writeback.py::test_atom_count_mismatch_is_actionable` |
+| `calc.class.MACEEdgeForcesWrapper` | `MACEEdgeForcesWrapper` | `mace/calculators/lammps_mliap_mace.py:59` | KEEP — per-pair forces for the ML-IAP path | `tests/integrations/lammps/test_mliap_buffer_dtype.py::test_the_wrapper_buffers_follow_the_model_dtype` |
+| `calc.class.MACELammpsConfig` | `MACELammpsConfig` | `mace/calculators/lammps_mliap_mace.py:22` | MERGE — the ML-IAP wrapper's own config object, an implementation detail | `tests/integrations/lammps/test_mliap_writeback.py::test_atom_count_mismatch_is_actionable` |
+| `calc.class.MaceTorchSimModel` | `MaceTorchSimModel` | `mace/calculators/mace_torchsim.py:52` | KEEP — the torch-sim backend | `tests/extensions/torchsim/test_torchsim.py::test_mace_torchsim_no_stress` |
+
 ## 8. Loss classes (10)
 
 All ten MERGE into composable per-stage losses: each becomes a documented composition

--- a/tests/golden/test_inventory.py
+++ b/tests/golden/test_inventory.py
@@ -532,3 +532,59 @@ def test_the_gate_does_not_run_the_audit():
         "the audit no longer short-circuits ahead of the gate, so a heuristic "
         "now runs as part of a required check"
     )
+
+
+# ---------------------------------------------------------------------------
+# The five class sets added because a mutation test showed the gate missing them
+# ---------------------------------------------------------------------------
+
+#: Prefix -> a file the set must read. Before these sets existed, a new class in
+#: any of these files passed the gate in silence: the registries cover the string
+#: a user passes, not the class, and `model.`/`loss.` read two files each.
+CLASS_SET_SOURCES = {
+    "radial.": "mace/modules/radial.py",
+    "block.": "mace/modules/blocks.py",
+    "contraction.": "mace/modules/symmetric_contraction.py",
+    "transform.": "mace/data/augmentation.py",
+    "calc.class.": "mace/calculators/mace.py",
+}
+
+
+@pytest.mark.parametrize("prefix", sorted(CLASS_SET_SOURCES))
+def test_the_class_sets_are_declared(prefix):
+    assert prefix in {s.prefix for s in check_inventory.collect_sources()}
+
+
+@pytest.mark.parametrize("prefix,path", sorted(CLASS_SET_SOURCES.items()))
+def test_each_class_set_reads_its_file(prefix, path):
+    """Named by file rather than by count, so adding a class to one of them does
+    not have to be reflected here as well."""
+    declared = {s.prefix: s.decls for s in check_inventory.collect_sources()}[prefix]
+    lines = {decl.site.split(":")[0] for decl in declared.values()}
+
+    assert path in lines, f"{prefix} does not read {path}, it reads {sorted(lines)}"
+
+
+def test_the_block_set_also_reads_the_gate_module():
+    """`gate.py` holds one class and is easy to forget; it is where the gate the
+    nonlinear readouts apply actually lives."""
+    blocks = {s.prefix: s.decls for s in check_inventory.collect_sources()}["block."]
+    lines = {decl.site.split(":")[0] for decl in blocks.values()}
+
+    assert "mace/modules/gate.py" in lines
+
+
+def test_a_class_in_a_covered_file_with_no_row_fails():
+    """The mutation that used to pass. A class the inventory does not mention has
+    to be reported, whichever of the five files it appears in.
+
+    Uses the shared `_source` helper rather than a real radial set, because the
+    behaviour under test is the comparison, not which files it reads: that is
+    what the two tests above are for.
+    """
+    ok, report = check_inventory.check_set(
+        _source(BesselBasis="", ProbeBasis=""), [_row("train.BesselBasis")]
+    )
+
+    assert not ok
+    assert any("ProbeBasis" in line for line in report), report


### PR DESCRIPTION
Follow up to #1667, which added the inventory and its gate.

**The problem.** The gate did not notice new classes. I planted a fake class in `radial.py`, `blocks.py`, `symmetric_contraction.py`, `data/augmentation.py` and in the calculator modules, and the gate passed every time. The reason is that the old sets only read the registries, so a class with no registry entry was invisible to the inventory even though users can reach it from Python or from a checkpoint.

**The fix.** Five new sets read those files directly, and each of the 46 classes they find now has a row: radial bases and cutoffs, blocks (including the one in `gate.py`), the many body contraction, the data transforms, and the calculators plus the three deployment wrappers. All seven fake classes fail the gate now.

**What it found.** 41 of the 46 rows have a test. Five do not, and four of those matter: `RealAgnosticAttResidual` and the residual SOC interaction can be selected with `--interaction` but nothing builds them, and three field and magnetic blocks are used from `extensions.py` with no test naming them. Three other classes looked dead but are not, so each is pinned through the test that uses it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 26decca44f361cf3693ed0f555f0f59d1958938c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->