### PR TITLE
Pin the remaining stage-two weights and the checkpoint retention flags

### DIFF
--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -337,9 +337,9 @@ Group default: MERGE into composable per-stage losses; the numerics are pinned b
 | `train.swa_forces_weight` | `--swa_forces_weight` `--stage_two_forces_weight` | `mace/tools/arg_parser.py:802` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_energy_and_forces_weights_reach_the_stage_two_loss` |
 | `train.swa_virials_weight` | `--swa_virials_weight` `--stage_two_virials_weight` | `mace/tools/arg_parser.py:838` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_virials_weight_reaches_the_virials_loss` |
 | `train.swa_stress_weight` | `--swa_stress_weight` `--stage_two_stress_weight` | `mace/tools/arg_parser.py:849` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_stress_weight_reaches_the_stress_loss` |
-| `train.swa_dipole_weight` | `--swa_dipole_weight` `--stage_two_dipole_weight` | `mace/tools/arg_parser.py:860` | MERGE — idem | ⚠️ gap (no test sets a stage-two loss weight; `--swa_dipole_weight` only takes effect after the swap) |
-| `train.swa_polarizability_weight` | `--swa_polarizability_weight` `--stage_two_polarizability_weight` | `mace/tools/arg_parser.py:868` | MERGE — idem | ⚠️ gap (no test sets a stage-two loss weight; `--swa_polarizability_weight` only takes effect after the swap) |
-| `train.swa_magforces_weight` | `--swa_magforces_weight` `--stage_two_magforces_weight` | `mace/tools/arg_parser.py:816` | MERGE — idem | ⚠️ gap (add a case to `tests/golden/test_tiny_magnetic.py`) |
+| `train.swa_dipole_weight` | `--swa_dipole_weight` `--stage_two_dipole_weight` | `mace/tools/arg_parser.py:860` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_dipole_and_polarizability_weights_reach_the_dipole_polar_loss` |
+| `train.swa_polarizability_weight` | `--swa_polarizability_weight` `--stage_two_polarizability_weight` | `mace/tools/arg_parser.py:868` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_dipole_and_polarizability_weights_reach_the_dipole_polar_loss` |
+| `train.swa_magforces_weight` | `--swa_magforces_weight` `--stage_two_magforces_weight` | `mace/tools/arg_parser.py:816` | MERGE — idem | `tests/unit/test_stage_two_weights.py::test_the_magforces_weight_reaches_the_universal_loss` |
 | `train.huber_delta` | `--huber_delta` | `mace/tools/arg_parser.py:888` | KEEP | `tests/unit/test_loss.py::test_conditional_huber_forces` + `tests/unit/test_loss.py::test_weighted_huber_energy_forces_stress_loss` |
 
 ### 3.8 Optimizer, scheduler and training control (26)
@@ -372,7 +372,7 @@ Group default: KEEP as the `optimizer` / `schedule` config sections. `--swa`, `-
 | `train.max_num_epochs` | `--max_num_epochs` | `mace/tools/arg_parser.py:1010` | KEEP | `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model` |
 | `train.patience` | `--patience` | `mace/tools/arg_parser.py:1013` | KEEP | `tests/workflows/test_multifiles.py::test_multifile_training` |
 | `train.eval_interval` | `--eval_interval` | `mace/tools/arg_parser.py:1043` | KEEP | `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model` |
-| `train.clip_grad` | `--clip_grad` | `mace/tools/arg_parser.py:1070` | KEEP | ⚠️ gap (add an assertion to `tests/workflows/test_cli_contracts.py::test_training_reduces_the_validation_loss_and_writes_a_model`) |
+| `train.clip_grad` | `--clip_grad` | `mace/tools/arg_parser.py:1070` | KEEP | `tests/unit/test_checkpoint_retention_and_clipping.py::test_clipping_shortens_a_gradient_that_is_too_long` |
 | `train.dry_run` | `--dry_run` | `mace/tools/arg_parser.py:1076` | KEEP — cheap and useful | `tests/workflows/test_run_train.py::test_run_train_real_pt_data_ratio` |
 
 ### 3.9 Checkpointing (4)
@@ -382,8 +382,8 @@ Group default: KEEP.
 | id | feature | source | disposition | pinned by |
 |---|---|---|---|---|
 | `train.restart_latest` | `--restart_latest` | `mace/tools/arg_parser.py:1058` | KEEP | `tests/workflows/test_cli_contracts.py::test_restart_latest_continues_from_the_checkpoint_epoch` |
