### PR TITLE
Pin the optimizer, scheduler and EMA flags

### DIFF
--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -349,9 +349,9 @@ Group default: KEEP as the `optimizer` / `schedule` config sections. `--swa`, `-
 | id | feature | source | disposition | pinned by |
 |---|---|---|---|---|
 | `train.optimizer` | `--optimizer` | `mace/tools/arg_parser.py:894` | KEEP — adam / adamw / schedulefree | `tests/workflows/test_cli_contracts.py::test_lbfgs_is_selectable_from_the_command_line_and_reduces_the_loss` + `tests/extensions/schedulefree` |
-| `train.beta` | `--beta` | `mace/tools/arg_parser.py:901` | KEEP | ⚠️ gap (add a case beside `tests/workflows/test_cli_contracts.py::test_lbfgs_is_selectable_from_the_command_line_and_reduces_the_loss`) |
-| `train.amsgrad` | `--amsgrad` | `mace/tools/arg_parser.py:955` | KEEP | ⚠️ gap (add a case beside `tests/workflows/test_cli_contracts.py::test_lbfgs_is_selectable_from_the_command_line_and_reduces_the_loss`) |
-| `train.weight_decay` | `--weight_decay` | `mace/tools/arg_parser.py:940` | KEEP | ⚠️ gap (add a case beside `tests/workflows/test_cli_contracts.py::test_lbfgs_is_selectable_from_the_command_line_and_reduces_the_loss`) |
+| `train.beta` | `--beta` | `mace/tools/arg_parser.py:901` | KEEP | `tests/unit/test_optimizer_flags.py::test_beta_is_the_first_adam_moment` |
+| `train.amsgrad` | `--amsgrad` | `mace/tools/arg_parser.py:955` | KEEP | `tests/unit/test_optimizer_flags.py::test_amsgrad_reaches_the_optimizer` |
+| `train.weight_decay` | `--weight_decay` | `mace/tools/arg_parser.py:940` | KEEP | `tests/unit/test_optimizer_flags.py::test_weight_decay_applies_to_the_interaction_linears_and_the_products` + `tests/unit/test_optimizer_flags.py::test_weight_decay_is_kept_off_the_rest` |
 | `train.beta1_schedulefree` | `--beta1_schedulefree` | `mace/tools/arg_parser.py:907` | KEEP — the schedulefree extra's tuning surface | `tests/extensions/schedulefree` |
 | `train.beta2_schedulefree` | `--beta2_schedulefree` | `mace/tools/arg_parser.py:913` | KEEP — idem | `tests/extensions/schedulefree` |
 | `train.warmup_steps_schedulefree` | `--warmup_steps_schedulefree` | `mace/tools/arg_parser.py:919` | KEEP — idem (linear LR warmup, not an LR scheduler) | `tests/extensions/schedulefree` |
@@ -361,14 +361,14 @@ Group default: KEEP as the `optimizer` / `schedule` config sections. `--swa`, `-
 | `train.lr` | `--lr` | `mace/tools/arg_parser.py:929` | KEEP | `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model` |
 | `train.lr_factor` | `--lr_factor` | `mace/tools/arg_parser.py:964` | KEEP | `tests/workflows/test_freeze.py::test_run_train_soft_freeze` |
 | `train.scheduler` | `--scheduler` | `mace/tools/arg_parser.py:961` | KEEP | `tests/extensions/schedulefree/test_schedulefree.py::test_can_load_checkpoint` (sets `args.scheduler`; nothing passes the flag itself) |
-| `train.scheduler_patience` | `--scheduler_patience` | `mace/tools/arg_parser.py:967` | KEEP | ⚠️ gap (no test passes `--scheduler_patience`) |
+| `train.scheduler_patience` | `--scheduler_patience` | `mace/tools/arg_parser.py:967` | KEEP | `tests/unit/test_optimizer_flags.py::test_scheduler_patience_reaches_the_plateau_scheduler` |
 | `train.lr_scheduler_gamma` | `--lr_scheduler_gamma` | `mace/tools/arg_parser.py:970` | KEEP | `tests/extensions/schedulefree/test_schedulefree.py::test_can_load_checkpoint` (sets `args.lr_scheduler_gamma`; nothing passes the flag itself) |
 | `train.lr_params_factors` | `--lr_params_factors` | `mace/tools/arg_parser.py:943` | MERGE — typed per-param-group fields of the per-stage optimizer config; the capability stays (`--freeze` reuses it by zeroing factors), the hand-parsed JSON-in-a-string dies | `tests/workflows/test_freeze.py::test_run_train_soft_freeze` |
 | `train.swa` | `--swa` `--stage_two` | `mace/tools/arg_parser.py:976` | MERGE — stage two becomes a preset second stage of an arbitrary-stage schedule | `tests/unit/test_arg_parser.py::test_stage_two_alias_maps_to_swa_dest` + `tests/workflows/test_multifiles.py::test_multifile_training` |
 | `train.start_swa` | `--start_swa` `--start_stage_two` | `mace/tools/arg_parser.py:984` | MERGE — idem | `tests/unit/test_arg_parser.py::test_stage_two_alias_maps_to_swa_dest` + `tests/workflows/test_multifiles.py::test_multifile_training` |
