### PR TITLE
Handle biased e3nn linears when merging LoRA weights

### DIFF
--- a/mace/modules/lora.py
+++ b/mace/modules/lora.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import torch
 import torch.nn.functional as F
 from e3nn import o3
@@ -85,7 +87,9 @@ class LoRAO3Linear(nn.Module):
         blocks = {}
         offset = 0
         for idx, instr in enumerate(linear.instructions):
-            size = instr.path_shape[0] * instr.path_shape[1]
+            if instr.i_in == -1:
+                continue
+            size = math.prod(instr.path_shape)
             block = linear.weight[offset : offset + size].reshape(instr.path_shape)
             blocks[idx] = block
             offset += size
@@ -102,6 +106,12 @@ class LoRAO3Linear(nn.Module):
             i_in_base = base_instr.i_in
             i_out_base = base_instr.i_out
             pw_base = base_instr.path_weight
+
+            # e3nn represents bias terms as instructions with no input. Their
+            # parameters live in ``linear.bias``, not ``linear.weight``, and
+            # LoRA must leave them unchanged.
+            if i_in_base == -1:
+                continue
 
             # Find corresponding lora_A instruction
             if i_in_base not in self._A_by_i_in:

--- a/tests/unit/test_lora.py
+++ b/tests/unit/test_lora.py
@@ -255,6 +255,28 @@ def test_lora_merge_preserves_outputs(build_lora_model, random_configs) -> None:
     ), f"Forces mismatch after merge: max diff = {(forces_before - forces_after).abs().max()}"
 
 
+def test_lora_merge_handles_o3_linear_bias_instructions() -> None:
+    """Bias paths have a one-dimensional path shape, unlike weight paths."""
+    from mace.modules.lora import LoRAO3Linear
+
+    base = o3.Linear("2x0e", "3x0e", biases=True)
+    assert any(len(instr.path_shape) == 1 for instr in base.instructions)
+
+    wrapped = LoRAO3Linear(base, rank=2, alpha=0.5)
+    with torch.no_grad():
+        for param in wrapped.lora_A.parameters():
+            param.normal_(mean=0.0, std=0.05)
+        for param in wrapped.lora_B.parameters():
+            param.normal_(mean=0.0, std=0.05)
+
+        inputs = torch.randn(5, base.irreps_in.dim)
+        output_before = wrapped(inputs)
+        merged = wrapped.merge_into_base()
+        output_after = merged(inputs)
+
+    torch.testing.assert_close(output_after, output_before)
+
+
 def test_lora_merge_removes_wrappers(build_lora_model) -> None:
     """Test that merging removes LoRA wrapper modules."""
     from mace.modules.lora import LoRADenseLinear, LoRAFCLayer, LoRAO3Linear


### PR DESCRIPTION
This fixes #1640.

e3nn represents a bias as an instruction with `i_in == -1`, but the actual parameter lives in `linear.bias`, not `linear.weight`. The LoRA merge code was treating that instruction as another weight block, so biased readouts such as the ones in PolarMACE eventually tried to slice past the end of the weight tensor.

This skips bias-only instructions while extracting and composing LoRA weight blocks. The base bias is left unchanged.

I added a regression with a biased `o3.Linear`. The full LoRA unit test file passes (8 tests), and I also loaded the released MACE-POLAR-1-M checkpoint and successfully computed and merged all 44 equivariant LoRA wrappers.