### PR TITLE
Pin the block-config flags and --train_one_body_contribution

### DIFF
--- a/tests/extensions/polar/test_polar_block_configs.py
+++ b/tests/extensions/polar/test_polar_block_configs.py
@@ -1,0 +1,206 @@
+"""`--fixedpoint_update_config` and `--field_readout_config`.
+
+Two CLI flags that choose which block PolarMACE builds and how, written as
+dict literals in a string. They travel a path nothing tested: the string is
+parsed by `_parse_literal_or_none`, handed to the constructor, and there a `type`
+key is looked up in a registry while the remaining keys become that block's own
+keyword arguments. The existing polar tests pass fully-spelled dicts to the
+constructor directly, so both the parse and the registry lookup were unobserved,
+and a flag that reached the model as a string rather than a dict would fail
+somewhere far from the flag.
+
+Assertions are on the model the CLI path builds, through `_build_model` -- the
+same call `configure_model` makes -- rather than on a training, which for a
+PolarMACE is minutes and adds nothing here.
+"""
+
+import numpy as np
+import pytest
+import torch
+from e3nn import o3
+
+from mace import modules
+from mace.modules.field_blocks import (
+    AgnosticChargeBiasedLinearPotentialEmbedding,
+    AgnosticEmbeddedOneBodyVariableUpdate,
+    MLPNonLinearity,
+    OneBodyMLPFieldReadout,
+    field_readout_blocks,
+    field_update_blocks,
+)
+from mace.tools import build_default_arg_parser
+from mace.tools.model_script_utils import _build_model, _parse_literal_or_none
+from mace.tools.torch_tools import default_dtype
+
+ATOMIC_NUMBERS = [1, 8]
+
+
+def build(fixedpoint=None, readout=None):
+    """A small PolarMACE, built the way `configure_model` builds one."""
+    argv = [
+        "--name", "polarblocks",
+        "--train_file", "train.xyz",
+        "--model", "PolarMACE",
+        "--num_recursion_steps", "1",
+        "--atomic_multipoles_max_l", "1",
+        "--field_feature_max_l", "1",
+        "--MLP_irreps", "8x0e",
+        "--radial_MLP", "[16]",
+    ]
+    if fixedpoint is not None:
+        argv += ["--fixedpoint_update_config", fixedpoint]
+    if readout is not None:
+        argv += ["--field_readout_config", readout]
+    args = build_default_arg_parser().parse_args(argv)
+    args.std, args.mean = 1.0, 0.0
+
+    model_config = dict(
+        r_max=4.0,
+        num_bessel=4,
+        num_polynomial_cutoff=3,
+        max_ell=2,
+        interaction_cls=modules.interaction_classes[args.interaction],
+        num_interactions=2,
+        num_elements=len(ATOMIC_NUMBERS),
+        hidden_irreps=o3.Irreps("4x0e + 4x1o"),
+        edge_irreps=None,
+        atomic_energies=np.zeros(len(ATOMIC_NUMBERS)),
+        apply_cutoff=args.apply_cutoff,
+        avg_num_neighbors=3.0,
+        atomic_numbers=ATOMIC_NUMBERS,
+        use_reduced_cg=args.use_reduced_cg,
+        use_so3=args.use_so3,
+        use_edge_irreps_first=args.use_edge_irreps_first,
+        cueq_config=None,
+    )
+    with default_dtype(torch.float64):
+        return _build_model(args, model_config, None, ["Default"])
+
+
+# ---------------------------------------------------------------------------
+# the string, before it is a config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, "None", "none", "", "  "])
+def test_an_absent_config_is_none_however_it_is_spelled(value):
+    """The flags default to `None`, and a YAML config file naturally writes the
+    absent case as the string `None` -- which `ast.literal_eval` would turn into
+    a name lookup rather than nothing."""
+    assert _parse_literal_or_none(value) is None
+
+
+def test_a_dict_literal_becomes_a_dict():
+    parsed = _parse_literal_or_none("{'type': 'OneBodyMLPFieldReadout'}")
+
+    assert parsed == {"type": "OneBodyMLPFieldReadout"}
+
+
+def test_a_value_that_is_not_a_literal_is_refused():
+    """Same reasoning as `--foundation_model_kwargs`: the flag carries code-shaped
+    text and must not be able to run any."""
+    with pytest.raises(ValueError):
+        _parse_literal_or_none("{'type': __import__('os').name}")
+
+
+# ---------------------------------------------------------------------------
+# the defaults
+# ---------------------------------------------------------------------------
+
+
+def test_neither_flag_given_builds_the_default_blocks():
+    model = build()
+
+    assert model._fixedpoint_update_config == {}
+    assert model._field_readout_config == {}
+    assert isinstance(
+        model.field_dependent_charges_maps[0], AgnosticEmbeddedOneBodyVariableUpdate
+    )
+    assert isinstance(model.local_electron_energy, OneBodyMLPFieldReadout)
+
+
+def test_the_registries_name_the_defaults():
+    """`type` is resolved through these, so a block that is not in them cannot be
+    asked for by name however the flag is spelled."""
+    assert field_update_blocks["AgnosticEmbeddedOneBodyVariableUpdate"] is (
+        AgnosticEmbeddedOneBodyVariableUpdate
+    )
+    assert field_readout_blocks["OneBodyMLPFieldReadout"] is OneBodyMLPFieldReadout
+
+
+# ---------------------------------------------------------------------------
+# what the flags change
+# ---------------------------------------------------------------------------
+
+
+def test_the_flags_reach_the_model_as_dicts():
+    """The end of the path: string on the command line, dict on the model. The
+    model keeps its own copy including `type`, which the constructor pops off the
+    working copy -- so what was asked for stays legible after the block is built.
+    """
+    model = build(
+        fixedpoint="{'type': 'AgnosticEmbeddedOneBodyVariableUpdate'}",
+        readout="{'type': 'OneBodyMLPFieldReadout'}",
+    )
+
+    assert model._fixedpoint_update_config == {
+        "type": "AgnosticEmbeddedOneBodyVariableUpdate"
+    }
+    assert model._field_readout_config == {"type": "OneBodyMLPFieldReadout"}
+
+
+def test_a_class_valued_key_chooses_the_block_it_names():
+    """`potential_embedding_cls` is a class rather than a scalar, and the flag can
+    only carry its name, so it is mapped to an implementation on the way in. The
+    block is built with the class; the recorded config keeps the string."""
+    model = build(
+        fixedpoint=(
+            "{'potential_embedding_cls': "
+            "'AgnosticChargeBiasedLinearPotentialEmbedding'}"
+        )
+    )
+    block = model.field_dependent_charges_maps[0]
+
+    assert model._fixedpoint_update_config == {
+        "potential_embedding_cls": "AgnosticChargeBiasedLinearPotentialEmbedding"
+    }
+    assert isinstance(
+        block.potential_embedding, AgnosticChargeBiasedLinearPotentialEmbedding
+    )
+
+
+def test_nonlinearity_cls_is_accepted_and_ignored():
+    """Recorded, not endorsed. `AgnosticEmbeddedOneBodyVariableUpdate._setup`
+    discards `nonlinearity_cls` -- `_ = (nonlinearity_cls, num_elements)` -- and
+    builds a `RadialMLP` whatever was asked for. The name is still resolved to a
+    class on the way in, so the request looks honoured all the way to the block
+    that throws it away, and this repository's own polar model builders pass
+    `MLPNonLinearity` for it.
+    """
+    asked = build(fixedpoint="{'nonlinearity_cls': 'MLPNonLinearity'}")
+    default = build()
+
+    assert asked._fixedpoint_update_config == {"nonlinearity_cls": "MLPNonLinearity"}
+    assert type(asked.field_dependent_charges_maps[0].nonlinearity) is type(
+        default.field_dependent_charges_maps[0].nonlinearity
+    )
+    assert not isinstance(
+        asked.field_dependent_charges_maps[0].nonlinearity, MLPNonLinearity
+    )
+
+
+def test_a_block_the_registry_does_not_know_is_refused():
+    """The one thing in either config that is checked."""
+    with pytest.raises(KeyError):
+        build(readout="{'type': 'NoSuchReadout'}")
+
+
+def test_an_unknown_key_is_discarded_without_a_word():
+    """Recorded. `OneBodyMLPFieldReadout._setup` takes `**kwargs` and drops them
+    (`_ = kwargs`), so a misspelled option is not a failure and not a warning: the
+    model is built as if the flag had been empty, and the only trace is the
+    string kept on the model."""
+    model = build(readout="{'no_such_option': 1}")
+
+    assert model._field_readout_config == {"no_such_option": 1}
+    assert isinstance(model.local_electron_energy, OneBodyMLPFieldReadout)