-| `train.swa_lr` | `--swa_lr` `--stage_two_lr` | `mace/tools/arg_parser.py:932` | MERGE — idem | ⚠️ gap (no test passes `--swa_lr`; only the dest aliasing is pinned) |
-| `train.ema` | `--ema` | `mace/tools/arg_parser.py:998` | KEEP | ⚠️ gap (every training fixture sets `--ema`, but nothing asserts what it changes; add a case to `tests/workflows/test_cli_contracts.py`) |
-| `train.ema_decay` | `--ema_decay` | `mace/tools/arg_parser.py:1004` | KEEP | ⚠️ gap (idem) |
+| `train.swa_lr` | `--swa_lr` `--stage_two_lr` | `mace/tools/arg_parser.py:932` | MERGE — idem | `tests/unit/test_optimizer_flags.py::test_swa_lr_is_the_rate_the_second_stage_anneals_to` |
+| `train.ema` | `--ema` | `mace/tools/arg_parser.py:998` | KEEP | `tests/unit/test_optimizer_flags.py::test_the_average_lags_the_parameters` |
+| `train.ema_decay` | `--ema_decay` | `mace/tools/arg_parser.py:1004` | KEEP | `tests/unit/test_optimizer_flags.py::test_the_configured_decay_barely_matters_at_the_start` (the cold-start cap) + `tests/unit/test_optimizer_flags.py::test_a_higher_decay_lags_further_once_the_warmup_is_past` |
 | `train.max_num_epochs` | `--max_num_epochs` | `mace/tools/arg_parser.py:1010` | KEEP | `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model` |
 | `train.patience` | `--patience` | `mace/tools/arg_parser.py:1013` | KEEP | `tests/workflows/test_multifiles.py::test_multifile_training` |
 | `train.eval_interval` | `--eval_interval` | `mace/tools/arg_parser.py:1043` | KEEP | `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model` |

