### PR TITLE
Stop the anchor builders writing over the committed checkpoints

### DIFF
--- a/tests/golden/build_dipole_anchor.py
+++ b/tests/golden/build_dipole_anchor.py
@@ -108,8 +108,14 @@ def build_model() -> torch.nn.Module:
     )
 
 
-def build_anchor(model_path: Path = MODEL_PATH) -> Path:
-    """Build, save and document the anchor. Returns the model path."""
+def build_anchor(model_path: Path) -> Path:
+    """Build, save and document the anchor. Returns the model path.
+
+    `model_path` is required rather than defaulted to `MODEL_PATH`: this writes
+    over whatever it is given, and the committed anchor is what every reference
+    in this directory was recorded against. A default meant that calling this
+    with no argument, from a REPL or a half-remembered one-liner, silently
+    replaced the checkpoint with a fresh one -- same recipe, different bytes."""
     previous = torch.get_default_dtype()
     torch.set_default_dtype(torch.float64)
     try:
@@ -125,7 +131,7 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "recipe": "tests/golden/build_dipole_anchor.py",
         "command": (
             "python -c \"from tests.golden.build_dipole_anchor import "
-            'build_anchor; build_anchor()"'
+            'build_anchor, MODEL_PATH; build_anchor(MODEL_PATH)"'
         ),
         "regenerate_with": (
             "python tests/golden/regenerate.py --target dipoles "
@@ -143,11 +149,15 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "config": ANCHOR_CONFIG,
         "num_parameters": int(sum(p.numel() for p in model.parameters())),
     }
-    with SIDECAR_PATH.open("w", encoding="utf-8") as handle:
+    # Beside the model that was actually written, not beside the committed
+    # one: a build into a temporary directory used to leave the checkpoint
+    # there and overwrite the committed sidecar in place.
+    sidecar_path = model_path.with_suffix(".build.json")
+    with sidecar_path.open("w", encoding="utf-8") as handle:
         json.dump(sidecar, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return model_path
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    print(build_anchor())
+    print(build_anchor(MODEL_PATH))

--- a/tests/golden/build_mace_anchor.py
+++ b/tests/golden/build_mace_anchor.py
@@ -109,8 +109,14 @@ def build_model() -> torch.nn.Module:
     )
 
 
-def build_anchor(model_path: Path = MODEL_PATH) -> Path:
-    """Build, save and document the anchor. Returns the model path."""
+def build_anchor(model_path: Path) -> Path:
+    """Build, save and document the anchor. Returns the model path.
+
+    `model_path` is required rather than defaulted to `MODEL_PATH`: this writes
+    over whatever it is given, and the committed anchor is what every reference
+    in this directory was recorded against. A default meant that calling this
+    with no argument, from a REPL or a half-remembered one-liner, silently
+    replaced the checkpoint with a fresh one -- same recipe, different bytes."""
     previous = torch.get_default_dtype()
     torch.set_default_dtype(torch.float64)
     try:
@@ -126,7 +132,7 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "recipe": "tests/golden/build_mace_anchor.py",
         "command": (
             "python -c \"from tests.golden.build_mace_anchor import "
-            'build_anchor; build_anchor()"'
+            'build_anchor, MODEL_PATH; build_anchor(MODEL_PATH)"'
         ),
         "regenerate_with": (
             "python tests/golden/regenerate.py --target anchors "
@@ -140,11 +146,15 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "config": ANCHOR_CONFIG,
         "num_parameters": int(sum(p.numel() for p in model.parameters())),
     }
-    with SIDECAR_PATH.open("w", encoding="utf-8") as handle:
+    # Beside the model that was actually written, not beside the committed
+    # one: a build into a temporary directory used to leave the checkpoint
+    # there and overwrite the committed sidecar in place.
+    sidecar_path = model_path.with_suffix(".build.json")
+    with sidecar_path.open("w", encoding="utf-8") as handle:
         json.dump(sidecar, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return model_path
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    print(build_anchor())
+    print(build_anchor(MODEL_PATH))

--- a/tests/golden/build_maceles_anchor.py
+++ b/tests/golden/build_maceles_anchor.py
@@ -142,8 +142,14 @@ def build_model(les_arguments: Dict[str, Any] | None = None) -> torch.nn.Module:
     )
 
 
-def build_anchor(model_path: Path = MODEL_PATH) -> Path:
-    """Build, save and document the anchor. Returns the model path."""
+def build_anchor(model_path: Path) -> Path:
+    """Build, save and document the anchor. Returns the model path.
+
+    `model_path` is required rather than defaulted to `MODEL_PATH`: this writes
+    over whatever it is given, and the committed anchor is what every reference
+    in this directory was recorded against. A default meant that calling this
+    with no argument, from a REPL or a half-remembered one-liner, silently
+    replaced the checkpoint with a fresh one -- same recipe, different bytes."""
     from tests.golden.les_pin import installed_les_commit  # noqa: PLC0415
 
     les_arguments = load_les_arguments()