--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -234,8 +234,8 @@ Group default: KEEP as the electrostatics-extra config section, pinned by the po
 | `train.quadrupole_feature_corrections` | `--quadrupole_feature_corrections` | `mace/tools/arg_parser.py:371` | KEEP | `tests/foundations/test_foundations.py::test_polar_extract_config_roundtrip` + `tests/golden/test_polar_foundation.py::test_the_reference_pins_the_electrostatics_and_not_only_the_energy` |
 | `train.return_electrostatic_potentials` | `--return_electrostatic_potentials` | `mace/tools/arg_parser.py:377` | MERGE — an observable declared in the output spec, not a model flag | `tests/extensions/polar/test_polar_output_keys.py::test_electrostatic_potentials_are_absent_unless_asked_for` (pins the off state; a case with it on is still to come) |
 | `train.field_norm_factor` | `--field_norm_factor` | `mace/tools/arg_parser.py:383` | KEEP | `tests/foundations/test_foundations.py::test_polar_extract_config_roundtrip` + `tests/golden/test_polar_foundation.py::test_the_reference_pins_the_electrostatics_and_not_only_the_energy` |
-| `train.fixedpoint_update_config` | `--fixedpoint_update_config` | `mace/tools/arg_parser.py:389` | KEEP — the fixed-point solver settings; the expert electrostatics config section | ⚠️ gap (add a case to `tests/golden/test_polar_foundation.py`) |
-| `train.field_readout_config` | `--field_readout_config` | `mace/tools/arg_parser.py:395` | KEEP — idem | ⚠️ gap (add a case to `tests/golden/test_polar_foundation.py`) |
+| `train.fixedpoint_update_config` | `--fixedpoint_update_config` | `mace/tools/arg_parser.py:389` | KEEP — the fixed-point solver settings; the expert electrostatics config section | `tests/extensions/polar/test_polar_block_configs.py` (the parse, the registry lookup, and the one option inside it that is ignored) |
+| `train.field_readout_config` | `--field_readout_config` | `mace/tools/arg_parser.py:395` | KEEP — idem | `tests/extensions/polar/test_polar_block_configs.py` (idem; unknown keys are discarded rather than refused) |
 
 ### 3.4 Outputs and scaling (8)
 
