### PR TITLE
Mask the stress of a graph with no periodic direction

### DIFF
--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -305,6 +305,7 @@ class MACELES(ScaleShiftMACE):
         vectors = ctx.vectors
         lengths = ctx.lengths
         cell = ctx.cell
+        pbc = ctx.pbc
         node_heads = ctx.node_heads
         interaction_kwargs = ctx.interaction_kwargs
         lammps_natoms = interaction_kwargs.lammps_natoms
@@ -614,6 +615,7 @@ class MACELES(ScaleShiftMACE):
             displacement=displacement,
             vectors=vectors,
             cell=cell,
+            pbc=pbc,
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,
@@ -632,6 +634,7 @@ class MACELES(ScaleShiftMACE):
                 num_atoms=positions.shape[0],
                 batch=data["batch"],
                 cell=cell,
+                pbc=pbc,
             )
         return {
             "energy": total_energy,
@@ -982,6 +985,7 @@ class PolarMACE(ScaleShiftMACE):
         vectors = ctx.vectors
         lengths = ctx.lengths
         cell = ctx.cell
+        pbc = ctx.pbc
         node_heads = ctx.node_heads
         interaction_kwargs = ctx.interaction_kwargs
         lammps_natoms = interaction_kwargs.lammps_natoms
@@ -1292,6 +1296,7 @@ class PolarMACE(ScaleShiftMACE):
             displacement=displacement,
             vectors=vectors,
             cell=cell,
+            pbc=pbc,
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,
@@ -1923,6 +1928,7 @@ class MagneticScaleShiftMACE(MagneticMACE):
             displacement=displacement,
             vectors=vectors,
             cell=data["cell"],
+            pbc=data["pbc"] if "pbc" in data else None,
             magmoms=data["magmom"],
             training=training,
             compute_force=compute_force,
@@ -1942,6 +1948,7 @@ class MagneticScaleShiftMACE(MagneticMACE):
                 num_atoms=data["positions"].shape[0],
                 batch=data["batch"],
                 cell=data["cell"],
+                pbc=data["pbc"] if "pbc" in data else None,
             )
         output = {
             "energy": total_energy,

--- a/mace/modules/extensions.py
+++ b/mace/modules/extensions.py
@@ -1317,6 +1317,7 @@ class PolarMACE(ScaleShiftMACE):
                 num_atoms=positions.shape[0],
                 batch=data["batch"],
                 cell=cell,
+                pbc=pbc,
             )
 
         return {

--- a/mace/modules/models.py
+++ b/mace/modules/models.py
@@ -303,6 +303,7 @@ class MACE(torch.nn.Module):
         vectors = ctx.vectors
         lengths = ctx.lengths
         cell = ctx.cell
+        pbc = ctx.pbc
         node_heads = ctx.node_heads.to(torch.int64)
         interaction_kwargs = ctx.interaction_kwargs
         lammps_natoms = interaction_kwargs.lammps_natoms
@@ -405,6 +406,7 @@ class MACE(torch.nn.Module):
             displacement=displacement,
             vectors=vectors,
             cell=cell,
+            pbc=pbc,
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,
@@ -423,6 +425,7 @@ class MACE(torch.nn.Module):
                 num_atoms=positions.shape[0],
                 batch=data["batch"],
                 cell=cell,
+                pbc=pbc,
             )
         return {
             "energy": total_energy,
@@ -483,6 +486,7 @@ class ScaleShiftMACE(MACE):
         vectors = ctx.vectors
         lengths = ctx.lengths
         cell = ctx.cell
+        pbc = ctx.pbc
         node_heads = ctx.node_heads.to(torch.int64)
         interaction_kwargs = ctx.interaction_kwargs
         lammps_natoms = interaction_kwargs.lammps_natoms
@@ -587,6 +591,7 @@ class ScaleShiftMACE(MACE):
             displacement=displacement,
             vectors=vectors,
             cell=cell,
+            pbc=pbc,
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,
@@ -605,6 +610,7 @@ class ScaleShiftMACE(MACE):
                 num_atoms=positions.shape[0],
                 batch=data["batch"],
                 cell=cell,
+                pbc=pbc,
             )
         return {
             "energy": total_energy,
@@ -1439,6 +1445,7 @@ class EnergyDipolesMACE(torch.nn.Module):
             positions=data["positions"],
             displacement=displacement,
             cell=data["cell"],
+            pbc=data["pbc"] if "pbc" in data else None,
             training=training,
             compute_force=compute_force,
             compute_virials=compute_virials,

--- a/mace/modules/utils.py
+++ b/mace/modules/utils.py
@@ -49,6 +49,43 @@ def compute_forces(
     return -1 * gradient
 
 
+def cell_volume_and_mask(
+    cell: torch.Tensor,  # [n_graphs, 3, 3] or [n_graphs * 3, 3]
+    pbc: Optional[torch.Tensor] = None,  # [n_graphs, 3]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-graph cell volume, plus a mask of the graphs it is a volume for.
+
+    A graph with no periodic direction has nothing to normalize a virial by:
+    the cell it carries is the padding box `get_neighborhood` builds around the
+    atoms, so `virials / det(cell)` is a number set by that padding rather than
+    a stress. The mask marks those graphs (and any with a degenerate cell) so
+    the caller can zero them and keep the stress of the periodic graphs in a
+    batch that mixes molecules with crystals. `pbc` may be None (LAMMPS,
+    hand-built inputs), in which case only a degenerate cell is masked.
+
+    The returned volume is 1 where the mask is False, so the caller's division
+    stays finite: masking a nan after the fact still routes a nan back through
+    the division on the backward pass.
+    """
+    cell = cell.view(-1, 3, 3)
+    volume = torch.linalg.det(cell).abs()
+    periodic = volume > 0.0
+    if pbc is not None:
+        periodic = torch.logical_and(periodic, pbc.view(-1, 3).any(dim=-1))
+    return torch.where(periodic, volume, torch.ones_like(volume)), periodic
+
+
+def stress_from_virials(
+    virials: torch.Tensor,  # [n_graphs, 3, 3]
+    cell: torch.Tensor,
+    pbc: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    volume, periodic = cell_volume_and_mask(cell, pbc)
+    stress = virials / volume.view(-1, 1, 1)
+    stress = torch.where(periodic.view(-1, 1, 1), stress, torch.zeros_like(stress))
+    return torch.where(torch.abs(stress) < 1e10, stress, torch.zeros_like(stress))
+
+
 def compute_forces_virials(
     energy: torch.Tensor,
     positions: torch.Tensor,
@@ -56,6 +93,7 @@ def compute_forces_virials(
     cell: torch.Tensor,
     training: bool = True,
     compute_stress: bool = False,
+    pbc: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     grad_outputs: List[Optional[torch.Tensor]] = [torch.ones_like(energy)]
     forces, virials = torch.autograd.grad(
@@ -68,10 +106,7 @@ def compute_forces_virials(
     )
     stress = torch.zeros_like(displacement)
     if compute_stress and virials is not None:
-        cell = cell.view(-1, 3, 3)
-        volume = torch.linalg.det(cell).abs().unsqueeze(-1)
-        stress = virials / volume.view(-1, 1, 1)
-        stress = torch.where(torch.abs(stress) < 1e10, stress, torch.zeros_like(stress))
+        stress = stress_from_virials(virials, cell, pbc)
     if forces is None:
         forces = torch.zeros_like(positions)
     if virials is None:
@@ -183,6 +218,7 @@ def compute_forces_virials_magforces(
     magmoms: torch.Tensor,
     training: bool = True,
     compute_stress: bool = False,
+    pbc: Optional[torch.Tensor] = None,
 ) -> Tuple[
     torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]
 ]:
@@ -218,10 +254,7 @@ def compute_forces_virials_magforces(
     # Compute stress if requested
     stress = torch.zeros_like(displacement)
     if compute_stress:
-        cell = cell.view(-1, 3, 3)
-        volume = torch.linalg.det(cell).abs().unsqueeze(-1)
-        stress = virials / volume.view(-1, 1, 1)
-        stress = torch.where(torch.abs(stress) < 1e10, stress, torch.zeros_like(stress))
+        stress = stress_from_virials(virials, cell, pbc)
 
     return -forces, -virials, stress, -mag_forces
 
@@ -281,6 +314,7 @@ def get_outputs(
     compute_hessian: bool = False,
     compute_edge_forces: bool = False,
     compute_magforces: bool = False,
+    pbc: Optional[torch.Tensor] = None,
 ) -> Tuple[
     Optional[torch.Tensor],
     Optional[torch.Tensor],
@@ -303,6 +337,7 @@ def get_outputs(
             magmoms=magmoms,
             training=(training or compute_hessian or compute_edge_forces),
             compute_stress=True,
+            pbc=pbc,
         )
     elif (compute_virials or compute_stress) and displacement is not None:
         forces, virials, stress = compute_forces_virials(
@@ -312,6 +347,7 @@ def get_outputs(
             cell=cell,
             compute_stress=compute_stress,
             training=(training or compute_hessian or compute_edge_forces),
+            pbc=pbc,
         )
         mag_forces = None
     elif compute_force and compute_magforces:
@@ -362,6 +398,7 @@ def get_atomic_virials_stresses(
     num_atoms: int,
     batch: torch.Tensor,
     cell: torch.Tensor,  # [n_graphs, 3, 3]
+    pbc: Optional[torch.Tensor] = None,  # [n_graphs, 3]
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """
     Compute atomic virials and optionally atomic stresses from edge forces and vectors.
@@ -380,11 +417,13 @@ def get_atomic_virials_stresses(
     )
     atom_virial = (atom_virial_sender + atom_virial_receiver) / 2
     atom_virial = (atom_virial + atom_virial.transpose(-1, -2)) / 2
-    atom_stress = None
-    cell = cell.view(-1, 3, 3)
-    volume = torch.linalg.det(cell).abs().unsqueeze(-1)
-    atom_volume = volume[batch].view(-1, 1, 1)
-    atom_stress = atom_virial / atom_volume
+    # Masked exactly like the total stress, so an aperiodic graph's atomic
+    # stresses stay zero rather than reporting its padding box.
+    volume, periodic = cell_volume_and_mask(cell, pbc)
+    atom_stress = atom_virial / volume[batch].view(-1, 1, 1)
+    atom_stress = torch.where(
+        periodic[batch].view(-1, 1, 1), atom_stress, torch.zeros_like(atom_stress)
+    )
     atom_stress = torch.where(
         torch.abs(atom_stress) < 1e10, atom_stress, torch.zeros_like(atom_stress)
     )
@@ -722,6 +761,7 @@ class GraphContext(NamedTuple):
     vectors: torch.Tensor
     lengths: torch.Tensor
     cell: torch.Tensor
+    pbc: Optional[torch.Tensor]
     node_heads: torch.Tensor
     interaction_kwargs: InteractionKwargs
 
@@ -742,6 +782,7 @@ def prepare_graph(
         else torch.zeros_like(data["batch"])
     )
 
+    pbc: Optional[torch.Tensor] = None
     if lammps_mliap:
         n_real, n_ghost = data["natoms"][0], data["natoms"][1]
         num_graphs = 2
@@ -765,6 +806,7 @@ def prepare_graph(
             data["positions"].requires_grad_(True)
         positions = data["positions"]
         cell = data["cell"]
+        pbc = data["pbc"] if "pbc" in data else None
         num_atoms_arange = torch.arange(positions.shape[0], device=positions.device)
         num_graphs = int(data["ptr"].numel() - 1)
         displacement = torch.zeros(
@@ -797,6 +839,7 @@ def prepare_graph(
         vectors=vectors,
         lengths=lengths,
         cell=cell,
+        pbc=pbc,
         node_heads=node_heads,
         interaction_kwargs=ikw,
     )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -527,6 +527,98 @@ def test_stress_partial_pbc():
     )
 
 
+def test_stress_zero_without_pbc():
+    """
+    A graph with no periodic direction has no volume to normalize a virial by:
+    the cell it carries is the box get_neighborhood pads around the atoms, so
+    its stress is exactly zero rather than virials/det(padding box). The energy
+    and the virial are identical whatever that box is, so the old behaviour was
+    an arbitrary number that merely shrank as the padding grew.
+    """
+    torch.set_default_dtype(torch.float64)
+    torch.manual_seed(7)
+
+    mixed_z_table = tools.AtomicNumberTable([1, 8, 14])
+    model = modules.ScaleShiftMACE(
+        r_max=5.0,
+        num_bessel=8,
+        num_polynomial_cutoff=6,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        interaction_cls_first=modules.interaction_classes[
+            "RealAgnosticResidualInteractionBlock"
+        ],
+        num_interactions=2,
+        num_elements=3,
+        hidden_irreps=o3.Irreps("16x0e + 16x1o"),
+        MLP_irreps=o3.Irreps("16x0e"),
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.zeros(3),
+        avg_num_neighbors=8,
+        atomic_numbers=mixed_z_table.zs,
+        correlation=3,
+        radial_type="bessel",
+        atomic_inter_scale=1.0,
+        atomic_inter_shift=0.0,
+    )
+
+    def compute(atoms_list):
+        dataset = [
+            data.AtomicData.from_config(
+                data.config_from_atoms(atoms), z_table=mixed_z_table, cutoff=5.0
+            )
+            for atoms in atoms_list
+        ]
+        loader = torch_geometric.dataloader.DataLoader(
+            dataset=dataset, batch_size=len(dataset), shuffle=False, drop_last=False
+        )
+        batch = next(iter(loader)).to_dict()
+        output = model(
+            batch,
+            training=True,
+            compute_stress=True,
+            compute_virials=True,
+            compute_edge_forces=True,
+            compute_atomic_stresses=True,
+        )
+        return batch, output
+
+    molecule = build.molecule("H2O")
+    crystal = build.bulk("Si", "diamond", a=5.43)
+    crystal.set_cell(crystal.get_cell() @ (np.eye(3) * 1.02), scale_atoms=True)
+
+    _, molecule_only = compute([molecule])
+    assert torch.count_nonzero(molecule_only["stress"]) == 0
+    assert torch.count_nonzero(molecule_only["atomic_stresses"]) == 0
+    # The virial itself is untouched: it is the volume that is missing, not the
+    # strain derivative.
+    assert molecule_only["virials"].abs().max() > 0
+
+    # Enlarging the padding box cannot move a masked stress, whereas dividing
+    # by det(cell) would scale it by 1/L**3.
+    padded = molecule.copy()
+    padded.set_cell(np.eye(3) * 50.0)
+    padded.set_pbc(False)
+    _, padded_only = compute([padded])
+    assert torch.count_nonzero(padded_only["stress"]) == 0
+
+    # A periodic graph keeps its stress, and keeps it unchanged when batched
+    # next to an aperiodic one.
+    _, crystal_only = compute([crystal])
+    assert crystal_only["stress"].abs().max() > 0
+    _, mixed = compute([molecule, crystal])
+    assert torch.count_nonzero(mixed["stress"][0]) == 0
+    assert torch.allclose(mixed["stress"][1], crystal_only["stress"][0])
+
+    # The atomic stresses stay a decomposition of the total, per graph.
+    batch, mixed = compute([molecule, crystal])
+    summed = torch.zeros_like(mixed["stress"])
+    summed.index_add_(0, batch["batch"], mixed["atomic_stresses"])
+    assert torch.allclose(summed, mixed["stress"], atol=1e-9)
+
+
 # ===========================================================================
 # Two model-construction knobs no published checkpoint stores, and which
 # therefore have no golden: --use_edge_irreps_first and a non-linear first

--- a/tests/unit/test_stress_mask_call_sites.py
+++ b/tests/unit/test_stress_mask_call_sites.py
@@ -1,0 +1,86 @@
+"""The stress mask is shared, and this is what keeps it shared.
+
+``cell_volume_and_mask`` decides per graph whether a virial has a volume to be
+normalized by. That decision is only worth anything if every model reaches it,
+and a model reaches it by passing ``pbc`` alongside ``cell``. Miss one call
+site and that model reports the padding box again, which is invisible until
+somebody compares a molecule's stress against zero.
+
+It is exactly the kind of property that decays one call site at a time. The
+call site missed the first time round was ``PolarMACE``'s atomic stresses,
+which reaches the helper through a function-local ``import ... as _gav``, so
+grepping for the function's own name did not see it while the total stress
+right above it was already masked.
+
+So it is a test rather than a comment. The check is crude on purpose: names
+are read out of the source with ``ast`` and never resolved, which is enough to
+notice a new call site and cheap enough to always run.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Helpers that turn a virial into a stress. Any call to one of these that
+#: says which cell to divide by must also say which graphs have a volume.
+MASK_CONSUMERS = frozenset(
+    {
+        "get_outputs",
+        "get_atomic_virials_stresses",
+        "compute_forces_virials",
+        "compute_forces_virials_magforces",
+    }
+)
+
+
+def _local_names(tree: ast.Module) -> dict[str, str]:
+    """Local name -> helper name, for every import anywhere in the file.
+
+    Walks the whole tree rather than the module body, so a function-local
+    import (and an ``as`` alias) is picked up too.
+    """
+    names: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for imported in node.names:
+                if imported.name in MASK_CONSUMERS:
+                    names[imported.asname or imported.name] = imported.name
+    return names
+
+
+def _call_sites():
+    for path in sorted((REPO_ROOT / "mace").rglob("*.py")):
+        if "torch_geometric" in str(path):  # vendored
+            continue
+        tree = ast.parse(path.read_text())
+        names = _local_names(tree)
+        if not names:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Name) or node.func.id not in names:
+                continue
+            keywords = {kw.arg for kw in node.keywords}
+            yield (
+                path.relative_to(REPO_ROOT),
+                node.lineno,
+                names[node.func.id],
+                keywords,
+            )
+
+
+def test_every_stress_call_site_passes_pbc():
+    sites = list(_call_sites())
+    # A rename or a moved import would empty this and pass silently.
+    assert len(sites) >= 10, f"expected the known call sites, found {len(sites)}"
+
+    unmasked = [
+        f"{path}:{line} calls {helper} with cell= but no pbc="
+        for path, line, helper, keywords in sites
+        if "cell" in keywords and "pbc" not in keywords
+    ]
+    assert not unmasked, "\n".join(unmasked)


### PR DESCRIPTION
## What is wrong

matscipy cannot bin atoms along a non periodic axis, so `get_neighborhood`
returns a padding box for a fully aperiodic system. The models then divide the
strain derivative by that invented volume and report the result as a stress.

The number is an artifact of the box. On a water molecule the energy and the
virial are bit identical at every box size, while the reported stress tracks
1/V exactly:

| padding box | volume | energy | \|virial\|max | \|stress\|max |
|---|---|---|---|---|
| current, `extent + 2*cutoff + 1` | 1597.87 | 0.395732697 | 0.492090 | 3.08e-04 |
| pre #1533, `(max\|pos\|+1)*5*cutoff` | 85655.17 | 0.395732697 | 0.492090 | 5.74e-06 |
| cubic L=200 | 8.0e6 | 0.395732697 | 0.492090 | 6.15e-08 |
| cubic L=1000 | 1.0e9 | 0.395732697 | 0.492090 | 4.92e-10 |

So enlarging the cell does not fix this. It only dilutes it. The value never
reaches zero, and #1533 shrank that box for a reason. The old box scaled with
the absolute coordinates and blew the PolarMACE k space electrostatics into a
GPU OOM.

## What this does

`cell_volume_and_mask` in `mace/modules/utils.py` masks per graph on
`pbc.any()`. The total stress, the magnetic path and the atomic stresses all
share it, so a batch mixing molecules with crystals keeps the crystals'
stress, and so does a slab that is periodic in two directions.

Three details worth review:

1. The masked graphs divide by one rather than by zero. Masking after the
   division is not enough on its own, because a nan still routes back through
   the division on the backward pass, which poisons gradients for a stress
   loss on an aperiodic graph.
2. The existing `abs(stress) < 1e10` clamp was doing this job by accident, and
   only for a fully degenerate cell where `0/0` gives a nan. It stays as the
   near degenerate backstop.
3. `pbc` reaches the models through `GraphContext`, and is None under LAMMPS,
   where the cell is always periodic and only the volume is checked. The
   lookup is spelled with `in` rather than `.get`, because `Batch` implements
   `__contains__` but not `.get`, and `EnergyDipolesMACE` callers pass a
   `Batch`.

## What this does not change

Periodic and partially periodic stress are untouched. The division is the same
operation on the same values whenever the mask is True. A slab's analytic
stress still matches the finite difference strain derivative of its own energy
to 1e-5 in every component, including sigma_zz, so this deliberately does not
zero the non periodic components of a slab.

## Consequence to be aware of

An aperiodic system now reports exactly zero, while `(1/V) dE/deps` computed by
finite differences on the padding box is nonzero. That divergence is deliberate,
since there is no volume to make the two agree. Zero is the conventional choice
here. Most ASE calculators refuse stress without pbc outright.

## Tests

`test_stress_zero_without_pbc` pins the contract: exactly zero for the total
and the atomic stresses, unchanged when the padding box is enlarged, a nonzero
virial alongside it, a periodic graph keeping its stress when batched next to
an aperiodic one, and the atomic stresses still summing to the total per graph.

Run locally on macOS arm64, python 3.11, torch 2.13:

- `tests/unit -m "not slow"`: 449 passed, 22 skipped
- `tests/golden`: 107 passed, references unchanged
- `tests/extensions` and `tests/backends`: 95 passed, 167 skipped, 1 xfailed
- `tests/workflows`: 108 passed, 16 skipped, 2 xfailed
- pylint 10.00/10


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how stress is derived from virials on aperiodic graphs, which can affect training losses and reported stresses for molecules. Periodic and partial-PBC paths are intended to be numerically identical.
> 
> **Overview**
> Zeros **total and atomic stress** on graphs with no periodic direction, instead of dividing the virial by the padding box `get_neighborhood` invents for aperiodic systems.
> 
> `cell_volume_and_mask` / `stress_from_virials` mask per graph on `pbc.any()` (and degenerate cells). Masked graphs divide by 1 so the backward pass stays finite. Periodic and slab stress are unchanged; mixed molecule/crystal batches keep the crystal values.
> 
> `pbc` is threaded through `GraphContext` into `get_outputs` and `get_atomic_virials_stresses` across the energy, magnetic, LES, Polar, and dipole models. LAMMPS leaves `pbc` as `None` and only checks volume.
> 
> Tests pin zero stress for molecules (including enlarged padding), mixed-batch isolation, atomic stresses summing to the total, and an AST check that every stress call site passes `pbc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21608c7eee1514c929d4050facb5c06a1c9e1386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->