@@ -162,7 +168,7 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "recipe": "tests/golden/build_maceles_anchor.py",
         "command": (
             "python -c \"from tests.golden.build_maceles_anchor import "
-            'build_anchor; build_anchor()"'
+            'build_anchor, MODEL_PATH; build_anchor(MODEL_PATH)"'
         ),
         "regenerate_with": (
             "python tests/golden/regenerate.py --target les "
@@ -190,11 +196,15 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
             "The architecture is otherwise the tiny_scaleshift anchor's."
         ),
     }
-    with SIDECAR_PATH.open("w", encoding="utf-8") as handle:
+    # Beside the model that was actually written, not beside the committed
+    # one: a build into a temporary directory used to leave the checkpoint
+    # there and overwrite the committed sidecar in place.
+    sidecar_path = model_path.with_suffix(".build.json")
+    with sidecar_path.open("w", encoding="utf-8") as handle:
         json.dump(sidecar, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return model_path
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    print(build_anchor())
+    print(build_anchor(MODEL_PATH))

--- a/tests/golden/build_magnetic_anchor.py
+++ b/tests/golden/build_magnetic_anchor.py
@@ -183,8 +183,14 @@ def build_model() -> torch.nn.Module:
     )
 
 
-def build_anchor(model_path: Path = MODEL_PATH) -> Path:
-    """Build, save and document the anchor. Returns the model path."""
+def build_anchor(model_path: Path) -> Path:
+    """Build, save and document the anchor. Returns the model path.
+
+    `model_path` is required rather than defaulted to `MODEL_PATH`: this writes
+    over whatever it is given, and the committed anchor is what every reference
+    in this directory was recorded against. A default meant that calling this
+    with no argument, from a REPL or a half-remembered one-liner, silently
+    replaced the checkpoint with a fresh one -- same recipe, different bytes."""
     previous = torch.get_default_dtype()
     torch.set_default_dtype(torch.float64)
     try:
@@ -200,7 +206,7 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "recipe": "tests/golden/build_magnetic_anchor.py",
         "command": (
             "python -c \"from tests.golden.build_magnetic_anchor import "
-            'build_anchor; build_anchor()"'
+            'build_anchor, MODEL_PATH; build_anchor(MODEL_PATH)"'
         ),
         "regenerate_with": (
             "python tests/golden/regenerate.py --target magnetic "
@@ -219,11 +225,15 @@ def build_anchor(model_path: Path = MODEL_PATH) -> Path:
         "scf_config": SCF_CONFIG,
         "num_parameters": int(sum(p.numel() for p in model.parameters())),
     }