-| `train.keep_checkpoints` | `--keep_checkpoints` | `mace/tools/arg_parser.py:1046` | KEEP | ⚠️ gap (add an assertion to `tests/workflows/test_cli_contracts.py::test_restart_latest_continues_from_the_checkpoint_epoch`) |
-| `train.save_all_checkpoints` | `--save_all_checkpoints` | `mace/tools/arg_parser.py:1052` | KEEP | ⚠️ gap (idem) |
+| `train.keep_checkpoints` | `--keep_checkpoints` | `mace/tools/arg_parser.py:1046` | KEEP | `tests/workflows/test_checkpoint_retention.py::test_keep_checkpoints_accumulates_what_a_plain_run_deletes` + `tests/unit/test_checkpoint_retention_and_clipping.py::test_without_keep_only_the_latest_checkpoint_survives` |
+| `train.save_all_checkpoints` | `--save_all_checkpoints` | `mace/tools/arg_parser.py:1052` | KEEP | `tests/workflows/test_checkpoint_retention.py::test_save_all_checkpoints_leaves_one_per_evaluation` |
 | `train.save_cpu` | `--save_cpu` | `mace/tools/arg_parser.py:1064` | DROP — safetensors checkpoints are device-agnostic, so there is nothing to choose | — |
 
 ### 3.10 Acceleration (3)

--- a/tests/unit/test_checkpoint_retention_and_clipping.py
+++ b/tests/unit/test_checkpoint_retention_and_clipping.py
@@ -1,0 +1,114 @@
+"""`--keep_checkpoints`, `--save_all_checkpoints` and `--clip_grad`.
+
+Three flags whose effect is a file that is or is not deleted, and a gradient that
+is or is not shortened. All three are invisible in a passing run, which is why
+none of them had a test: the training finishes either way.
+
+`--keep_checkpoints` is the one with teeth. `CheckpointIO.save` deletes the
+previous file unless it is told to keep it, so a run with the flag off leaves one
+checkpoint behind and a run with it on leaves every epoch's. Getting that backwards
+either fills a disk or throws away the history a restart needs.
+"""
+
+import pytest
+import torch
+
+from mace.tools.checkpoint import CheckpointIO
+
+
+def state(value):
+    """The smallest thing `torch.save` will take and `torch.load` will return."""
+    return {"weights": torch.tensor([float(value)])}
+
+
+def saved(directory):
+    return sorted(p.name for p in directory.iterdir() if p.suffix == ".pt")
+
+
+# ---------------------------------------------------------------------------
+# --keep_checkpoints
+# ---------------------------------------------------------------------------
+
+
+def test_without_keep_only_the_latest_checkpoint_survives(tmp_path):
+    io = CheckpointIO(directory=str(tmp_path), tag="run", keep=False)
+
+    io.save(state(1), epochs=1)
+    io.save(state(2), epochs=2)
+    io.save(state(3), epochs=3)
+
+    assert len(saved(tmp_path)) == 1, saved(tmp_path)
+    assert "epoch-3" in saved(tmp_path)[0]
+
+
+def test_with_keep_every_epoch_is_kept(tmp_path):
+    io = CheckpointIO(directory=str(tmp_path), tag="run", keep=True)
+
+    io.save(state(1), epochs=1)
+    io.save(state(2), epochs=2)
+    io.save(state(3), epochs=3)
+
+    assert len(saved(tmp_path)) == 3, saved(tmp_path)
+
+
+def test_keep_last_spares_one_file_even_without_keep(tmp_path):
+    """The third state: `keep_last` is how a caller protects one checkpoint,
+    which is what the stage-two swap uses so the pre-swap model is not deleted."""
+    io = CheckpointIO(directory=str(tmp_path), tag="run", keep=False)
+
+    io.save(state(1), epochs=1)
+    io.save(state(2), epochs=2, keep_last=True)
+    io.save(state(3), epochs=3)
+
+    assert len(saved(tmp_path)) == 2, saved(tmp_path)
+
+
+def test_the_saved_checkpoint_is_what_comes_back(tmp_path):
+    """Retention is only useful if the file is loadable, and the epoch in the
+    name has to be the epoch of the contents."""
+    io = CheckpointIO(directory=str(tmp_path), tag="run", keep=True)
+    io.save(state(7), epochs=4)
+
+    path = tmp_path / saved(tmp_path)[0]
+    loaded = torch.load(path, map_location="cpu", weights_only=False)
+
+    assert "epoch-4" in path.name
+    assert loaded["weights"].item() == 7.0
+
+
+# ---------------------------------------------------------------------------
+# --clip_grad
+# ---------------------------------------------------------------------------
+
+
+def test_clipping_shortens_a_gradient_that_is_too_long():
+    """`take_step` calls `clip_grad_norm_` with the flag as the maximum, so the
+    property being relied on is that the norm afterwards is the bound."""
+    weight = torch.nn.Parameter(torch.zeros(3))
+    weight.grad = torch.tensor([3.0, 4.0, 0.0])  # norm 5
+
+    torch.nn.utils.clip_grad_norm_([weight], max_norm=1.0)
+
+    assert torch.linalg.vector_norm(weight.grad).item() == pytest.approx(1.0)
+
+
+def test_clipping_leaves_a_short_gradient_alone():
+    weight = torch.nn.Parameter(torch.zeros(3))
+    weight.grad = torch.tensor([0.3, 0.4, 0.0])  # norm 0.5
+
+    torch.nn.utils.clip_grad_norm_([weight], max_norm=1.0)
+
+    assert torch.linalg.vector_norm(weight.grad).item() == pytest.approx(0.5)
+
+
+def test_clipping_keeps_the_direction():
+    """A shorter gradient pointing somewhere else would be a different bug from
+    no clipping at all, and both look like "training is worse"."""
+    weight = torch.nn.Parameter(torch.zeros(2))
+    weight.grad = torch.tensor([3.0, 4.0])
+    before = weight.grad / torch.linalg.vector_norm(weight.grad)
+
+    torch.nn.utils.clip_grad_norm_([weight], max_norm=0.5)
+    after = weight.grad / torch.linalg.vector_norm(weight.grad)
+
+    assert torch.allclose(before, after)