@@ -421,7 +421,7 @@ Group default: KEEP as the `magnetic`-extra config. Grouped like §3.3, but the 
 | `train.num_mag_radial_basis` | `--num_mag_radial_basis` | `mace/tools/arg_parser.py:1178` | KEEP — idem | `tests/extensions/magnetic` |
 | `train.num_mag_radial_basis_one_body` | `--num_mag_radial_basis_one_body` | `mace/tools/arg_parser.py:1154` | KEEP — idem | `tests/extensions/magnetic` |
 | `train.use_magmom_one_body` | `--use_magmom_one_body` | `mace/tools/arg_parser.py:1184` | KEEP — the one-body magmom term | `tests/golden/test_tiny_magnetic.py::test_the_one_body_magnetic_term_is_inside_the_reference` |
-| `train.train_one_body_contribution` | `--train_one_body_contribution` | `mace/tools/arg_parser.py:1190` | KEEP — whether the one-body coefficients are optimized | ⚠️ gap (add a case to `tests/golden/test_tiny_magnetic.py`) |
+| `train.train_one_body_contribution` | `--train_one_body_contribution` | `mace/tools/arg_parser.py:1190` | KEEP — whether the one-body coefficients are optimized | `tests/golden/test_tiny_magnetic.py::test_not_training_it_requires_freezing_it_first` + `::test_training_the_one_body_term_gives_it_its_own_parameter_group` |
 | `train.data_aug_magmom` | `--data_aug_magmom` | `mace/tools/arg_parser.py:1197` | MERGE — a training-data transform (`Random3DRotation`), not a model flag | `tests/extensions/magnetic` (rotation equivariance) |
 | `train.data_aug_magmom_mode` | `--data_aug_magmom_mode` | `mace/tools/arg_parser.py:1203` | MERGE — selects which spin symmetry the transform draws from (`non-soc` the full O(3), `soc` the sign flip alone), so it travels with `data_aug_magmom` | `tests/extensions/magnetic/test_magmom_augmentation.py::test_non_soc_mode_samples_the_full_o3` |
 

--- a/tests/golden/test_tiny_magnetic.py
+++ b/tests/golden/test_tiny_magnetic.py
@@ -561,3 +561,97 @@ def test_a_joint_rotation_is_a_symmetry_and_a_spin_only_one_is_not(anchor, fixtu
         "architecture has become spin-only invariant and --data_aug_magmom "
         "induces something it already has"
     )
