### PR TITLE
Pin --foundation_model_kwargs and --weight_pt_head

### DIFF
--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -295,12 +295,12 @@ Group default: KEEP.
 | id | feature | source | disposition | pinned by |
 |---|---|---|---|---|
 | `train.foundation_model` | `--foundation_model` | `mace/tools/arg_parser.py:1019` | KEEP | `tests/workflows/test_finetuning_contracts.py::test_multihead_replay_finetuning_completes_and_carries_both_heads` + `tests/workflows/test_finetuning_contracts.py::test_finetuning_reduces_the_error_on_the_finetuning_set` |
-| `train.foundation_model_kwargs` | `--foundation_model_kwargs` | `mace/tools/arg_parser.py:1025` | KEEP | ⚠️ gap (no test passes `--foundation_model_kwargs`) |
+| `train.foundation_model_kwargs` | `--foundation_model_kwargs` | `mace/tools/arg_parser.py:1025` | KEEP | `tests/workflows/test_foundation_kwargs.py` (the parse every run performs, and that a checkpoint path ignores them) |
 | `train.foundation_model_readout` | `--foundation_model_readout` | `mace/tools/arg_parser.py:1031` | KEEP | `tests/unit/test_foundation_readout_flag.py::test_the_flag_turns_the_transfer_off` + `tests/unit/test_foundation_readout_flag.py::test_loading_without_it_leaves_them_alone` (`--foundation_filter_elements` is a deprecated alias of this dest) |
 | `train.multiheads_finetuning` | `--multiheads_finetuning` | `mace/tools/arg_parser.py:573` | KEEP | `tests/workflows/test_finetuning_contracts.py::test_multihead_replay_finetuning_completes_and_carries_both_heads` |
 | `train.heads` | `--heads` | `mace/tools/arg_parser.py:566` | KEEP — the heads YAML sub-schema | `tests/workflows/test_multifiles.py::test_multiple_xyz_per_head` |
 | `train.foundation_head` | `--foundation_head` | `mace/tools/arg_parser.py:579` | KEEP | `tests/workflows/test_run_train.py::test_run_train_mh_foundation` |