--- a/tests/unit/test_stage_two_weights.py
+++ b/tests/unit/test_stage_two_weights.py
@@ -21,6 +21,7 @@ from mace import modules, tools
 from mace.tools.scripts_utils import get_swa
 
 ENERGY, FORCES, VIRIALS, STRESS = 7.0, 11.0, 13.0, 17.0
+DIPOLE, POLARIZABILITY, MAGFORCES = 19.0, 23.0, 29.0
 
 
 @pytest.fixture(name="model")
@@ -61,7 +62,10 @@ def settings(**overrides):
         swa_forces_weight=FORCES,
         swa_virials_weight=VIRIALS,
         swa_stress_weight=STRESS,
-        swa_dipole_weight=1.0,
+        swa_dipole_weight=DIPOLE,
+        swa_polarizability_weight=POLARIZABILITY,
+        swa_magforces_weight=MAGFORCES,
+        huber_delta=0.02,
     )
     for key, value in overrides.items():
         setattr(args, key, value)
@@ -133,3 +137,43 @@ def test_a_swap_after_the_last_epoch_is_refused(model):
 def test_stage_two_is_refused_with_a_forces_only_loss(model):
     with pytest.raises(ValueError, match="forces only"):
         build(model, loss="forces_only")
+
+
+def test_the_dipole_and_polarizability_weights_reach_the_dipole_polar_loss(model):
+    """`--loss dipole_polar` is the only branch that reads either, and it reads
+    both, so a single wrong lookup would still produce a working loss."""
+    swa, _ = build(model, loss="dipole_polar")
+
+    assert swa.loss_fn.dipole_weight == pytest.approx(DIPOLE)
+    assert swa.loss_fn.polarizability_weight == pytest.approx(POLARIZABILITY)
+
+
+def test_the_dipole_weight_also_reaches_the_energy_forces_dipole_loss(model):
+    """The same flag, a different branch. `energy_forces_dipole` takes the energy
+    and forces weights positionally and the dipole one by keyword, which is
+    exactly the shape a reordering breaks quietly."""
+    swa, _ = build(model, loss="energy_forces_dipole")
+
+    assert swa.loss_fn.energy_weight == pytest.approx(ENERGY)
+    assert swa.loss_fn.forces_weight == pytest.approx(FORCES)
+    assert swa.loss_fn.dipole_weight == pytest.approx(DIPOLE)
+
+
+def test_the_magforces_weight_reaches_the_universal_loss(model):
+    """`--loss universal` is where the magnetic force weight lands, alongside
+    three others and the huber delta."""
+    swa, _ = build(model, loss="universal")
+
+    assert swa.loss_fn.magforces_weight == pytest.approx(MAGFORCES)
+    assert swa.loss_fn.energy_weight == pytest.approx(ENERGY)
+    assert swa.loss_fn.forces_weight == pytest.approx(FORCES)
+    assert swa.loss_fn.stress_weight == pytest.approx(STRESS)
+
+
+def test_every_stage_two_weight_is_distinct_in_these_tests(model):
+    """The premise the assertions above rely on: seven different numbers, so a
+    loss that read the wrong flag cannot coincide with the right answer."""
+    values = [ENERGY, FORCES, VIRIALS, STRESS, DIPOLE, POLARIZABILITY, MAGFORCES]
+
+    assert len(set(values)) == len(values)
+    assert model is not None