+
+
+# ---------------------------------------------------------------------------
+# --train_one_body_contribution
+# ---------------------------------------------------------------------------
+#
+# The flag decides whether the one-body magnetic coefficients are trained, and
+# it does so in two places that only work together: `run_train` freezes
+# `onebody_magmombasis_coeffs` when the flag is off, and `get_params_options`
+# adds a parameter group for it when the flag is on. Skipping the freeze is not
+# a slower run or a differently-trained model -- `get_params_options` refuses a
+# trainable parameter that belongs to no group -- so the pairing is the contract
+# worth pinning rather than either half.
+
+
+def _params_options(flag, model):
+    from mace.tools import build_default_arg_parser  # noqa: PLC0415
+    from mace.tools.scripts_utils import get_params_options  # noqa: PLC0415
+
+    args = build_default_arg_parser().parse_args(
+        [
+            "--name", "onebody",
+            "--train_file", "train.xyz",
+            "--train_one_body_contribution", flag,
+        ]
+    )
+    return get_params_options(args, model)
+
+
+def _group_names(options):
+    return [group.get("name") for group in options["params"]]
+
+
+@pytest.fixture(name="trainable_anchor")
+def fixture_trainable_anchor():
+    """A fresh anchor, not the module-scoped one.
+
+    These are the only tests here that care about `requires_grad`, and the shared
+    anchor has been through `eval_configs` by the time they run, which freezes
+    every parameter of the model it is handed. Loading one costs a moment and
+    removes the ordering dependency entirely.
+    """
+    model = ms.load_anchor()
+    assert model.onebody_magmombasis_coeffs.requires_grad, (
+        "a freshly loaded anchor should carry trainable one-body coefficients"
+    )
+    return model
+
+
+def test_training_the_one_body_term_gives_it_its_own_parameter_group(
+    trainable_anchor,
+):
+    """Its own group because it takes its own weight decay: the coefficients are
+    a one-body correction, and decaying them toward zero pulls the isolated-atom
+    energies with them."""
+    options = _params_options("True", trainable_anchor)
+
+    assert "onebody_magmombasis_coeffs" in _group_names(options)
+
+
+def test_not_training_it_requires_freezing_it_first(trainable_anchor):
+    """What `run_train` does immediately before building the optimizer, and why.
+    Left trainable and ungrouped, the parameter would silently never be updated,
+    so `get_params_options` refuses instead -- naming the parameter, which is the
+    only reason this is a legible failure rather than a quietly wrong run.
+    """
+    with pytest.raises(ValueError, match="onebody_magmombasis_coeffs"):
+        _params_options("False", trainable_anchor)
+
+
+def test_frozen_it_is_absent_from_the_optimizer_and_nothing_complains(
+    trainable_anchor,
+):
+    """The flag's off state, spelled the way `run_train` spells it."""
+    trainable_anchor.onebody_magmombasis_coeffs.requires_grad_(False)
+
+    options = _params_options("False", trainable_anchor)
+
+    assert "onebody_magmombasis_coeffs" not in _group_names(options)
+
+
+def test_the_flag_defaults_to_training_it(trainable_anchor):
+    """So `--use_magmom_one_body` alone gives a trained one-body term, and the
+    flag exists to hold it fixed -- at a foundation model's values, say."""
+    from mace.tools import build_default_arg_parser  # noqa: PLC0415
+
+    args = build_default_arg_parser().parse_args(
+        ["--name", "onebody", "--train_file", "train.xyz"]
+    )
+
+    assert args.train_one_body_contribution is True
+    assert "onebody_magmombasis_coeffs" in _group_names(
+        _params_options("True", trainable_anchor)
+    )


### PR DESCRIPTION
`--fixedpoint_update_config` and `--field_readout_config` choose which block PolarMACE builds and how. The existing polar tests hand fully-spelled dicts to the constructor, so the path the flags take — parse, registry lookup on `type`, the rest splatted into the block's constructor — was unobserved end to end. The tests follow it through `_build_model`, the call `configure_model` makes.

Two things that path does silently, recorded rather than changed:

- `nonlinearity_cls` is accepted, resolved from a name to a class, and then discarded: `AgnosticEmbeddedOneBodyVariableUpdate._setup` does `_ = (nonlinearity_cls, num_elements)` and builds a `RadialMLP` regardless. This repository's own polar builders pass `MLPNonLinearity` for it. 
- an unknown key is not an error: `OneBodyMLPFieldReadout._setup` takes  `**kwargs` and drops them, so a misspelled option builds the default block  with no warning.

`--train_one_body_contribution` is pinned as the pair of things it is. `run_train` freezes `onebody_magmombasis_coeffs` when the flag is off and `get_params_options` gives it a group when it is on, and skipping the freeze is not a differently trained model: `get_params_options` refuses a trainable parameter belonging to no group, naming it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage of existing CLI/model-build paths; no production code changes.
> 
> **Overview**
> Closes inventory gaps by pinning two PolarMACE config flags and the magnetic one-body training flag, without changing production code.
> 
> `--fixedpoint_update_config` and `--field_readout_config` now go through `_parse_literal_or_none` and `_build_model` (the same path as `configure_model`). The tests cover absent/`None` spellings, dict-literal parse, refusal of non-literals, default blocks, registry `type` lookup, class-name keys, unknown-block `KeyError`, and two silent behaviours: `nonlinearity_cls` is resolved then discarded, and unknown keys are recorded but dropped.
> 
> `--train_one_body_contribution` is pinned as the freeze + optimizer-group pair: on → its own param group; off without freeze → `get_params_options` raises naming `onebody_magmombasis_coeffs`; frozen off is accepted; the flag defaults to training. Inventory rows now point at these tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd9805777270ef659e9b88ef4fa05b1e9fd73df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->