### PR TITLE
Record the doc pages as reviewed rather than tested

### DIFF
--- a/tests/golden/check_inventory.py
+++ b/tests/golden/check_inventory.py
@@ -116,6 +116,12 @@ NON_TEST_PINS = {
         "`[dev]` is what the lint job installs; same reason, and `pre-commit "
         "run --all-files` is the assertion"
     ),
+    "the docs, reviewed not tested": (
+        "the pages live in the separate mace-docs repository and are not run in "
+        "CI, by decision: what keeps them true is a doc review when the surface "
+        "they describe changes. A gap marker here would read as a test somebody "
+        "still owes, and nobody does"
+    ),
 }
 
 COLUMNS = (

--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -48,9 +48,9 @@ were live in this file:
 |---|---|
 | a gap marker, `⚠️ gap (…)` | nothing pins this yet, and the cell says where the test belongs |
 | a backticked path under `tests/` | a test that runs today: a file, a `::test_name`, a `::TABLE[key]` entry, or a directory at least two levels deep |
-| one of two named CI jobs | `the suite itself` and `the lint job itself`, for the two `setup.cfg` extras, where the only thing that can fail is a job installing them. Allowed by name, one entry each, with a written reason |
+| one of three named non-test pins | `the suite itself` and `the lint job itself` for the two `setup.cfg` extras, where the only thing that can fail is a job installing them, and `the docs, reviewed not tested` for the pages in mace-docs, which CI does not run. Allowed by name, with a written reason each |
 
-There is deliberately no fourth form. A pin used to be allowed to name a *planned* test by ticket id,
+There is deliberately no further form. A pin used to be allowed to name a *planned* test by ticket id,
 which meant the cell recorded an intention nobody could resolve: a plan that slipped read exactly
 like coverage that existed. Every pin now names something that runs, or admits that nothing does.
 A pin naming a *test id* rather than a ticket is also what makes the checker able to verify it, which
@@ -1090,23 +1090,23 @@ them and nothing here is pinned by a test that imports one.
 
 | id | feature | source | disposition | pinned by |
 |---|---|---|---|---|
-| `doc.quickstart` | Quick Start / Introduction / Installation / Troubleshooting | mace-docs | KEEP — maps to §1 and §10 | ⚠️ gap (docs are not CI-tested today) |
-| `doc.training` | Training | mace-docs | KEEP — maps to §3 | ⚠️ gap (idem) |
-| `doc.evaluation` | Evaluation | mace-docs | KEEP — maps to §5 eval | ⚠️ gap (idem) |
-| `doc.multihead` | Heterogeneous Data Training / Multihead Training | mace-docs | KEEP — maps to §3.6 | ⚠️ gap (idem) |
-| `doc.ase` | ASE calculator | mace-docs | KEEP — maps to §9 and §16 | ⚠️ gap (idem) |
-| `doc.descriptors` | MACE descriptors | mace-docs | KEEP — maps to `get_descriptors` (§16) and the eval descriptor flags (§5) | ⚠️ gap (idem) |
+| `doc.quickstart` | Quick Start / Introduction / Installation / Troubleshooting | mace-docs | KEEP — maps to §1 and §10 | the docs, reviewed not tested |
+| `doc.training` | Training | mace-docs | KEEP — maps to §3 | the docs, reviewed not tested |
+| `doc.evaluation` | Evaluation | mace-docs | KEEP — maps to §5 eval | the docs, reviewed not tested |
+| `doc.multihead` | Heterogeneous Data Training / Multihead Training | mace-docs | KEEP — maps to §3.6 | the docs, reviewed not tested |
+| `doc.ase` | ASE calculator | mace-docs | KEEP — maps to §9 and §16 | the docs, reviewed not tested |
+| `doc.descriptors` | MACE descriptors | mace-docs | KEEP — maps to `get_descriptors` (§16) and the eval descriptor flags (§5) | the docs, reviewed not tested |
 | `doc.hessians` | Analytical Hessians | mace-docs | KEEP — maps to `get_hessian` (§16) | `tests/foundations/test_hessian.py` |
-| `doc.dipoles` | Dipole Moments and Polarizabilities | mace-docs | KEEP — maps to §6 and §11 | ⚠️ gap (docs are not CI-tested today) |
+| `doc.dipoles` | Dipole Moments and Polarizabilities | mace-docs | KEEP — maps to §6 and §11 | the docs, reviewed not tested |
 | `doc.cuda` | CUDA Acceleration (cuEquivariance) | mace-docs | KEEP — rewritten: v1 dispatches instead of converting, so the page's central instruction (convert your model) disappears | `tests/golden/test_backend_parity_golden.py::test_the_audits_verdict_tracks_whether_the_fused_ops_are_installed` |
-| `doc.openmm` | OpenMM Interface | mace-docs | KEEP | ⚠️ gap (no OpenMM coverage in-tree) |
+| `doc.openmm` | OpenMM Interface | mace-docs | KEEP — and the interface has no in-tree coverage at all, which is separate from the page: a test would need OpenMM installed | the docs, reviewed not tested |
 | `doc.lammps` | MACE in LAMMPS / MACE in LAMMPS with ML-IAP | mace-docs | KEEP — reduced to the MLIAP path; maps to §17 | `tests/integrations/lammps` |
 | `doc.foundation_models` | Foundation models | mace-docs | KEEP — maps to §9.2 | `tests/golden/test_foundation_goldens.py::test_the_registry_url_is_still_the_package_url` |
 | `doc.electrostatics` | Electrostatic MACE | mace-docs | KEEP — maps to §3.3 and PolarMACE (§6) | `tests/golden/test_polar_foundation.py::test_the_reference_pins_the_electrostatics_and_not_only_the_energy` |
 | `doc.finetuning` | Fine-tuning / Multihead Replay / LoRA | mace-docs | KEEP — maps to §3.6 | `tests/workflows/test_finetuning_contracts.py::test_multihead_replay_finetuning_completes_and_carries_both_heads` |
 | `doc.preprocessing` | Large Dataset Pre-processing | mace-docs | KEEP — maps to §4 | `tests/workflows/test_preprocess.py` |
 | `doc.multigpu` | Multi-GPUs Training | mace-docs | KEEP — maps to `--distributed` (§3.1) | `tests/workflows/test_distributed.py` |
-| `doc.examples` | Examples (MD22, ANI-1x, liquid water; NVT with a foundation model) and Tutorials 1–3 | mace-docs | KEEP — end-to-end usage; the theory tutorial is superseded by the marimo notebooks | ⚠️ gap (examples are not CI-tested) |
+| `doc.examples` | Examples (MD22, ANI-1x, liquid water; NVT with a foundation model) and Tutorials 1–3 | mace-docs | KEEP — end-to-end usage; the theory tutorial is superseded by the marimo notebooks | the docs, reviewed not tested |
 
 ## 19. Package-level surfaces and second-pass findings
 

--- a/tests/golden/test_inventory.py
+++ b/tests/golden/test_inventory.py
@@ -252,6 +252,7 @@ def test_a_directory_pin_may_still_name_a_test_inside_it():
         "`tests/golden/anchors.py::ANCHORS[tiny_mace]`",
         "the suite itself",
         "the lint job itself",
+        "the docs, reviewed not tested",
         "—",
         "",
     ],