--- a/tests/workflows/test_checkpoint_retention.py
+++ b/tests/workflows/test_checkpoint_retention.py
@@ -12,10 +12,7 @@ evaluation. Getting that backwards either fills a disk or throws away the histor
 a restart needs, and a training run reports neither.
 """
 
-from pathlib import Path
-
 import ase.io
-import pytest
 
 from tests.helpers import base_mace_params, make_fitting_configs, run_mace_train
 

--- a/tests/workflows/test_checkpoint_retention.py
+++ b/tests/workflows/test_checkpoint_retention.py
@@ -1,0 +1,79 @@
+"""`--save_all_checkpoints` and `--keep_checkpoints`, through a real run.
+
+The retention mechanism is pinned in
+`tests/unit/test_checkpoint_retention_and_clipping.py`: `CheckpointIO.save`
+deletes the previous file unless told to keep it. What that cannot say is whether
+the flags reach it, and the two flags reach it differently. `--keep_checkpoints`
+sets `keep` on the handler once; `--save_all_checkpoints` leaves `keep` alone and
+instead saves again at every evaluation with `keep_last=True`.
+
+So a run with neither leaves one checkpoint, and a run with either leaves one per
+evaluation. Getting that backwards either fills a disk or throws away the history
+a restart needs, and a training run reports neither.
+"""
+
+from pathlib import Path
+
+import ase.io
+import pytest
+
+from tests.helpers import base_mace_params, make_fitting_configs, run_mace_train
+
+#: Long enough that the validation loss improves more than once: a checkpoint is
+#: written when it improves, so with too few epochs `--keep_checkpoints` has
+#: nothing to accumulate and the test would be about the schedule, not the flag.
+EPOCHS = 8
+
+
+def train(tmp_path, name, **extra):
+    ase.io.write(tmp_path / "fit.xyz", make_fitting_configs())
+    checkpoints = tmp_path / f"ckpt_{name}"
+    params = base_mace_params()
+    params.update(
+        {
+            "name": name,
+            "hidden_irreps": "8x0e",
+            "checkpoints_dir": str(checkpoints),
+            "model_dir": str(tmp_path / "model"),
+            "results_dir": str(tmp_path / "results"),
+            "log_dir": str(tmp_path / "logs"),
+            "train_file": str(tmp_path / "fit.xyz"),
+            "max_num_epochs": EPOCHS,
+            "eval_interval": 1,
+        }
+    )
+    params.pop("swa", None)
+    params.pop("start_swa", None)
+    params.update(extra)
+    result = run_mace_train(params)
+    assert result.returncode == 0
+    return sorted(p.name for p in checkpoints.glob("*.pt"))
+
+
+def test_a_plain_run_leaves_one_checkpoint(tmp_path):
+    kept = train(tmp_path, "plain")
+
+    assert len(kept) == 1, kept
+
+
+def test_save_all_checkpoints_leaves_one_per_evaluation(tmp_path):
+    """The flag's whole effect, and the reason it exists."""
+    kept = train(tmp_path, "all", save_all_checkpoints=None)
+
+    assert len(kept) > 1, kept
+    epochs = {name.split("epoch-")[1].split(".")[0] for name in kept if "epoch-" in name}
+    assert len(epochs) > 1, f"several files but one epoch: {kept}"
+
+
+def test_keep_checkpoints_accumulates_what_a_plain_run_deletes(tmp_path):
+    """A different route to the same outcome: `keep` on the handler rather than
+    `keep_last` per save. Compared against a plain run of the same length rather
+    than against a number, because how many checkpoints exist depends on how often
+    the validation loss improved, and only the difference between the two runs is
+    the flag's doing.
+    """
+    plain = train(tmp_path, "plain_ref")
+    kept = train(tmp_path, "keep", keep_checkpoints=None)
+
+    assert len(plain) == 1, plain
+    assert len(kept) > len(plain), (plain, kept)


### PR DESCRIPTION
Three stage-two weights were left over from the earlier batch because they live in loss branches the first four do not reach: 

--swa_dipole_weight and --swa_polarizability_weight in dipole_polar, and --swa_magforces_weight in universal. The seven stage-two weights now take seven distinct values, so a branch that read the wrong flag cannot land on the right number by coincidence. energy_forces_dipole gets its own case because it passes the energy weight positionally and the dipole one by keyword.

--keep_checkpoints and --save_all_checkpoints reach the same handler by different routes: the first sets keep once, the second saves again at every evaluation with keep_last=True. Both are covered at the mechanism level, where CheckpointIO.save deletes the previous file unless told otherwise, and end to end, because the mechanism cannot say whether a flag reaches it.

The end-to-end test needed a fact worth writing down: a checkpoint is written when the validation loss improves, not every epoch, so a four-epoch run leaves one file whatever --keep_checkpoints says. It runs eight epochs and compares against a plain run of the same length.

--clip_grad is pinned on the property take_step relies on: the gradient norm afterwards is the bound, and the direction is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 931237e430882118fd005b37a0692256c0f0b119. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->