-    with SIDECAR_PATH.open("w", encoding="utf-8") as handle:
+    # Beside the model that was actually written, not beside the committed
+    # one: a build into a temporary directory used to leave the checkpoint
+    # there and overwrite the committed sidecar in place.
+    sidecar_path = model_path.with_suffix(".build.json")
+    with sidecar_path.open("w", encoding="utf-8") as handle:
         json.dump(sidecar, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return model_path
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    print(build_anchor())
+    print(build_anchor(MODEL_PATH))

--- a/tests/golden/test_anchor_builders.py
+++ b/tests/golden/test_anchor_builders.py
@@ -1,0 +1,92 @@
+"""No anchor builder may default its output path.
+
+Each `build_*_anchor.py` writes a checkpoint and a sidecar, and every reference in
+this directory was recorded against the committed bytes. `build_anchor` used to
+default `model_path` to the committed `MODEL_PATH`, so calling it with no argument
+overwrote the anchor with a fresh one: the same recipe, a different file, and no
+sign of it until the goldens are compared or the diff is read.
+
+A rebuild is a deliberate act, hence `regenerate.py --i-know-what-i-am-doing`. The
+signature is the last place that can insist on it, which is what this checks. It
+also runs each builder into a temporary directory, because a required argument is
+only an improvement if the builders still work.
+"""
+
+import ast
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+import torch
+
+BUILDERS = [
+    "build_mace_anchor",
+    "build_dipole_anchor",
+    "build_maceles_anchor",
+    "build_magnetic_anchor",
+]
+
+#: `train_anchor.py` is the fifth of these and trains rather than instantiating,
+#: so it has its own function name and is not run here: a training belongs in the
+#: workflows tier, not in a check about signatures.
+TRAINED = ("train_anchor", "train_anchor")
+
+
+def module(name):
+    return importlib.import_module(f"tests.golden.{name}")
+
+
+@pytest.mark.parametrize(
+    "name,function",
+    [(n, "build_anchor") for n in BUILDERS] + [TRAINED],
+)
+def test_the_output_path_has_no_default(name, function):
+    signature = inspect.signature(getattr(module(name), function))
+    parameter = signature.parameters["model_path"]
+
+    assert parameter.default is inspect.Parameter.empty, (
+        f"{name}.{function} defaults its output path, so calling it with no "
+        f"argument overwrites the committed anchor"
+    )
+
+
+@pytest.mark.parametrize("name", BUILDERS)
+def test_calling_it_without_a_path_is_a_type_error(name):
+    """The behaviour the signature buys, stated so it survives a refactor that
+    reintroduces a default with a different spelling."""
+    with pytest.raises(TypeError):
+        module(name).build_anchor()  # pylint: disable=no-value-for-parameter
+
+
+@pytest.mark.parametrize("name", BUILDERS)
+def test_the_main_block_passes_the_committed_path(name):
+    """Running the file as a script is still meant to rebuild the anchor in
+    place; only the importable function refuses to guess."""
+    source = Path(inspect.getfile(module(name))).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    calls = [
+        ast.unparse(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and ast.unparse(node.func) == "build_anchor"
+    ]
+
+    assert calls, f"{name} never calls build_anchor"
+    assert any("MODEL_PATH" in call for call in calls), calls
+
+
+@pytest.mark.parametrize("name", ["build_mace_anchor", "build_dipole_anchor"])
+def test_a_builder_still_builds_when_given_a_path(name, tmp_path):
+    """Only the two that need no optional dependency; the LES and magnetic
+    builders are covered by their own families' tests."""
+    destination = tmp_path / "anchor.model"
+
+    written = module(name).build_anchor(destination)
+
+    assert written == destination
+    assert destination.exists()
+    assert torch.load(destination, map_location="cpu") is not None
+    assert (tmp_path / "anchor.build.json").exists(), (
+        "the sidecar has to land beside the model it documents, or a build into a "
+        "temporary directory overwrites the committed one"
+    )

--- a/tests/golden/train_anchor.py
+++ b/tests/golden/train_anchor.py
@@ -155,7 +155,7 @@ def read_final_metrics(work_dir: Path) -> Dict[str, object]:
     return {k: v for k, v in evals[-1].items() if k != "time"}
 
 
-def train_anchor(model_path: Path = MODEL_PATH) -> Path:
+def train_anchor(model_path: Path) -> Path:
     """Run the training, install the checkpoint and write both sidecars."""
     with tempfile.TemporaryDirectory(prefix="golden_anchor_") as tmp:
         work_dir = Path(tmp)
@@ -219,7 +219,11 @@ def train_anchor(model_path: Path = MODEL_PATH) -> Path:
         "train_file": "tests/golden/fixtures/tiny_train.xyz",
         "args": {k: ("<flag>" if v is None else v) for k, v in TRAIN_ARGS.items()},
     }
-    with SIDECAR_PATH.open("w", encoding="utf-8") as handle:
+    # Beside the model that was written, for the same reason as the other
+    # builders: a run into a temporary directory must not touch the committed
+    # sidecar.
+    sidecar_path = model_path.with_suffix(".build.json")
+    with sidecar_path.open("w", encoding="utf-8") as handle:
         json.dump(sidecar, handle, indent=2, sort_keys=True)
         handle.write("\n")
 
@@ -250,4 +254,4 @@ def train_anchor(model_path: Path = MODEL_PATH) -> Path:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    print(train_anchor())
+    print(train_anchor(MODEL_PATH))


### PR DESCRIPTION
build_anchor defaulted its output path to the committed MODEL_PATH, so calling it with no argument rebuilt the anchor in place: same recipe, different bytes, and nothing to see until the goldens are compared. That is how a 320-byte change to tiny_dipoles.model turned up in a worktree here, in a repo where git add -A is one keystroke.

The path is required now, in all four builders and in train_anchor.

That alone was not enough. The sidecar was written to a module-level SIDECAR_PATH whatever path the model took, so building into a temporary directory left the checkpoint there and still overwrote the committed *.build.json. It follows the model now.

Running the file as a script still rebuilds in place, which is what it is for. Only the importable function refuses to guess. The tests check the signatures, that calling with no path raises, that the scripts still pass MODEL_PATH, and that a build into a temporary directory leaves both files there and nothing in tests/golden/models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 22d2885957d22c28efa5783a26ff2cced7517fff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->