--- a/tests/unit/test_optimizer_flags.py
+++ b/tests/unit/test_optimizer_flags.py
@@ -1,0 +1,290 @@
+"""The optimizer, scheduler and EMA flags, checked where they take effect.
+
+Seven flags that every training run carries and no test asserted anything about.
+They all end up as a number inside an optimizer, a scheduler or the moving
+average, and none of them changes whether a run succeeds, so a flag that stopped
+being read would show up as a slightly different training curve and nothing else.
+
+`--ema` is the sharpest case: every training fixture in the suite passes it, so a
+build that ignored it entirely would still be green everywhere.
+
+Weight decay is the one with real structure. It is not a single number handed to
+the optimizer: `get_params_options` puts the interaction linears and the product
+basis in decaying groups and everything else in groups with decay zero, because
+biases, gates and physically meaningful scalars must not be pulled toward zero.
+That split is a decision worth pinning, not an accident of the loop that builds it.
+"""
+
+import argparse
+import json
+
+import numpy as np
+import pytest
+import torch
+from e3nn import o3
+
+from mace import modules, tools
+from mace.tools.scripts_utils import LRScheduler, get_optimizer, get_params_options
+
+LR = 0.017
+BETA = 0.87
+WEIGHT_DECAY = 0.031
+PATIENCE = 13
+GAMMA = 0.71
+
+
+@pytest.fixture(name="model", scope="module")
+def fixture_model():
+    table = tools.AtomicNumberTable([1, 8])
+    torch.manual_seed(0)
+    return modules.MACE(
+        r_max=5,
+        num_bessel=8,
+        num_polynomial_cutoff=5,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=2,
+        hidden_irreps=o3.Irreps("8x0e + 8x1o"),
+        MLP_irreps=o3.Irreps("8x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([1.0, 3.0]),
+        avg_num_neighbors=3,
+        atomic_numbers=table.zs,
+        correlation=3,
+        radial_type="bessel",
+    )
+
+
+def args_for(**overrides):
+    args = argparse.Namespace(
+        lr=LR,
+        beta=BETA,
+        amsgrad=True,
+        weight_decay=WEIGHT_DECAY,
+        optimizer="adam",
+        freeze=0,
+        lr_params_factors=json.dumps({}),
+        scheduler="ReduceLROnPlateau",
+        scheduler_patience=PATIENCE,
+        lr_factor=0.6,
+        lr_scheduler_gamma=GAMMA,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def groups(model, **overrides):
+    options = get_params_options(args_for(**overrides), model)
+    return {group["name"]: group for group in options["params"]}, options
+
+
+# ---------------------------------------------------------------------------
+# --beta, --amsgrad
+# ---------------------------------------------------------------------------
+
+
+def test_beta_is_the_first_adam_moment(model):
+    """`--beta` sets beta1 only; beta2 is fixed at 0.999. A flag named `beta`
+    could plausibly be read into either."""
+    _, options = groups(model)
+
+    assert options["betas"] == (BETA, 0.999)
+
+
+def test_amsgrad_reaches_the_optimizer(model):
+    _, options = groups(model)
+    optimizer = get_optimizer(args_for(), options)
+
+    assert all(group["amsgrad"] for group in optimizer.param_groups)
+
+
+def test_amsgrad_off_stays_off(model):
+    _, options = groups(model, amsgrad=False)
+    optimizer = get_optimizer(args_for(amsgrad=False), options)
+
+    assert not any(group["amsgrad"] for group in optimizer.param_groups)
+
+
+def test_the_learning_rate_reaches_every_group(model):
+    parameter_groups, options = groups(model)
+
+    assert options["lr"] == LR
+    assert all(group["lr"] == LR for group in parameter_groups.values())
+
+
+# ---------------------------------------------------------------------------
+# --weight_decay
+# ---------------------------------------------------------------------------
+
+
+def test_weight_decay_applies_to_the_interaction_linears_and_the_products(model):
+    parameter_groups, _ = groups(model)
+
+    assert parameter_groups["interactions_decay"]["weight_decay"] == WEIGHT_DECAY
+    assert parameter_groups["products"]["weight_decay"] == WEIGHT_DECAY
+
+
+def test_weight_decay_is_kept_off_the_rest(model):
+    """The deliberate half. Embeddings, readouts and the non-linear interaction
+    parameters stay at zero whatever the flag says, so a change that applied the
+    flag uniformly would regularize scalars that must not move."""
+    parameter_groups, _ = groups(model)
+
+    for name in ("embedding", "interactions_no_decay", "readouts"):
+        assert parameter_groups[name]["weight_decay"] == 0.0, name
+
+
+def test_a_zero_weight_decay_is_zero_everywhere(model):
+    parameter_groups, _ = groups(model, weight_decay=0.0)
+
+    assert all(group["weight_decay"] == 0.0 for group in parameter_groups.values())
+
+
+# ---------------------------------------------------------------------------
+# --scheduler_patience, --swa_lr
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_patience_reaches_the_plateau_scheduler(model):
+    _, options = groups(model)
+    optimizer = get_optimizer(args_for(), options)
+
+    scheduler = LRScheduler(optimizer, args_for())
+
+    assert scheduler.lr_scheduler.patience == PATIENCE
+
+
+def test_the_exponential_scheduler_takes_the_gamma_instead(model):
+    """`--scheduler_patience` belongs to one scheduler and the gamma to the
+    other; picking the wrong branch is silent because both accept a step()."""
+    _, options = groups(model)
+    optimizer = get_optimizer(args_for(), options)
+
+    scheduler = LRScheduler(optimizer, args_for(scheduler="ExponentialLR"))
+
+    assert scheduler.lr_scheduler.gamma == GAMMA
+
+
+def test_an_unknown_scheduler_is_refused(model):
+    _, options = groups(model)
+    optimizer = get_optimizer(args_for(), options)
+
+    with pytest.raises(RuntimeError, match="Unknown scheduler"):
+        LRScheduler(optimizer, args_for(scheduler="Whatever"))
+
+
+def test_swa_lr_is_the_rate_the_second_stage_anneals_to(model):
+    """`--swa_lr` only appears after the stage-two swap, so it is checked on the
+    SWALR the swap builds rather than on the first-stage optimizer."""
+    from mace.tools.scripts_utils import get_swa  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    _, options = groups(model)
+    optimizer = get_optimizer(args_for(), options)
+    args = args_for(
+        loss="weighted",
+        start_swa=2,
+        max_num_epochs=6,
+        swa_lr=0.0009,
+        swa_energy_weight=1.0,
+        swa_forces_weight=1.0,
+        swa_virials_weight=1.0,
+        swa_stress_weight=1.0,
+        swa_dipole_weight=1.0,
+    )
+
+    get_swa(args, model, optimizer, [])
+
+    assert [group["swa_lr"] for group in optimizer.param_groups] == [0.0009] * len(
+        optimizer.param_groups
+    )
+
+
+# ---------------------------------------------------------------------------
+# --ema, --ema_decay
+# ---------------------------------------------------------------------------
+
+
+def test_the_moving_average_takes_the_decay_it_is_given(model):
+    from torch_ema import ExponentialMovingAverage  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    ema = ExponentialMovingAverage(model.parameters(), decay=0.995)
+
+    assert ema.decay == 0.995
+
+
+def test_the_average_lags_the_parameters(model):
+    """What `--ema` buys, and what nothing asserted: the averaged parameters are
+    not the live ones, and the live ones come back afterwards. A build that
+    dropped the EMA would keep every training fixture green, since they all pass
+    `--ema` and none of them looks at the result.
+    """
+    from torch_ema import ExponentialMovingAverage  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    parameter = next(model.parameters())
+    original = parameter.detach().clone()
+    ema = ExponentialMovingAverage(model.parameters(), decay=0.9)
+
+    with torch.no_grad():
+        parameter.add_(1.0)
+    ema.update()
+
+    with ema.average_parameters():
+        averaged = parameter.detach().clone()
+
+    assert not torch.allclose(averaged, parameter), "the average must lag"
+    assert torch.allclose(parameter, original + 1.0), "and the live value returns"
+
+
+def test_the_configured_decay_barely_matters_at_the_start():
+    """`torch_ema` corrects for the cold start by capping the effective decay at
+    `(1 + n) / (10 + n)`, and MACE takes that default. So the first updates track
+    the parameters closely whatever `--ema_decay` says: after one update, 0.5,
+    0.9 and 0.99 all give the same average.
+
+    Recorded because it is the opposite of what the flag reads like, and because
+    0.99 does not begin to behave like 0.99 until roughly 890 updates in.
+    """
+    from torch_ema import ExponentialMovingAverage  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    def averaged_after_one_update(decay):
+        weight = torch.nn.Parameter(torch.zeros(1))
+        ema = ExponentialMovingAverage([weight], decay=decay)
+        with torch.no_grad():
+            weight.add_(1.0)
+        ema.update()
+        with ema.average_parameters():
+            return float(weight)
+
+    values = [averaged_after_one_update(d) for d in (0.5, 0.9, 0.99)]
+
+    assert values[0] == pytest.approx(values[1]) == pytest.approx(values[2])
+    assert values[0] == pytest.approx(1 - 2 / 11, abs=1e-6), (
+        "the cap is (1 + num_updates) / (10 + num_updates)"
+    )
+
+
+def test_a_higher_decay_lags_further_once_the_warmup_is_past():
+    """The direction of the knob, measured after enough updates that the cap
+    above no longer binds for either value."""
+    from torch_ema import ExponentialMovingAverage  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    def averaged_after(decay, steps=40):
+        weight = torch.nn.Parameter(torch.zeros(1))
+        ema = ExponentialMovingAverage([weight], decay=decay)
+        for _ in range(steps):
+            with torch.no_grad():
+                weight.add_(1.0)
+            ema.update()
+        with ema.average_parameters():
+            return float(weight) / float(steps)
+
+    assert averaged_after(0.5) < averaged_after(0.1), (
+        "a larger decay keeps more of the old average, so it trails further"
+    )


### PR DESCRIPTION
Seven flags every training run carries that no test asserted anything about. None changes whether a run succeeds, so one that stopped being read would show up as a slightly different training curve and nothing else. They are checked where they land: the parameter groups, the optimizer, the scheduler, and the moving average.

--ema is the sharpest case. Every training fixture passes it and none looks at the result, so a build that dropped the moving average would still be green everywhere.

--weight_decay is the one with structure. The interaction linears and the product basis decay; the embeddings, readouts and non-linear interaction parameters are held at zero, because biases, gates and physically meaningful scalars must not be regularized toward zero. Both halves are asserted, since a change that applied the flag uniformly would look like an improvement.

--ema_decay turned out to be worth more than a pass-through check. torch_ema caps the effective decay at (1 + n) / (10 + n) to correct for the cold start, and MACE takes that default, so the first updates track the parameters closely whatever the flag says: after one update, 0.5, 0.9 and 0.99 give the same average, and 0.99 does not behave like 0.99 until roughly 890 updates in. Recorded rather than worked around, with the direction of the knob asserted separately once the cap no longer binds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 65f6537e6dba1069fa0e01dc3090b64c66228428. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->