@@ -262,24 +263,45 @@ def test_the_pin_vocabulary_actually_in_use_is_accepted(pin):
     assert check_inventory.check_pins([_row("x.a", pinned=pin)]) == []
 
 
-def test_the_two_non_test_pins_are_named_and_justified():
+def test_the_non_test_pins_are_named_and_justified():
     """Allowed by name, not by a wildcard, and each says why it is not a file.
 
-    Both are extras groups: the only thing that can fail is a CI job
-    installing them, and no test inside the suite can assert that the suite's
-    own dependencies resolve. Everything else that used this phrasing -- the
-    thirteen pytest markers -- now points into `tests/conftest.py`, each
-    capability at its own `CAPABILITY_PROBES` entry rather than at the file.
+    Two are extras groups: the only thing that can fail is a CI job installing
+    them, and no test inside the suite can assert that the suite's own
+    dependencies resolve. The third is the docs, which live in a separate
+    repository that CI does not run: what keeps them true is a review when the
+    surface they describe changes.
+
+    Everything else that used this phrasing -- the thirteen pytest markers --
+    now points into `tests/conftest.py`, each capability at its own
+    `CAPABILITY_PROBES` entry rather than at the file.
     """
     assert set(check_inventory.NON_TEST_PINS) == {
         "the suite itself",
         "the lint job itself",
+        "the docs, reviewed not tested",
     }
-    for pin, reason in check_inventory.NON_TEST_PINS.items():
-        assert len(reason) > 40, pin
+    for reason in check_inventory.NON_TEST_PINS.values():
+        assert len(reason) > 40, reason
+
+    # And who is allowed to use one, since the excuse is the kind of thing that
+    # spreads: a row that cannot be tested is rare, a row nobody got round to
+    # testing is not, and only the first sort belongs on this list.
     rows, _ = check_inventory.read_rows()
     users = sorted(r.ident for r in rows if r.pinned_by in check_inventory.NON_TEST_PINS)
-    assert users == ["extra.dev", "extra.test"], users
+    assert users == [
+        "doc.ase",
+        "doc.descriptors",
+        "doc.dipoles",
+        "doc.evaluation",
+        "doc.examples",
+        "doc.multihead",
+        "doc.openmm",
+        "doc.quickstart",
+        "doc.training",
+        "extra.dev",
+        "extra.test",
+    ], users
 
 
 def test_every_marker_row_pins_its_own_probe():


### PR DESCRIPTION
Nine `doc.*` rows carried a gap marker reading "docs are not CI-tested today", which put them in the open-work column and left them there. The pages live in the separate mace-docs repository and CI does not run them, by decision: what keeps them true is a doc review when the surface they describe changes. A gap marker reads as a test somebody still owes, and nobody does.

They take a third named non-test pin, `the docs, reviewed not tested`, alongside the two that already exist for the `setup.cfg` extras. Named with a written reason rather than a wildcard, so the next page cannot quietly acquire the excuse: the vocabulary table lists all three, and the test guarding the allowlist asserts the three entries, that each carries a reason, and which rows are allowed to use one. That last assertion is the one that matters — a row that *cannot* be tested is rare, a row nobody got round to testing is not, and only the first sort belongs on the list.

`doc.openmm` is one of the nine, and its old marker carried a second fact worth keeping: the interface has no in-tree coverage at all, which is about the code rather than the page. That moves into its disposition, since a non-test pin has to match the allowlist exactly and cannot take a qualifier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inventory and golden-test vocabulary only; no product, auth, or runtime behavior changes.
> 
> **Overview**
> Stops treating nine `doc.*` inventory rows as open test debt. Those pages live in mace-docs and are not run in CI by design, so a gap marker implied a test nobody is expected to write.
> 
> Adds a third named non-test pin, `the docs, reviewed not tested`, next to the extras-group pins. The allowlist is still name-only with a written reason; the gate test now also lists exactly which rows may use a non-test pin so the excuse cannot spread.
> 
> Moves the “no in-tree OpenMM coverage” note from `doc.openmm`’s pin into its disposition, because a non-test pin cannot carry a qualifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2a2109a5389ea34d038393bdc2463af7c4c295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->