-| `train.weight_pt_head` | `--weight_pt_head` | `mace/tools/arg_parser.py:586` | KEEP | ⚠️ gap (no test passes `--weight_pt_head`, so the replay head's loss weight is unprotected) |
+| `train.weight_pt_head` | `--weight_pt_head` | `mace/tools/arg_parser.py:586` | KEEP | `tests/unit/test_multihead_tools.py::test_weight_pt_head_is_the_weight_every_replay_config_carries` (offline, against a seeded replay cache) |
 | `train.num_samples_pt` | `--num_samples_pt` | `mace/tools/arg_parser.py:598` | KEEP | `tests/workflows/test_finetuning_contracts.py::test_the_replay_selection_flags_exist_on_the_training_cli` |
 | `train.real_pt_data_ratio_threshold` | `--real_pt_data_ratio_threshold` | `mace/tools/arg_parser.py:592` | KEEP | `tests/workflows/test_run_train.py::test_run_train_real_pt_data_ratio` |
 | `train.pt_train_file` | `--pt_train_file` | `mace/tools/arg_parser.py:628` | KEEP | `tests/workflows/test_run_train.py::test_run_train_multihead_replay_custom_finetuning` |

--- a/tests/unit/test_multihead_tools.py
+++ b/tests/unit/test_multihead_tools.py
@@ -21,6 +21,7 @@ import dataclasses
 import numpy as np
 import pytest
 import torch
+import ase.io
 from ase import Atoms
 from e3nn import o3
 
@@ -33,6 +34,7 @@ from mace.tools import build_default_arg_parser
 from mace.tools.torch_tools import default_dtype
 from mace.tools.multihead_tools import (
     HeadConfig,
+    assemble_replay_data,
     apply_pseudolabels_to_pt_head_configs,
     dict_head_to_dataclass,
     generate_pseudolabels_for_configs,
@@ -504,3 +506,92 @@ def test_forcing_it_adds_the_stress_the_model_predicts():
     assert all(
         c.property_weights.get("stress", 0.0) > 0.0 for c in relabelled
     ), "a written label needs a weight, or the loss ignores it"
+
+
+# ---------------------------------------------------------------------------
+# --weight_pt_head
+# ---------------------------------------------------------------------------
+#
+# The flag sets the loss weight every replay configuration carries. It reaches
+# the data through `assemble_replay_data` -> `SelectionSettings.weight_pt` ->
+# `_write_metadata`, and only on the branch that downloads a named replay set:
+# a `--pt_train_file` given by hand is used as it stands. That branch is
+# reachable offline anyway, because it skips the download when the cache already
+# holds the file, which is what these tests exploit -- no network, and the real
+# selection code runs.
+
+
+REPLAY_CACHE_NAMES = {"mp": "mp_traj_combinedxyz"}
+
+
+def _seed_replay_cache(tmp_path, monkeypatch, name="mp", count=6):
+    """Put a replay set where the downloader looks, so it does not download."""
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    cached = tools.utils.get_cache_dir() / REPLAY_CACHE_NAMES[name]
+    cached.parent.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(3)
+    atoms_list = []
+    for index in range(count):
+        atoms = Atoms(
+            "H2O",
+            positions=[[0, 0, 0], [0.95, 0, 0], [-0.24, 0.93, 0]],
+            cell=[8, 8, 8],
+            pbc=True,
+        )
+        atoms.info["REF_energy"] = float(rng.normal())
+        atoms.info["config_type"] = f"replay_{index}"
+        atoms.arrays["REF_forces"] = rng.normal(size=(3, 3))
+        atoms_list.append(atoms)
+    ase.io.write(cached, atoms_list, format="extxyz")
+    return cached
+
+
+def _replay(tmp_path, monkeypatch, extra=None):
+    """Run `assemble_replay_data` in `tmp_path` and read back what it wrote.
+
+    It writes `mp_finetuning-<tag>.xyz` into the working directory, so the test
+    has to own the working directory.
+    """
+    _seed_replay_cache(tmp_path, monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    # `--num_samples_pt` defaults to 10000, and asking a six-structure cache for
+    # that many fails before any weight is written.
+    args = parse_minimal_args(["--num_samples_pt", "4"] + list(extra or []))
+    args.work_dir = str(tmp_path)
+    head_config_pt = prepare_pt_head(
+        args, args.key_specification, foundation_model_num_neighbours=8.0
+    )
+    config = dict_head_to_dataclass(head_config_pt, "pt_head", args)
+
+    assemble_replay_data("mp", args, config, tag="tagged")
+
+    written = ase.io.read(tmp_path / "mp_finetuning-tagged.xyz", index=":")
+    assert written, "the selection wrote no replay configurations"
+    return written
+
+
+def test_the_replay_weight_defaults_to_one(tmp_path, monkeypatch):
+    written = _replay(tmp_path, monkeypatch)
+
+    assert {atoms.info["config_weight"] for atoms in written} == {1.0}
+
+
+def test_weight_pt_head_is_the_weight_every_replay_config_carries(
+    tmp_path, monkeypatch
+):
+    """`--weight_pt_head` is how the replay head's pull on the loss is tuned
+    against the new head's, and it is per configuration rather than per head:
+    the number lands in `config_weight` on every selected structure."""
+    written = _replay(tmp_path, monkeypatch, ["--weight_pt_head", "0.25"])
+
+    assert {atoms.info["config_weight"] for atoms in written} == {0.25}
+
+
+def test_the_replay_configs_are_tagged_as_the_pretraining_head(tmp_path, monkeypatch):
+    """The weight only means something alongside the head it weighs, and both
+    are written by the same call."""
+    written = _replay(tmp_path, monkeypatch)
+
+    assert {atoms.info["head"] for atoms in written} == {"pbe_mp"}
+    assert {atoms.info["pretrained"] for atoms in written} == {True}

--- a/tests/workflows/test_foundation_kwargs.py
+++ b/tests/workflows/test_foundation_kwargs.py
@@ -1,0 +1,104 @@
+"""`--foundation_model_kwargs`, and the one path that reads it.
+
+The flag is a string holding a Python dict literal, parsed with
+`ast.literal_eval` at the very top of `run()` -- before any data is read, and
+whether or not a foundation model was asked for. So the parse is what every run
+pays for, and it had no test.
+
+Where the parsed dict *goes* is narrower than the flag's name suggests: it is
+splatted into `mace_mp(...)`, and only on the branch that recognises the
+foundation model as one of the named MACE-MP releases. A foundation model given
+as a path takes a different branch, which never looks at the kwargs. Passing both
+is therefore accepted and silently ineffective, which is worth a test precisely
+because nothing says so.
+"""
+
+from pathlib import Path
+
+import ase.io
+import pytest
+
+from tests.helpers import base_mace_params, make_fitting_configs, run_mace_train
+
+ANCHOR = Path(__file__).resolve().parents[1] / "golden" / "models" / "tiny_scaleshift.model"
+
+
+def train(tmp_path, kwargs_value, foundation=None, check=True):
+    ase.io.write(tmp_path / "fit.xyz", make_fitting_configs())
+    params = base_mace_params()
+    params.update(
+        {
+            "name": "fk",
+            "hidden_irreps": "16x0e",
+            "checkpoints_dir": str(tmp_path),
+            "model_dir": str(tmp_path),
+            "results_dir": str(tmp_path),
+            "log_dir": str(tmp_path),
+            "train_file": str(tmp_path / "fit.xyz"),
+            "max_num_epochs": 1,
+            "seed": 3,
+            "foundation_model_kwargs": kwargs_value,
+        }
+    )
+    if foundation is not None:
+        params["foundation_model"] = str(foundation)
+        params["multiheads_finetuning"] = "False"
+    return run_mace_train(
+        params, check=check, capture_output=True, text=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# the parse, which every run performs
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_is_an_empty_dict_and_a_run_survives_it(tmp_path):
+    """`--foundation_model_kwargs` defaults to the string `{}`, so the parse runs
+    on every training whether or not there is a foundation model to configure."""
+    assert train(tmp_path, "{}").returncode == 0
+
+
+def test_a_value_that_is_not_a_literal_stops_the_run(tmp_path):
+    """`ast.literal_eval`, so a name or a call is refused rather than executed.
+    This is what keeps the flag from being an arbitrary-code entry point."""
+    done = train(tmp_path, "{'device': open('x')}", check=False)
+
+    assert done.returncode != 0
+    assert "ValueError" in done.stderr or "malformed node" in done.stderr, done.stderr
+
+
+def test_an_unparseable_value_stops_the_run(tmp_path):
+    done = train(tmp_path, "{not a dict", check=False)
+
+    assert done.returncode != 0
+    assert "SyntaxError" in done.stderr, done.stderr
+
+
+def test_a_literal_that_is_not_a_dict_stops_the_run(tmp_path):
+    """`[1, 2]` parses and then fails on the next line, where the foundation head
+    is written into it. Nothing checks the shape, so the message is about list
+    indices rather than about the flag -- the only hint a user gets that a mapping
+    was wanted."""
+    done = train(tmp_path, "[1, 2]", check=False)
+
+    assert done.returncode != 0
+    assert "list indices must be integers" in done.stderr, done.stderr
+
+
+# ---------------------------------------------------------------------------
+# where it is read, and where it is not
+# ---------------------------------------------------------------------------
+
+
+def test_the_kwargs_are_ignored_when_the_foundation_model_is_a_path(tmp_path):
+    """Recorded, not endorsed. Only the named-release branch splats them into
+    `mace_mp`; a checkpoint path is loaded directly. A kwarg no loader would
+    accept is therefore accepted here, and the run finishes as if it had not been
+    given -- so a user who spells the model as a path gets silence rather than
+    the setting they asked for.
+    """
+    done = train(tmp_path, "{'nonexistent_kwarg': 12345}", foundation=ANCHOR)
+
+    assert done.returncode == 0
+    assert "nonexistent_kwarg" not in done.stderr


### PR DESCRIPTION
`--foundation_model_kwargs` is a dict literal parsed at the top of `run()`, before any data is read and whether or not a foundation model was asked for, so the parse is what every run pays for. Covered there: the default `{}`, a value `literal_eval` refuses, one that does not parse, and one that parses to the wrong type — that last message is about list indices rather than about the flag, because the shape is never checked and the failure comes from the next line writing the foundation head into it.

Where the dict goes is narrower than the flag's name suggests: it is splatted into `mace_mp`, and only on the branch that recognises a named MACE-MP release. A foundation model given as a path takes a different branch that never reads it, so a kwarg no loader would accept is accepted and ignored. Recorded rather than changed, since it is silence a user cannot tell from success.

`--weight_pt_head` sets the loss weight every replay configuration carries. It only acts on the branch that fetches a named replay set, which the test reaches offline by seeding the download cache, so the real selection code runs and the weight is read back off the configurations it wrote.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage of existing CLI flags; no production behavior change.
> 
> **Overview**
> Closes two inventory gaps by pinning `--foundation_model_kwargs` and `--weight_pt_head` with tests; no production code changes.
> 
> `--foundation_model_kwargs` is now covered as the `ast.literal_eval` parse every training run performs (default `{}`, refused literals, unparseable input, non-dict shape) plus the recorded silence when a checkpoint *path* is used: kwargs are only splatted into named `mace_mp` loads.
> 
> `--weight_pt_head` is pinned offline by seeding the replay cache and running real `assemble_replay_data` selection: default `config_weight` is 1.0, the flag writes that weight onto every selected structure, and those configs are tagged as the pretraining head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86b0c87720820f1446822d59091638d9673bae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->