### PR TITLE
Add the Reforge skills and planning docs

### DIFF
--- a/.claude/skills/mace-reforge-backend/SKILL.md
+++ b/.claude/skills/mace-reforge-backend/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: mace-reforge-backend
+description: The MACE Reforge kernel-backend contract - how framework, kernel backend and kernel differ, entry-point registration, torch.library.custom_op requirements, build-time dispatch, the canonical weight layout, the reduced Clebsch-Gordan basis, the conformance suite, and the electrostatics solver analogue. Use when writing or reviewing a kernel, a backend, the dispatch layer, or anything touching weight layout or the CG basis.
+---
+
+# mace-reforge-backend
+
+The op layer. This is a frozen spec - implement it, do not redesign it. If your
+ticket seems to require a change here, flag it on the ticket.
+
+## Three things that must never be conflated
+
+- **Framework** - torch or jax. The tensor type, the autograd, the compiler. It
+  is *which package you installed*, not a runtime choice.
+- **Kernel backend** - a *set* of op implementations *for one framework*:
+  reference, cueq, oeq, yours.
+- **Kernel** - one op implementation: forward, backward, meta.
+
+**A backend is therefore never framework-independent.** Its ops are typed on the
+framework's tensor and register through that framework's autograd. Any design
+that tries to share a kernel across frameworks is wrong at the first line.
+
+`mace_core` owns only what is *data about* the ops: descriptors, `weight_numel`,
+the canonical spec, the Clebsch-Gordan basis, capabilities, and the
+tensor-**generic** Protocol (`Generic[TensorT]`, the same trick as `MACEOutput`).
+Dtypes there are **names** (`Literal["float64", ...]`), never `torch.dtype`,
+because `mace_core` imports no framework.
+
+## Registration and dispatch
+
+- Registration is **per framework**, through entry-point groups
+  `mace.kernel_backends.torch` and `mace.kernel_backends.jax` - the same split
+  `cuequivariance` makes between `cuequivariance_torch` and `cuequivariance_jax`.
+- **The plain-torch reference backend is mandatory and CPU-capable.** Everything
+  else is optional acceleration.
+- **Dispatch resolves once at model build time** and is frozen into the module
+  tree. Nothing is resolved inside `forward`: no dtype check, no device check, no
+  `isinstance`, on the hot path.
+- Capability negotiation is per op: a backend returning `NotImplemented` falls
+  back to the reference **op by op**, not wholesale.
+
+## The hot ops
+
+`linear`, `channelwise_tp_conv`, `symmetric_contraction`, `fully_connected_tp`
+are `torch.library.custom_op` with `register_fake`, each with a **differentiable
+backward** so double-backward (force training) is correct on the reference and a
+hard requirement for any accelerated backend. See `mace-reforge-numerics` for the
+`gradgradcheck` gate.
+
+## Weight layout
+
+- **A canonical weight layout means one checkpoint loads into any backend.**
+  There are no weight-conversion CLIs, and none should be added.
+- Weight conversion happens at the **save/load boundary** and is free.
+- **Activation** layout is resolved once for the whole op chain and is never
+  converted inside `forward`. Those two conversions are different things and only
+  one of them is cheap; conflating them puts a transpose on the hot path.
+
+## The Clebsch-Gordan basis
+
+- **`reduced` is the only value for new training.** A full-basis artifact
+  converts to reduced **at load**, exactly, in fp64.
+- **The basis and the full<->reduced conversion are computed from first
+  principles** - no e3nn, no cuequivariance. Deriving either from a third-party
+  library is the bug this replaced.
+- The **path order and normalization are pinned, and that is the on-disk weight
+  format.** Goldens lock the tensors, not the counts.
+- One basis on every device and every backend. The legacy behaviour - a CLI flag
+  defaulting to off, an environment variable, and whether `cuequivariance`
+  happened to be importable - meant every model defaulted to a roughly 3x
+  over-parametrized symmetric contraction and an explicit request was silently
+  downgraded. A golden pins the parameter count per `(irreps, correlation)` so
+  that coupling cannot come back.
+
+## The conformance suite
+
+Any kernel backend - in-tree or third-party - proves itself against the same
+parametrized suite:
+
+- equivariance
+- parity against the reference
+- `gradcheck` and `gradgradcheck`
+- weight round-trip
+- compiles with no graph break
+- **capability honesty** - what it claims to support is what it supports
+
+A **span factory** (an optional factory that fuses a wider span of the
+interaction layer in one kernel, e.g. conv -> linear -> skip_tp ->
+symmetric_contraction) is negotiated exactly the same way as any single op, and
+runs the same suite.
+
+## The electrostatics solver is the same pattern, one op class over
+
+The long-range/electrostatics solver (k-space or PME, plus an optional SCF fixed
+point) dispatches like any other op class, with its **own registry**: a
+plain-torch reference solver and accelerated libraries behind it. The op is the
+k-space solve, with the SCF loop as an optional span.
+
+**Where the analogy breaks, and it matters:** a bit-parity accelerated solver is
+a free backend choice, but a **non-bit-parity solver is model-affecting state**,
+not a free choice - it has to be recorded as part of the model, because the
+numbers it produces are part of what the model is. Do not treat solver selection
+as interchangeable the way you would treat a `linear` kernel.

--- a/.claude/skills/mace-reforge-goldens/SKILL.md
+++ b/.claude/skills/mace-reforge-goldens/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: mace-reforge-goldens
+description: Work with the MACE Reforge frozen oracle - the committed golden references in tests/golden and the in-process parity suite. Use when adding or reading goldens, choosing a tolerance, debugging a golden or parity mismatch, or when asked to regenerate a reference. Also use before touching anything that changes energies, forces or stress.
+---
+
+# mace-reforge-goldens
+
+The rewrite is measured against committed numbers. `tests/golden/` holds them;
+`tests/parity/` compares the two stacks live, in one process. Nothing in either
+is regenerated as a side effect of another change.
+
+## Layout
+
+```
+harness.py            fixtures, snapshot schema, tolerance table, comparison
+fixtures/             committed .xyz structures + manifest.json
+models/               committed anchor checkpoints + build sidecars
+references/           committed expected-output JSON
+regenerate.py         the only thing allowed to rewrite any of the above
+targets/              one module per family: what regenerating that family means
+docs/                 one page per family: what its goldens pin and why
+surface_scan.py       derives the channel/key schema out of mace/ by AST
+feature_inventory.md  the capability ledger, gated by check_inventory.py
+```
+
+Two structural properties, both of which are load-bearing:
+
+- **A family of goldens owns exactly two files** - a module in `targets/` and a
+  page in `docs/` - and edits no shared list. `regenerate.py` discovers its
+  targets rather than naming them. This is a merge property, not filing
+  preference: the moment two families have to append to one enumeration, every
+  pair of them conflicts. When you add a family, add those two files and touch
+  nothing shared.
+- **`harness.py` imports no framework** - standard library, numpy and ase only.
+  The parity suites that consume it are forbidden from importing the legacy
+  tree, so a single convenience `import torch` here would make the shared
+  comparison machinery useless to the tests it exists for. Two tests enforce it,
+  one by grepping the source and one by importing it in a subprocess with the
+  framework blocked on `sys.meta_path`. Anything framework-specific belongs in
+  the test files or the build scripts.
+
+## Tolerances
+
+**The table in `harness.py` is the single source of truth.** Rows are used
+exactly as `numpy.isclose` does - `|a - b| <= atol + rtol * |b|`, with `b` the
+committed reference:
+
+| Row | atol | rtol | For |
+|---|---|---|---|
+| `FP64_CPU_REFERENCE` | 1e-6 | 0 | fp64 CPU, cross-machine (eV, eV/Angstrom) |
+| `FP64_ACCELERATED_BACKEND` | 1e-5 | 0 | cueq/oeq fp64 vs the reference |
+| `FP32` | 5e-5 | 1e-3 | anything fp32 |
+| `CLOSED_FORM_FP64` | 1e-12 | 1e-12 | closed-form quantities |
+| `EXACT` | 0 | 0 | must reproduce bit for bit |
+
+Pick a row by name; never inline a number in a test. **Tolerances are
+edit-locked**: changing one is a separate, justified, reviewed PR - never part of
+a feature PR, and never the fix for a failing test.
+
+**Bit-exactness holds only within one process, and only with the same gradient
+seeds.** Across processes or against a committed file, compare through the
+harness table. An `EXACT` expectation written against a file will eventually
+fail for reasons that have nothing to do with the change under test.
+
+## When a golden or a parity test fails
+
+**The default assumption is that your change is wrong.** Work through it in this
+order:
+
+1. Reproduce the mismatch and read the actual numbers. A mismatch at 1e-16 and
+   one at 1e-3 are different bugs.
+2. Debug in one process - the legacy package is in the tree and importable
+   alongside `packages/`, so no second venv is needed.
+3. Suspect shared global state before suspecting the physics. `mace/__init__`
+   sets `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD`, and `e3nn.set_optimization_defaults`
+   is process-wide. The parity harness snapshots and restores this state around
+   each comparison, or forks a subprocess per engine where in-process isolation
+   cannot be guaranteed. **Do not "fix" a parity mismatch by silencing that
+   snapshot/restore step** - it is the thing keeping the comparison honest.
+4. If the numbers really do disagree and your implementation is right, you have
+   found a discrepancy in the oracle. Flag it on the ticket. Do not encode a
+   workaround, and do not average the two behaviours.
+
+What is never a fix: widening a tolerance, regenerating the reference, marking
+the test xfail, or adding a dtype cast that happens to make the numbers line up.
+
+## The oracle is internally inconsistent about dtype - pin both sides
+
+In `mace/modules/models.py`, total energy is computed in the model's own dtype
+while node energy is computed unconditionally in fp64. Total energy and node
+energy are therefore pinned as **separate goldens, in both fp32 and fp64, and
+separately for `MACE` and `ScaleShiftMACE`** - those two differ in whether the
+ZBL/pair-repulsion term falls inside or outside the scale-shift, so their
+goldens diverge on the same structure.
+
+Do not resolve this by picking one dtype policy for both quantities. Reproduce
+the split. Where `PrecisionConfig` needs a dtype decision here, make it
+per-quantity, not a global default.
+
+## Regenerating a reference
+
+Only through `tests/golden/regenerate.py`, only in a **dedicated PR**, with a
+physics justification in the description. Never inside a feature PR. The
+committed fixtures, checkpoints and reference JSON are the contract the whole
+rewrite is measured against; they travel with the repository on purpose (the
+`.gitignore` patterns for `*.xyz`, `*.model` and `*.pt` carry explicit negations
+for them), and a golden that changes quietly is worse than no golden.

--- a/.claude/skills/mace-reforge-numerics/SKILL.md
+++ b/.claude/skills/mace-reforge-numerics/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: mace-reforge-numerics
+description: Physics and numerics guardrails for MACE Reforge - units, force/stress/virial sign and Voigt conventions, equivariance tests, double-backward requirements for force training, per-op-class precision, determinism, and the capability-marker contract for GPU tests. Use when writing or reviewing anything that computes energies, forces, stress, dipoles, a derivative, or a kernel.
+---
+
+# mace-reforge-numerics
+
+The rules that keep the rewrite physically correct. Companion to
+`mace-reforge-goldens`, which covers how the numbers are pinned.
+
+## Units and conventions
+
+- **Units are eV and Angstrom.** Align constants with `ase.units`; use the
+  package's own units module where one exists rather than a local constant.
+- **forces = -dE/d(positions)**
+- **stress = (1/V) dE/d(strain)**
+- **virials = -stress * V**
+
+Sign and Voigt conventions are pinned by committed tests. **Read those tests'
+docstrings before touching any derivative path** - a sign or an ordering error
+here reproduces perfectly on your machine and destroys an MD run three months
+later.
+
+State units, shapes and conventions in the docstring of every function that
+returns a physical quantity. A shape comment is not optional documentation here;
+it is the only thing standing between a `[n_atoms, 3]` and a `[3, n_atoms]`.
+
+## Equivariance is a test, not an argument
+
+Every new block or model needs rotation, translation and permutation tests:
+rotate the inputs and the outputs must rotate accordingly; energies must be
+invariant. A block that is equivariant by construction still gets the test - the
+test is what catches the layout bug that construction cannot.
+
+## Double-backward is not optional
+
+Force training backpropagates through the forces (`create_graph=True`), so
+**every kernel op - reference or accelerated - needs a differentiable backward.**
+
+- `gradgradcheck` is the gate. An op that does not pass it is not done.
+- A backend that cannot support it must declare `supports_double_backward=False`
+  and is then **rejected at build time** for force training. It is never silently
+  wrong at runtime.
+- This applies to the plain reference implementation too. "It is only the
+  reference path" is not an exemption; the reference is what everything else is
+  compared against.
+
+## Precision
+
+- **No global AMP.** Dtype is assigned per op class through `PrecisionConfig`.
+- Linear layers may run in low precision; radial and cutoff ops high;
+  **reductions and scatter at the highest precision** - that is an MD-stability
+  requirement, not a preference.
+- When in doubt about a dtype, it becomes a `PrecisionConfig` decision, not a
+  hardcoded cast at the call site.
+- **fp32 results depend on the thread count and the reduction order.** Never pin
+  an fp32 expectation tightly, and never compare an fp32 number produced on one
+  machine against one produced on another outside the `FP32` tolerance row.
+
+## Determinism in tests
+
+Fixed seeds. No dependence on wall-clock time or on the network outside tests
+marked `network`. Where a reduction order is not deterministic and the test needs
+it to be, make that explicit in the test rather than hoping.
+
+## The capability-marker contract
+
+Markers (`gpu`, `cueq`, `oeq`, `polar`, `les`, `torchsim`, `schedulefree`,
+`network`, `bin_lammps`) are enforced by `tests/conftest.py`: a missing
+capability **skips** locally, but a CI job that exports `MACE_REQUIRE_CAPS`
+**fails** when a capability it guarantees is broken. `--strict-markers` is on, so
+a typo in a marker name is an error rather than a silently unmarked test.
+
+Two things about that guard that are easy to get wrong:
+
+- It counts **collected** tests, not **selected** ones - it runs before the mark
+  expression deselects. So listing a capability that the job's `-m` expression
+  cannot reach is an empty promise the harness will not catch.
+- Directory-derived markers are added automatically during collection. Put a
+  test in the directory that matches its requirements instead of hand-marking it.
+
+## GPU tests and vendor selection
+
+- **Tests always write `device="cuda"`**, which is valid on ROCm - torch's ROCm
+  build keeps the CUDA API names. Do not branch on a vendor inside test code,
+  and do not write a device string per vendor.
+- **Vendor selection happens in the marker expression**, per runner: the Nvidia
+  tier runs `-m gpu`, the AMD tier runs `-m "gpu and not cueq"` because
+  cuEquivariance is CUDA-only. OpenEquivariance is the AMD-capable accelerated
+  backend.
+- A capability is listed for a job only where the marker expression can actually
+  reach a test for it.
+
+If your ticket carries the `gpu` label, either run the selection on a GPU host or
+say in the PR that you are relying on GPU CI. A CPU-only run is not verification
+of a GPU ticket.

--- a/.claude/skills/mace-reforge-ticket/SKILL.md
+++ b/.claude/skills/mace-reforge-ticket/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: mace-reforge-ticket
+description: Take a MACE Reforge board ticket from start to a reviewable PR - session ritual, branch naming, scope discipline, the pre-PR verification commands for both toolchains, the feature-inventory gate, deletion-only RET tickets, and the review gate. Use when starting, implementing, or wrapping up work on a reforge ticket.
+---
+
+# mace-reforge-ticket
+
+Procedure for one reforge ticket. The rules it depends on are in
+`mace-reforge`; read that first.
+
+## Session ritual
+
+1. Read the ticket on the board (<https://github.com/orgs/ACEsuit/projects/2>).
+2. Read the files the ticket names. The ticket ID resolves to a GitHub issue in
+   `ACEsuit/mace` - work from the issue, since that is where discussion lands.
+3. **Restate the acceptance criteria in your own words before writing any code.**
+   If restating them exposes an ambiguity, resolve it on the ticket, not in the
+   implementation.
+4. Check that the ticket's dependencies are merged. If they are not, say so and
+   stop - a ticket built on an unmerged dependency produces a PR nobody can review.
+
+Where a new file goes is answered by `docs/reforge/target_layout.md`, and which
+gate the ticket sits behind by `docs/reforge/plan.md` §4 - consult them rather
+than inferring a location from the surrounding code.
+
+Never skip step 3. It is the step that makes two people implementing the same
+ticket produce comparable work.
+
+## One ticket, one PR
+
+```
+branch: reforge/<TICKET-ID>-<slug>      e.g. reforge/inf-3-import-guard
+base:   mace-reforge                   (the integration branch, cut from develop)
+```
+
+Ticket PRs target **`mace-reforge` on `ACEsuit/mace`**, not `develop` - the
+rewrite integrates on that branch and reaches `develop` as its own reviewed step.
+Push the work branch wherever you normally push (your fork or upstream); the PR
+base is what matters.
+
+Before branching, make sure your `mace-reforge` is current: `git pull upstream
+mace-reforge`. Branching from a local copy that is weeks behind produces a PR
+whose diff contains other people's already-merged work.
+
+- **The out-of-scope section is binding.** If the ticket turns out bigger than
+  its `Size` label, propose a split on the ticket. Do not silently expand scope,
+  and do not fold in an unrelated fix you noticed along the way.
+- **A tolerance change is never part of a feature PR.** Same for regenerating a
+  golden reference, and for reformatting anything under `mace/`.
+- **`RET-*` tickets are deletion-only.** Zero new v1 logic: the PR removes a
+  piece of `mace/` and degrades its parity test to a frozen golden, once the v1
+  counterpart has full parity. Nothing else changes in the same PR.
+- **If the ticket implements v0.3 functionality, flip its rows in the feature
+  inventory in the same PR** - `tests/golden/feature_inventory.md`, gated by
+  `tests/golden/check_inventory.py`. Phase gates audit that file, so a PR that
+  implements a capability and leaves its row `todo` fails the gate later, far
+  from the cause.
+
+## Before opening the PR
+
+Both toolchains, then the tests that can catch a behaviour change:
+
+```bash
+pre-commit run --all-files                                  # legacy toolchain, mace/**
+prek run --all-files                                        # new toolchain, packages/**
+python -m pytest packages/*/tests tests/architecture         # fast
+python -m pytest tests/golden -m "not slow"                  # the committed numbers
+python -m pytest tests/parity -m "not slow"                  # the live oracle
+python -m pytest tests/unit -m "not slow" -n auto            # legacy suite still green
+```
+
+The new toolchain expands to `ruff check packages/ && ruff format --check
+packages/ && ty check packages/` if you would rather run it directly. Skip the
+suites whose directories do not exist yet on your branch, and say which ones you
+skipped rather than reporting a clean run.
+
+Two traps in the legacy toolchain, both of which read as a false pass locally:
+
+- pylint's cyclic-import check (`R0401`) is hidden by pre-commit's concurrency.
+  Reproduce what CI sees with `PRE_COMMIT_NO_CONCURRENCY=1 pre-commit run --all-files`.
+- `tests/` is excluded from formatting and lint by both pre-commit and CI, so
+  test files are not auto-formatted and a lint pass says nothing about them.
+
+**A GPU-marked ticket needs a GPU.** Either run the `-m gpu` selection on a GPU
+host, or state in the PR description that you are relying on the GPU CI
+workflow. Do not report a GPU ticket as verified from a CPU-only run.
+
+## Reproducing a CI job locally
+
+CI has no shell scripts: every test job runs through the
+`.github/actions/run-tests` composite action, and its inputs (`tests`,
+`markers`, `require-caps`, `allow-network`, `splits`, `coverage`) map 1:1 to
+pytest flags. A job's `with:` block **is** its local reproduction recipe - read
+it instead of guessing the command.
+
+## Review
+
+- Every PR is reviewed before merge. Numerics and physics changes need a
+  reviewer with physics expertise; infra, CI and packaging changes need one
+  comfortable with the tooling.
+- When the ticket carries a **Review focus**, that focus is the merge gate.
+  Address it explicitly in the PR description.
+- Write the PR description so it can be reviewed without the ticket open:
+  what behaviour is pinned, what was verified, what was deliberately left out.

--- a/.claude/skills/mace-reforge/SKILL.md
+++ b/.claude/skills/mace-reforge/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: mace-reforge
+description: Shared working context for the MACE Reforge rewrite (MACE v1.0). Use whenever the task touches the rewrite - any ticket from the reforge board, anything under packages/, the frozen legacy mace/ package, the golden or parity test suites, or a design question about the new architecture. Load this before writing code for a reforge ticket.
+---
+
+# mace-reforge
+
+The MACE v1.0 rewrite. This skill carries the rules every reforge change must
+follow, so that work done by different people converges. Load it first; the
+companion skills below carry the procedures.
+
+| Companion skill | Use it for |
+|---|---|
+| `mace-reforge-ticket` | Taking a board ticket to a merged PR: branch, scope, verification, review gate |
+| `mace-reforge-goldens` | The frozen oracle: golden/parity tests, tolerances, debugging a mismatch |
+| `mace-reforge-numerics` | Units, sign conventions, equivariance, double-backward, precision |
+| `mace-reforge-backend` | Kernel backends, dispatch, canonical weights, Clebsch-Gordan basis |
+
+## Where the work comes from
+
+Tickets live on the **reforge board**: <https://github.com/orgs/ACEsuit/projects/2>
+(68 items, GitHub issues in `ACEsuit/mace`). Fields are `Status`
+(Todo -> In Progress -> PR Open -> Closed), `Phase`, `Size`, `Area`, plus flag
+labels (`gpu`, `network`, `numerics-critical`, `critical path`).
+
+**Ticket bodies are self-contained by design** - a ticket states its context,
+its acceptance criteria and its out-of-scope boundary, and is implementable
+without opening anything else. Work only on tickets whose dependencies are
+merged; the ticket names them.
+
+Two planning documents are in the repository, for when you want the reasoning
+behind a rule rather than the rule itself:
+
+- **`docs/reforge/plan.md`** - the execution plan: the transition strategy, the
+  five hard rules, the phases and their exit gates, the backend/kernel layer,
+  the risk register, and a ticket index mapping every ID to its issue.
+- **`docs/reforge/target_layout.md`** - the destination tree: where each piece
+  ends up, module by module. Read this before deciding where a new file goes.
+
+`docs/reforge/extending_mace.md` and `extending_plugin.md` cover the extension
+surface, and `run_train_rewrite.md` the training-entry-point rewrite.
+
+The **RFCs** are not in the repository: they are internal decision records, and
+their decisions are inlined into the tickets they block. So a ticket is the
+authority on what to build, and its RFC is not something to go looking for. If a
+ticket genuinely does not determine what to build, say so on the ticket rather
+than improvising a design.
+
+## The repository holds two stacks at once
+
+The rewrite is developed on the **`mace-reforge`** branch, cut from `develop`.
+There is one state of that branch, not a before and after:
+
+`mace/` is frozen **here**, not on `develop`. `develop` carries on taking v0.3
+bug fixes and self-contained features, and whatever is new there is migrated
+into v1 before the branches merge. So a fix you see on `develop` is not a fix
+this branch is missing; it is a fix the migration owes v1.
+
+```
+mace/              Legacy v0.3.x. BYTE-FROZEN on this branch. The live differential
+                   oracle. Never edited here; never imported by packages/.
+packages/
+  mace-core/       Framework-agnostic: types, config, observables, kernel Protocol,
+                   Clebsch-Gordan, neighbours, data spec. Imports no torch, no jax.
+  mace-torch/      The new PyTorch implementation. Depends on mace-core.
+  mace-jax/        Inference-only JAX. Depends on mace-core.
+  mace-launcher/   ~50 LOC. Owns the console entry points; dispatches on --engine {legacy,v1}.
+tests/
+  golden/          Committed fixtures, reference JSON, tiny checkpoints. Edit-locked.
+  parity/          In-process legacy-vs-v1 comparison. Double-import allowlisted.
+  architecture/    Fitness functions and the import-direction contract.
+docs/reforge/      The execution plan and the target layout.
+```
+
+Check the tree before relying on a path: `tests/golden/` landed with Phase 0,
+while `packages/`, `tests/parity/` and `tests/architecture/` are created by
+their own Phase 1 tickets. This skill deliberately records **no** phase or
+ticket status - that state lives on the board, which is always current.
+
+## The five hard rules
+
+- **R1 - Import direction.** `packages/` never imports `mace/`; `mace/` is never
+  edited to import `packages/`. Enforced statically by import-linter and at
+  runtime by an audit hook that catches dynamic `importlib` reach-in. Exactly two
+  places are allowlisted for double import: the launcher's dispatch module and
+  `tests/parity/`.
+- **R2 - Legacy is spec, not source.** The frozen `mace/` answers "what must the
+  numbers be", never "how should the code look". Do not copy legacy code into
+  `packages/`. A meta-lint asserts no file under `packages/` names a legacy class
+  (`ScaleShiftMACE`, `interaction_classes`, `AtomicData`, ...).
+- **R3 - `mace_core` purity.** It imports no torch, no jax, no e3nn, and no
+  sibling package. A test asserts it. Dtypes there are **names**
+  (`Literal["float64", ...]`), never `torch.dtype`.
+- **R4 - Spec-first.** Implement a frozen spec. If your ticket's design is not
+  settled, stop and flag it on the ticket. Do not improvise, not even
+  provisionally.
+- **R5 - The oracle never moves.** `mace/` is byte-frozen and the goldens are
+  edit-locked. A tolerance change is its own PR, never bundled with a feature.
+
+## Rebuild, do not port
+
+Start from the pinned behaviour and write the simplest implementation that
+reproduces it. If you find yourself translating legacy code line by line -
+abstractions, class hierarchy, parameter plumbing and all - you are doing it
+wrong. When a legacy mechanism and a simpler one produce the same pinned
+numbers, the simpler one wins.
+
+Corollary: **breaking changes are fine, silent behaviour changes are not.**
+Code and checkpoint compatibility are explicitly not preserved; a v0.3
+checkpoint enters the new architecture through an explicit converter. But if
+your implementation produces different numbers than the golden reference,
+either it is wrong or you found a real discrepancy worth flagging. Never widen
+a tolerance to make a test pass.
+
+## Conventions for every line written under `packages/`
+
+- **Descriptive names, no math shorthand.** `sender_node_features`, not `x_s`;
+  `edge_radial_embedding`, not `R_ij`. Put the paper symbol in the docstring.
+- **Typed, structured I/O.** Dataclass/Pydantic objects across public
+  boundaries; never a raw dict. Models return `MACEOutput`, with `extras` as the
+  only escape hatch.
+- **Pure functions; pass the model explicitly.** No closures that capture and
+  hide the model.
+- **Do not over-abstract.** Three similar concrete functions beat one
+  configurable god-function; duplicating a pipeline is acceptable when it avoids
+  a framework. An abstraction added "for the future" should be deleted.
+- **TorchScript is banned under `packages/`.** No `@torch.jit.script`, no
+  `torch.jit.annotate`, no scripting-driven type contortions. `torch.compile`
+  first, with eager as the always-working reference path.
+- **JAX is inference-only.** Do not add training code to `mace_jax`.
+- **Docstrings state units, shapes and conventions.** Error messages name the
+  offending key or value and the fix.
+- **Comments state constraints the code cannot** - units, conventions, why a
+  seam exists - not narration.
+
+**Path-scoped dual toolchain.** `mace/**` keeps black + isort + pylint + mypy
+(`pre-commit run --all-files`) and is **never reformatted**, even where a diff
+would look cleaner - that toolchain is permanent for the frozen tree, not
+transitional. `packages/**` uses ruff (lint + format) + `ty`, run through
+`prek`. A meta-lint asserts 1:1 file ownership, so no file falls between them.
+
+## Target architecture, in one screen
+
+- **Two layers.** `BaseMACE` is the equivariant backbone: a learned descriptor,
+  node features in, node features out, no readouts and no gradient calls.
+  `MACEOutputs` holds everything learnable beyond it - heads, readouts,
+  normalization including readout-only E0s, typed output construction. New
+  observables and heads are added there, driven by config.
+- **Two-phase forward.** Forces and stress are computed by a derivative engine
+  *around* the model call, never inside a module forward, so `torch.compile`
+  sees no `autograd.grad` graph break. The strain displacement still has to be
+  injected before edge vectors are computed; that seam is designed in its own
+  ticket.
+- **Declarative observables.** Any atomic or total spherical-tensor property is
+  declared in config (name, irreps, per-atom flag, units, normalization) and
+  becomes trainable with no new code: spec -> automatic head -> automatic loss
+  term. Derivatives are auto-named (`d_<q>_d_pos`; `energy` special-cases to
+  `forces`/`stress`). Declaring a property absent from the data is a hard error.
+- **Staged training.** `DataStage -> ModelStage -> TrainStage` with typed
+  boundary objects; an argparse namespace never crosses a stage boundary. The
+  loop is explicit and short - no Lightning, no callback framework.
+- **Config.** Pydantic(-settings), TOML/YAML/JSON, config-file-first with dotted
+  CLI overrides, unknown keys are errors. The fully resolved config is saved into
+  model metadata. CLI is hierarchical: `mace train / eval / model / data / export`.
+- **Precision.** No global AMP. A `PrecisionConfig` assigns dtypes per op class.
+- **Data.** Format-agnostic protocol in `mace_core` with pluggable backends
+  (XYZ, HDF5, LMDB); padded/static-shape neighbour lists for compiled paths. No
+  vendored `torch_geometric`.
+- **e3nn and e3nn-jax are removed entirely** - not a dependency, not even an
+  optional backend. Reference backends are plain torch and plain jax.
+
+## Vocabulary used by the tickets
+
+| Term | Meaning |
+|---|---|
+| Frozen oracle | The in-tree `mace/`: byte-frozen, the source of truth for what the numbers must be |
+| Live parity harness | `tests/parity/` - in-process legacy-vs-v1 comparison, run continuously |
+| Launcher / `--engine` | `mace_launcher`, owns the console entry points; `--engine {legacy,v1}` picks the stack |
+| Deletion-only PR (`RET-*`) | Removes a piece of `mace/` once its v1 counterpart has parity. Zero new v1 logic |
+| Debt book | Dated ledger of every legacy commitment still owed a v1 replacement |
+| Span factory | Optional backend factory fusing a wider span of the interaction layer in one kernel |
+| Conformance suite | The parametrized suite any kernel backend runs to prove itself |
+| Parity anchor | The committed tiny `ScaleShiftMACE` checkpoint the new architecture must reproduce |
+| Keystone gate | The exit test that the tiny checkpoint converts and matches its goldens at fp64, and matches the live legacy model in-process |
+| Capability marker | pytest marker (`gpu`, `cueq`, `network`, ...): skip locally, fail in CI jobs that guarantee it |
+| `prek` / `ty` | Pre-commit-style runner / type checker, used by the new stack only |
+| Merge back | When the rewrite finishes, what is new on `develop` is migrated into v1, then `mace-reforge` merges into `develop` and `develop` into `main` for the v1 release |

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ htmlcov/
 
 # local planning docs (not for the public repo)
 /doc
+
+# Claude Code: the shared skills under .claude/ are tracked; per-machine
+# settings and tool approvals are not.
+.claude/settings.local.json

--- a/docs/reforge/extending_mace.md
+++ b/docs/reforge/extending_mace.md
@@ -1,0 +1,398 @@
+# Extending MACE — a complete worked example
+
+The [target layout §3](target_layout.md) lists the extension points and the "spectrum" (config knob →
+observable row → registered plugin → new model). This doc is the other half: **one end-to-end
+example of a genuinely complex feature**, walked change-by-change, so you can see how the pieces
+compose and exactly which of them are config vs code.
+
+**Three ways to ship a feature.** All three use the *same* registries and the *same* `config.toml`;
+they differ only in where the code lives and who releases it:
+
+- **Built-in** — in the main `mace-torch` tree, part of the default install and the default model.
+- **In-tree extra** — in the MACE monorepo under `extras/<name>/`, optional and installed on demand
+  (`mace[<name>]`), gated by a capability marker. Ships and is maintained with MACE.
+- **External plugin** — a separate `pip`-installable package that hooks in through entry points, with
+  no changes to the MACE repo; released on its own cadence. Its own doc:
+  [Extending via a plugin](extending_plugin.md).
+
+This example is built as an **extra** (which is exactly how `#1244` ships it today); the final section
+shows the **built-in** variant, and the plugin doc shows it out-of-tree.
+
+The running example is the real `MagneticMACE` family (`#1244`): the model takes per-atom magnetic
+moments as a **vector input**, outputs their conjugate **magnetic forces** `−dE/dmagmom`, augments
+training by randomly rotating the magmom field, and ships an **SCF inference wrapper** that relaxes the
+moments to equilibrium. It deliberately touches every layer:
+
+| Change | Layer | Config or code? |
+|---|---|---|
+| 1. New **input** (per-atom `magmom`, a 3-vector) | graph input | registered embedding (spherical harmonics + radial) |
+| 2. New **derivative observable** (magnetic forces `−dE/dmagmom`, a `1o` vector) | observable table | **config only** |
+| 3. **Data augmentation** (SO(3) rotation of `magmom`) | transform registry | small registered module |
+| 4. **Loss** for `magforces` | loss config | **config only** |
+| 5. **Models** (`MagneticScaleShiftMACE` + the SCF inference wrapper) | model registry | registered models |
+| 6. **Calculator** exposure + the `[magnetic]` extra | deployment | small |
+
+As an extra (`mace[magnetic]`), all of its code lives together under one feature directory
+(`mace_torch/extras/magnetic/`) and **nothing here touches a shared MACE file** — each change is a
+config field, a registry decorator, or an entry point. Everything below is illustrative — the
+`packages/` tree is future work — but every mechanism, and the feature it describes, is the real one.
+
+---
+
+## 1. A new input feature — `magmom` per atom
+
+Per-atom and per-graph inputs are declared, not hardcoded. `magmom` is a per-atom **vector** `[n, 3]`.
+It does not enter as a raw number: a registered embedding expands it into **spherical-harmonic node
+attributes** (its direction) plus a **radial embedding of its magnitude** (an invariant), which the
+interaction blocks then tensor-product into the node features.
+
+```python
+# mace_torch/extras/magnetic/embedding.py  — lives in the extra, registered by decorator
+import sphericart.torch                                  # the [magnetic] extra's dependency
+from mace_torch.nn import register_input_embedding
+
+@register_input_embedding("magmom")
+class MagmomEmbedding(torch.nn.Module):
+    """Per-atom magmom vector [n, 3] -> (angular node attrs, invariant node feats)."""
+    def __init__(self, max_ell: int, num_radial: int):
+        super().__init__()
+        self.sph = sphericart.torch.SolidHarmonics(max_ell)   # direction -> Y_l  (l=1 is 1o)
+        self.radial = ChebyshevBasis(num_radial)              # |magmom| -> {num_radial}x0e
+
+    def forward(self, magmom):                     # magmom: [n_nodes, 3]
+        node_attrs = self.sph(magmom)              # spherical-harmonics irreps (1o + 2e + …)
+        node_feats = self.radial(magmom.norm(dim=-1, keepdim=True))
+        return node_attrs, node_feats              # wired into the interaction tensor product
+```
+
+```toml
+# config.toml (the training run config) — declare the input; the data-key convention names its source
+[data.inputs]
+magmom = { key = "REF_magmom", per_atom = true, irreps = "1o" }
+```
+
+No shared-file changes: the model reads `config.data.inputs`, finds `magmom`, and wires
+`MagmomEmbedding`. The magmom vector is expanded through spherical harmonics, so its `l=1` part is
+**`1o`** (odd parity) — the model treats it as a polar vector, which is why energy is invariant only
+under a *joint* rotation/inversion of positions **and** moments, not moments alone.
+
+A per-system input (total charge, spin, electronic temperature) uses the same recipe — only the
+`per_atom` flag changes: `true` folds into node features, `false` into the graph-level features.
+
+## 2. The derived output — magnetic forces `−dE/dmagmom` (config only)
+
+The magnetic model does **not** read out a magnetic moment: its only readout is **energy** (invariant
+scalars). The magnetic output is the moment's **conjugate force**, `magforces = −dE/dmagmom`, obtained
+by autograd exactly like `forces = −dE/dpositions`. It is a per-atom `1o` vector, declared as a
+derivative observable:
+
+```yaml
+# mace_torch/extras/magnetic/observables.yaml  — the extra ships its own observable rows
+magforces:
+  derivation: "autograd(energy, wrt=magmom)"   # -dE/dmagmom
+  per_atom: true
+  irreps: "1o"                                  # a 3-vector, same convention as magmom
+  default_loss_weight: 1.0
+```
+
+```toml
+# config.toml
+[model]
+observables = ["energy", "forces", "stress", "magforces"]
+```
+
+The derivative engine already differentiates energy w.r.t. positions and strain; adding `magmom` as a
+target is the same machinery (legacy `--compute_magforces`). **Zero code.** Declaring an observable
+with no matching data key is a hard error.
+
+### Illustrative: an equivariant moment readout (not in `#1244`)
+
+`#1244` predicts **no** magnetic moment — its magnetic output is `magforces` above. But an equivariant
+readout is a one-row change in the observable table, so here is what a *predicted* moment would look
+like. **This block is illustrative** — it is not in the current implementation; it is shown only to
+demonstrate the readout mechanism.
+
+```yaml
+# mace_torch/extras/magnetic/observables.yaml  — illustrative, NOT in #1244
+magnetic_moment:
+  derivation: readout        # a learned equivariant readout over node features
+  per_atom: true
+  irreps: "1o"               # same convention as the magmom input
+  normalization: "component" # scale-only; a 1o vector can be scaled but not shifted
+  default_loss_weight: 1.0
+```
+
+```toml
+# config.toml  — illustrative
+[model]
+observables = ["energy", "forces", "stress", "magforces", "magnetic_moment"]
+```
+
+`MACEOutputs` would build the equivariant `1o` readout head automatically; the result appears as
+`output.extras["magnetic_moment"]`. **Zero code** — the head, its typed output, its `normalization`
+and its loss term are all derived from this one row. (`normalization` is a user knob: a non-scalar like
+`1o` can be scaled but not shifted; only scalars such as energy take the classic **scale-shift**.) That
+is the payoff of the declarative table: a genuinely new *predicted* property is a row, not a model
+change.
+
+## 3. Data augmentation — random SO(3) rotation of `magmom` (a registered transform)
+
+Magnetic training augments by randomly rotating the **magmom field alone** — positions are held. It
+samples magmom orientations; it is a magmom-space augmentation, not a whole-system rotation. This is a
+**data transform**, not model code:
+
+```python
+# mace_torch/extras/magnetic/transforms.py
+from mace_torch.data import register_transform
+
+@register_transform("rotate_magmom")
+class RotateMagmom:
+    """One random SO(3) rotation of the magmom field (and its magforces); positions unchanged."""
+    def __call__(self, config, rng):
+        R = random_rotation(rng)                       # a proper rotation
+        config.magmom = config.magmom @ R.T
+        if config.magforces is not None:
+            config.magforces = config.magforces @ R.T  # the label rotates with its input
+        return config
+```
+
+```toml
+# config.toml
+[data]
+transforms = ["rotate_magmom"]     # legacy --data_aug_magmom
+```
+
+## 4. Loss — a term for `magforces` (config only)
+
+Because `magforces` is a declared observable, its loss term is **generated automatically** with its
+`default_loss_weight`; you only override the weights in config. Tuning the loss is never new code:
+
+```toml
+# config.toml
+[loss]
+weights = { energy = 1.0, forces = 10.0, magforces = 1.0 }
+```
+
+**Loss hyperparameters are config too**, not a new loss. A common case is *not* writing a new reduction
+but tuning one — e.g. switching to a Huber loss and setting its `huber_delta` (already supported today
+via `--huber_delta`). In the reforge that is a per-loss `params` block:
+
+```toml
+# config.toml
+[loss]
+weights = { energy = 1.0, forces = 10.0, magforces = 1.0 }
+type    = "huber"
+params  = { huber_delta = 0.02 }      # a loss hyperparameter — config, not code
+```
+
+Only a genuinely new *reduction* (say a custom magnetic-anisotropy penalty) is code — one
+`@register_loss` module selected by `LossConfig(name=...)`. Re-weighting and re-tuning existing losses,
+as above, need none.
+
+## 5. The models — the magmom channel is real code
+
+Everything so far is config plus two small registered modules. The models themselves are the code:
+
+```python
+# mace_torch/extras/magnetic/model.py
+from mace_torch.models import BaseMACE, register_model
+
+@register_model("MagneticScaleShiftMACE")
+class MagneticScaleShiftMACE(BaseMACE):
+    """Energy model with the magmom input channel; energy readout + magforces = -dE/dmagmom.
+    The magmom tensor-product channel is model code, not a readout row — the honest boundary."""
+    def forward(self, graph):
+        ...
+
+@register_model("MagneticSCFMACE")
+class MagneticSCFMACE(torch.nn.Module):
+    """Inference wrapper: relax magmom with LBFGS until magforce ~ 0, then report the energy and the
+    equilibrated moments. It deliberately does NOT differentiate through the loop — it is an eval-time
+    equilibration convenience, not a training-time implicit-diff hook."""
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+    def forward(self, graph):
+        magmom = graph["magmom"].requires_grad_(True)
+        # optimizer = torch.optim.LBFGS([magmom]); step(closure) with magmom.grad = -magforces
+        ...
+```
+
+```toml
+# config.toml
+[model]
+model = "MagneticScaleShiftMACE"       # the trainable model
+# MagneticSCFMACE wraps it for inference-time equilibration; it is not a training transform
+```
+
+`MagneticScaleShiftMACE` is a real `BaseMACE` subclass — the magmom channel lives in the forward, so it
+is genuine model code, unlike the config rows above. `MagneticSCFMACE` is a thin **inference wrapper**;
+because it is not differentiated through, it needs no implicit-diff contract. Both are **registered,
+not patched** — no shared-file changes. (If a variant needed an accelerated long-range solver, that
+would be a swappable **electrostatics backend** with its own entry-point registry — the model never
+selects it.)
+
+## 6. Running it: calculator, packaging, tests
+
+The feature is trainable at this point. Three last pieces make it usable and safe, each following an
+existing pattern.
+
+### 6.1 Using it in a calculator (no code)
+
+The ASE calculator reads the observable table for what each output is (per-atom vs per-graph), so it
+returns the magnetic outputs by name with nothing to wire:
+
+```python
+# a user script (ASE) — nothing in the package changes
+atoms.calc = MACECalculator("my_magnetic_model.model")
+atoms.get_potential_energy()                 # energy
+atoms.arrays["MACE_magmoms"]                 # equilibrated moments (from the SCF wrapper)
+atoms.arrays["magforces"]                    # -dE/dmagmom
+```
+
+### 6.2 Packaging the extra
+
+Packaging the magnetic extra is three coordinated places. Magnetic needs a fast spherical-harmonics
+library (**`sphericart-torch`**, used by the embedding in §1), so that dependency goes in the optional
+group; a feature with no such dependency just leaves the group's requirement list empty.
+
+**(a) Declare the optional dependency group** in the package's `pyproject.toml`. The extra is named
+after the **whole capability**, not the library — `[magnetic]` gates the entire magnetic feature:
+
+```toml
+# packages/mace-torch/pyproject.toml
+[project.optional-dependencies]
+magnetic = ["sphericart-torch==1.0.9", "torch-geometric"]   # NOT in [project.dependencies]
+```
+
+```bash
+pip install mace-torch              # base: no sphericart → the magnetic feature is not available
+pip install mace-torch[magnetic]    # opt in: deps present → the whole magnetic capability turns on
+```
+
+**(b) The guard lives in the feature's own module, not in a shared file.** This block sits in the
+magnetic feature's **own** `__init__.py`, and MACE reaches it through the `mace.plugins` entry point,
+never by naming `magnetic`. So registration and the dependency check are both local to the feature:
+
+```python
+# mace_torch/extras/magnetic/__init__.py   (or a separate mace-magnetic package)
+try:
+    import sphericart.torch
+except ImportError:
+    HAVE_MAGNETIC = False        # dep missing → this module registers nothing; MACE is untouched
+else:
+    HAVE_MAGNETIC = True
+    register_model("MagneticScaleShiftMACE")(MagneticScaleShiftMACE)
+    register_model("MagneticSCFMACE")(MagneticSCFMACE)
+    register_transform("rotate_magmom")(RotateMagmom)
+    # ... and the magforces observable row
+```
+
+```toml
+# this feature's OWN pyproject.toml — an entry point, NOT an edit to a shared file
+[project.entry-points."mace.plugins"]
+magnetic = "mace_torch.extras.magnetic"     # MACE imports this on discovery → its decorators run
+```
+
+MACE enumerates `mace.plugins` and imports whatever is installed; the loader tolerates a module that
+registers nothing. There is **no `if magnetic` branch anywhere in MACE**: install the extra → deps
+present → the module registers on discovery; skip it → nothing registers and
+`model = "MagneticScaleShiftMACE"` fails fast with "unknown model".
+
+**(c) Gate the tests on a capability marker** so they *skip* where the extra is absent and are
+*required* where it is (the skip-o-fail contract), so a broken-but-installed extra fails CI instead of
+silently skipping:
+
+```python
+# tests/extensions/magnetic/test_magnetic.py
+@pytest.mark.magnetic     # capability marker (requires sphericart-torch), auto-added from the dir
+def test_magforces_golden(): ...
+```
+
+**The whole extra lives in one directory.** Every file the magnetic feature owns — the embedding (§1),
+its observable row (§2), the transform (§3) and the models (§5) — sits under a single feature
+directory, wired by the `__init__.py` above:
+
+```text
+mace_torch/extras/magnetic/          # everything the feature owns lives here
+├── __init__.py                      # the registration entry point (the mace.plugins target)
+├── embedding.py                     # MagmomEmbedding             (§1)
+├── observables.yaml                 # the magforces row           (§2)
+├── transforms.py                    # RotateMagmom                (§3)
+└── model.py                         # MagneticScaleShiftMACE / MagneticSCFMACE   (§5)
+```
+
+**Nothing of the extra touches a shared file**, and `config.toml` refers to it only by name (`magmom`,
+`magforces`, `MagneticScaleShiftMACE`), never by path.
+
+### 6.3 Tests (three kinds, all small)
+
+1. **Value test** for the transform — a fixed input through `rotate_magmom` gives the expected rotated
+   `magmom` (and `magforces`).
+2. **Golden** for a tiny trained model — energy + `magforces` on committed fixtures, so the numbers can
+   never silently drift.
+3. **Equivariance** — under a proper rotation the `magmom` input and the `magforces` output rotate with
+   the frame while the energy stays invariant. (Since `magmom` is `1o`, inversion is a *joint*
+   operation on positions and moments — there is no moments-only symmetry to test.)
+
+### 6.4 The command line — no new flags
+
+The feature adds **no new CLI flags**; the command is unchanged (`mace train --config config.toml`).
+The launcher is config-file-first with **dotted CLI overrides**, so every field the feature declares is
+reachable on the command line for free (unknown keys are a hard error):
+
+```bash
+mace train --config config.toml \
+    data.inputs.magmom.key=REF_magmom \
+    model.model=MagneticScaleShiftMACE \
+    loss.weights.magforces=2.0
+```
+
+---
+
+## What was config vs code
+
+- **Config only:** the input declaration, the `magforces` observable, the loss weights, the transform
+  chaining, the model selection.
+- **Small registered modules:** the input embedding, the augmentation transform, and the two models.
+  All live inside the extra directory.
+- Because we shipped it as an **extra**, **zero** shared files were touched: everything entered through
+  a config field, a registry decorator, or an entry point, and all of the code sits under
+  `mace_torch/extras/magnetic/`.
+
+### If it shipped built-in instead
+
+If the maintainers decided magnetic belongs **built-in** rather than as an extra, the *mechanisms* are
+unchanged — only where the files sit and a couple of packaging details drop away:
+
+- The same modules move from `mace_torch/extras/magnetic/` into the main `mace-torch` tree
+  (`mace_torch/nn/`, `mace_torch/data/`, `mace_torch/models/`), still registered by the same decorators.
+- The observable row goes in the shared `defaults/observables.yaml` instead of a feature-local file.
+- No `mace.plugins` entry point, no `[magnetic]` optional-dependency group, no capability marker — its
+  dependencies (here `sphericart-torch`) would be base dependencies and its tests run unconditionally.
+
+And one rule relaxes. An extra must **not** touch a shared file — that is precisely what keeps it
+self-contained — but built-in work **may**. Adding `MagmomEmbedding` straight into the existing
+`mace_torch/nn/embedding.py` is perfectly fine for built-in functionality; it is not off-limits. Keeping
+each feature in its own file (`mace_torch/nn/magmom_embedding.py`) is **preferred for readability, not
+required**. So "no edits to existing shared files" is a property of the **extra path**, not a blanket
+prohibition.
+
+### Reusing it under JAX (inference)
+
+Everything above is `mace-torch`. Two things are shared across backends for free: the **`config.toml`**
+and the **trained weights** — the canonical layout is backend-neutral, so a torch checkpoint loads into
+the JAX model. Everything else in this extra is torch: `MagmomEmbedding` (which uses `sphericart-torch`),
+the two magnetic models, and the observable row the extra ships — they sit in the torch extra, not in
+`mace-core`. To run under JAX you re-provide those in `mace-jax` (same `extras/magnetic/` layout, JAX
+registries, `sphericart`'s JAX bindings). A **standard** model needs no port (its modules and observables
+already ship in `mace-jax` / `mace-core`); a **custom** extra does. Only the framework-agnostic contract
+a backend builds against — the `ObservableSpec` schema, the config schema, the canonical layout — lives
+in `mace-core`. If you want the declarative rows shared instead of duplicated, lift them from the extra
+into `mace-core`; then only the module code stays per-backend.
+
+The takeaway for methodological work: whether it ships as an extra or built-in, even a feature that adds
+a vector input, its conjugate force, augmentation, a loss term, and an SCF inference wrapper is a
+bounded set of **declarations plus a couple of registered modules** — the "hard" part is only the
+genuinely new physics in the forward, and even that plugs in through the registry rather than rewriting
+the framework.

--- a/docs/reforge/extending_plugin.md
+++ b/docs/reforge/extending_plugin.md
@@ -1,0 +1,142 @@
+# Extending MACE from outside — a third-party plugin (entry points)
+
+This is the companion to [Extending MACE](extending_mace.md). That doc built the magnetic feature as
+an **in-tree extra** — code under `mace_torch/extras/magnetic/`, shipped with MACE. Here we ship the
+*same* feature as a **standalone, `pip`-installable package** (`mace-magnetic`) that plugs into MACE
+**without touching the MACE repo at all**. The only mechanism is **entry points**.
+
+Same registries, same `config.toml`, same trained-weight format. The only differences are where the
+code lives and that the plugin releases on its own cadence. When to choose a plugin over an in-tree
+extra or built-in is the last section.
+
+---
+
+## 1. The entry-point groups MACE exposes
+
+MACE scans three entry-point groups at startup. A feature plugin like magnetic uses the first; the
+other two are for swapping *compute kernels*, not adding features.
+
+| Group | An entry is… | Contract | Selected |
+|---|---|---|---|
+| `mace.plugins` | a **module** imported at startup | its `@register_*` decorators populate the in-process registries (models, transforms, embeddings, losses, observable rows) | active once installed; referenced from `config.toml` by the names it registers |
+| `mace.kernel_backends.torch` / `.jax` | a **`KernelBackend`** implementation | Protocol: the equivariant tensor-product / symmetric-contraction ops + the canonical weight layout (RFC-01 / BKD-1) | by name in config/build |
+| `mace.electrostatics_backends` | a **long-range / electrostatics solver** | Protocol: k-space op + optional SCF span (RFC-09); a separate registry from the kernel backends | by name; bit-parity swaps are free |
+
+The distinction: `mace.plugins` entries are **imported for their side effects** (their decorators run
+and register things, and they stay active). The two backend groups are **named implementations you
+pick one of** — they don't turn on just by being installed.
+
+---
+
+## 2. The package skeleton
+
+A plugin is an ordinary Python distribution that depends on MACE and declares one entry point:
+
+```text
+mace-magnetic/                       # a separate repo / PyPI package — not in the MACE tree
+├── pyproject.toml
+├── src/mace_magnetic/
+│   ├── __init__.py                  # the mace.plugins target: runs the @register_* decorators
+│   ├── embedding.py                 # MagmomEmbedding                              (extending_mace.md §1)
+│   ├── observables.yaml             # the magforces row                            (§2)
+│   ├── transforms.py                # RotateMagmom                                 (§3)
+│   └── model.py                     # MagneticScaleShiftMACE / MagneticSCFMACE     (§5)
+└── tests/
+```
+
+```toml
+# mace-magnetic/pyproject.toml
+[project]
+name = "mace-magnetic"
+dependencies = ["mace-torch>=1.0", "sphericart-torch==1.0.9"]   # depends on MACE, never the reverse
+
+[project.entry-points."mace.plugins"]           # the whole hook: one line
+magnetic = "mace_magnetic"                       # MACE imports this module on discovery
+```
+
+That entry point is the *entire* integration surface. There is no MACE-side registration list, no
+edit to any MACE file.
+
+---
+
+## 3. Registration — identical to the in-tree extra
+
+The module code is what [Extending MACE](extending_mace.md) §1, §3 and §5 already showed; **only the
+import root changes** (`mace_magnetic` instead of `mace_torch.extras.magnetic`). The `__init__.py` runs the
+decorators and loads the observable rows:
+
+```python
+# src/mace_magnetic/__init__.py
+from mace_torch.models import register_model
+from mace_torch.data import register_transform
+from mace_torch.nn import register_input_embedding
+from mace_torch.observables import register_observables_yaml
+
+from .embedding import MagmomEmbedding
+from .transforms import RotateMagmom
+from .model import MagneticScaleShiftMACE, MagneticSCFMACE
+
+register_input_embedding("magmom")(MagmomEmbedding)
+register_transform("rotate_magmom")(RotateMagmom)
+register_model("MagneticScaleShiftMACE")(MagneticScaleShiftMACE)
+register_model("MagneticSCFMACE")(MagneticSCFMACE)
+register_observables_yaml(__file__, "observables.yaml")   # magforces
+```
+
+`config.toml` is byte-for-byte the one from the in-tree example — it refers to the feature only by
+name (`magmom`, `magforces`, `MagneticScaleShiftMACE`), and does not know or care that it now comes
+from an external package.
+
+---
+
+## 4. Versioning and compatibility
+
+- The plugin **pins a MACE range** (`mace-torch>=1.0`) and builds only against the **public registry
+  API** — `register_*`, `ObservableSpec`, `BaseMACE`, the model-transform hook. That surface is the
+  contract; internal modules are not.
+- MACE exposes its version; the loader can **warn and skip** a plugin whose declared target is
+  incompatible, rather than importing it into a mismatched API.
+- Because config and weights are backend-neutral, a model trained with the plugin installed produces a
+  normal checkpoint — anyone who later installs `mace-magnetic` at a compatible version can load it.
+
+---
+
+## 5. Discovery, load order, fault tolerance
+
+- At startup MACE enumerates the `mace.plugins` entry points (`importlib.metadata`) and imports each
+  **once**; the decorators register on import.
+- **Order-independent** — registration is by name. A name collision (two sources registering
+  `MagneticSCFMACE`) is a hard error that names both, never a silent last-wins.
+- A plugin that **raises on import is logged and skipped** — it never crashes MACE. The names it would
+  have registered are simply absent, so `config.toml` referencing them fails fast with a clear
+  "unknown model/observable" (and a hint that a plugin may be missing or broken).
+- A missing optional dep is the same story as the extra: the module guards the import and registers
+  nothing, so the capability is just off.
+
+---
+
+## 6. Testing and distribution
+
+- **Tests live in the plugin repo.** Install `mace-torch` + the plugin and run the same three checks
+  as [Extending MACE](extending_mace.md) §6.3 — the transform value test, the tiny-model golden
+  (energy + `magforces`), and rotation equivariance. A CI matrix pins the MACE versions you support.
+- **Distribute on PyPI.** Users `pip install mace-magnetic`; nothing needs to change in MACE or
+  coordinate with a MACE release.
+
+---
+
+## 7. Plugin vs in-tree extra vs built-in
+
+All three use the **same registries** and the **same `config.toml`**. The only axes are *where the
+code lives* and *who releases it*.
+
+| | Lives in | Released by | Reach for it when |
+|---|---|---|---|
+| **External plugin** (this doc) | its own repo / PyPI package | you, independently | you don't own MACE, want your own cadence, or the feature is niche / experimental / proprietary |
+| **In-tree extra** ([Extending MACE](extending_mace.md)) | the MACE monorepo, `extras/<name>/` | the MACE team, with MACE | it belongs with MACE but carries a heavy optional dep and should be gated by a capability marker |
+| **Built-in** | the main `mace-torch` tree (`nn/`, `data/`, `models/`) | the MACE team, with MACE | it is broadly useful, has no heavy dep, and is part of the default model |
+
+Moving between them is mechanical: the module code and the `@register_*` calls are identical; you only
+change where the files sit and how they're discovered (an entry point in a separate package → an entry
+point in MACE's own `pyproject` → imported directly in the built-in tree). The user's `config.toml`
+never changes.

--- a/docs/reforge/plan.md
+++ b/docs/reforge/plan.md
@@ -1,0 +1,318 @@
+# MACE Reforge — Execution Plan
+
+**Status:** living document · **Source of truth for scope:** the MACE Reforge workshop roadmap, an internal design document. It is cited below by chapter ("roadmap Ch. 4") where it is the authority for a decision; this plan is otherwise self-contained.
+**Companions:** the [ticket board](https://github.com/orgs/ACEsuit/projects/2) (the backlog — one GitHub issue per ticket) · [`target_layout.md`](target_layout.md) (the destination tree) · §10 (ticket ID → issue)
+
+This document turns the workshop roadmap into an executable plan: how the migration from v0.3.x to the rewrite works, what the phases and their exit gates are, how the work is organised, and where the roadmap is contradictory or under-specified. Dates are deliberately absent — phases are gated by exit criteria, not by the calendar. The roadmap's June–August window is treated as aspirational, not binding.
+
+## 0. Binding decisions
+
+These are fixed and are not re-litigated in tickets:
+
+| # | Decision |
+|---|----------|
+| D1 | **Full roadmap scope**: `mace-core` + `mace-torch` + `mace-jax` (inference-only) + an educational reference implementation. |
+| D2 | **Compatibility**: user checkpoints from v0.3.x are not runtime-loadable in the new architecture. Only published foundation models get a **one-shot converter** — the explicit artifact list (amended in review, 2026-07: the earlier family shorthand was ambiguous about the multi-head releases): the MACE-MP aliases **including `mh-0`/`mh-1`**, MACE-OFF, MACE-Polar, MACE-MDP, and **MACE-OMOL** (multi-head artifacts convert with their heads intact; single-head exports are `mace model select-head`, a separate step). MACE-ANI-CC: **dropped** (decided 2026-07-29) — superseded by MACE-OFF for organic chemistry, and its loader was the only one with a divergent signature; REL-1 points those users at MACE-OFF. "Loadable" in roadmap Principle 4 means *one-shot convertible*, not runtime-loadable. |
+| D3 | **Test prerequisite bar** (roadmap Ch. 11 "hard prerequisite"): golden characterization tests of physics behaviour + E2E CLI contracts + line-coverage floors **only** on modules whose behaviour ports to the rewrite. No global coverage percentage target. |
+| D4 | **Workflow**: tickets are self-contained work packages — context, steps, acceptance criteria and verify commands — consolidated so that one ticket is one PR. The limiting factors are review bandwidth per PR and parallelism, not implementation time. The backlog is the [ticket board](https://github.com/orgs/ACEsuit/projects/2). |
+| D5 | **Backlog location**: the [**GitHub Project**](https://github.com/orgs/ACEsuit/projects/2) is the source of truth — one issue per ticket in `ACEsuit/mace`, with dependency fields, progress tracking and native PR linking. Ticket IDs are stable and resolve to issue numbers through §10. **Board shape (decided 2026-08-03):** an org-owned Project v2 under ACEsuit mirroring **61 tickets** — Phase 1 through 5 plus the independent tracks. Two groups are deliberately not exported: the **5 RFC-track** tickets (closed work, decisions already inlined) and the **9 Phase 0** tickets (prerequisite characterization of the frozen legacy, done locally before the plan starts — they depend on local artifacts nobody else can act on). `Status` has exactly four options — **TODO → IN PROGRESS → PR OPEN → CLOSED** — plus fields `Phase` and `Size` and the flag labels (`gpu`, `network`, `numerics-critical`, `critical path`). Deliberately flat: no `Type`, no `Outcome`, no per-type lanes. **All 61 import as `TODO`** — the board starts clean and its state is maintained there from then on, never back-filled from local branch state. Note that a Projects `Status` field is a single-select and enforces no transitions: the column a ticket sits in is a statement of where it is, not a gate. |
+| D6 | **Progressive migration.** The new implementation grows alongside the frozen legacy package, which serves as the differential oracle. Legacy is reference material for *behaviour* only, never for structure; it is never edited and never imported by the new stack. It is deleted capability-by-capability once each capability reaches full parity. |
+
+## 1. Working model
+
+Tickets are picked from the backlog, not pre-assigned. Two kinds of work are distinguished by the tickets themselves, not by who does them:
+
+- **Numerics-critical tickets** (model architecture, derivative engine, losses, electrostatics, backends) require physics judgment in both implementation and review — they carry explicit design notes and golden/finite-difference validation so correctness is checkable, not assumed.
+- **Specification-driven tickets** (ports pinned by characterization tests, data backends, CLI subcommands, docs, pattern-following work) have tight, executable acceptance criteria so anyone can land them and review stays cheap.
+
+Rules of the working model:
+
+- Every session starts with the ticket, then the files the ticket names.
+- Tickets never contain open design decisions — those are resolved in an RFC or a parent ticket before the ticket is picked up.
+- **Numerics expertise is the capacity bottleneck** (about half the tickets touch numerics). Mitigation: inside bundled tickets, the first instance of each pattern (first backend, first foundation-model conversion) is the numerics-critical half; the pattern-following half is a separate specification-driven hand-off.
+- Every PR is reviewed before merge; numerics-critical changes need a reviewer with physics expertise.
+- Branch naming: `reforge/<TICKET-ID>-<slug>`. PRs target `mace-reforge`, which is installable and useful at every point.
+
+## 2. Transition strategy: coexistence with a live differential oracle
+
+The new stack (`packages/{mace-core,mace-torch,mace-jax}`) is built alongside a **byte-frozen** legacy `mace/` package. Frozen legacy is a **live, in-process differential oracle**: the parity harness loads both stacks in the same process (or in a forked subprocess) and compares them numerically on every migrated capability. Development proceeds as end-to-end **vertical slices** (config → kernel → observable → model → loss), selectable by an `--engine {legacy,v1}` flag on a thin launcher. Legacy is retired capability-by-capability at the end, through **deletion-only** PRs. `mace-reforge` is installable, releasable, and useful at every point; a hard release gate blocks the 1.0 tag until `git ls-files mace/ == 0`.
+
+### 2.1 The two stacks and the double-import allowlist
+
+The two stacks **never import each other**. The only exceptions on the double-import allowlist are:
+
+- **`mace_launcher.dispatch`** — the launcher (`packages/mace-launcher`, ~50 LOC) owns **all** console entry points and dispatches via `--engine {legacy,v1}` / `MACE_ENGINE` to `mace.cli.*` or the new `mace_torch.cli.*`. It **defaults to `legacy`**, so day-one behaviour is unchanged.
+- **`tests/parity/`** — the harness that imports both stacks to compare them numerically.
+
+Everything else is one-directional (`packages ⊥ mace`). New code is organised per [`target_layout.md`](target_layout.md):
+
+- **`mace_core`** (no torch/jax/e3nn): typed `MACEOutputs`, Pydantic `ModelConfig`/`PrecisionConfig`, declarative observables, the flat-dict graph contract, numpy/matscipy neighbours, Clebsch–Gordan, the kernel Protocol + entry-point registry, and `get_outputs` as pure physics — all **reimplemented**, never imported from legacy.
+- **`mace_torch`**: two-layer `BaseMACE` models with blocks born **without `@compile_mode("script")`**, the staged training pipeline, the ASE calculator, the new `cli/`, and the kernel backends registered via `entry_points("mace.kernel_backends.torch")`. Hot ops are `torch.library.custom_op` + `register_fake` with a reference double-backward autograd path; the canonical weight layout runs `to_canonical`/`from_canonical` only at the backend boundary.
+- **`mace_jax`**: the inference-only destination, validated against the neutral safetensors+JSON format and the goldens.
+
+### 2.2 The five rules that guarantee design purity
+
+Purity is not a review aspiration; it is enforced in CI.
+
+| # | Rule | CI enforcement |
+|---|------|----------------|
+| R1 | **One-way import direction** (`packages ⊥ mace`): a legacy class is physically unreachable from the new zone — it cannot be subclassed, re-exported, or imported. | `import-linter` (static) **plus** a runtime `sys.addaudithook` that closes the dynamic `importlib` reach-in. |
+| R2 | **Spec-first**: RFC-A..D are Accepted before the keystone slice is written; v1 implements a frozen spec, not a port. | Process gate at the Phase 0 exit. |
+| R3 | **No structural copying**: no `packages/**` file names a legacy class (`ScaleShiftMACE`, `interaction_classes`, `AtomicData`, …). | Meta-lint over the new tree. |
+| R4 | **Debt book**: every temporary compromise is a dated countdown. The dates are **internal** — there is no public EOL promise; `main` stays on v0.3 until v1 is released, and no end date for v0.3 is announced. | Fitness functions go **red** when a date expires. |
+| R5 | **The oracle never moves**: `mace/` is byte-frozen and the goldens are edit-locked. The freeze is **on `mace-reforge`**, not on `develop`: the rewrite is built on that branch and never edits `mace/` there, while `develop` carries on taking 0.3.x bugfixes and self-contained features. Nothing closes the v0.3 line; `main` holds it until v1 ships. A tolerance change is its own PR. | Branch rule + edit-lock check; a tolerance change lands only as a standalone, reviewed PR. |
+
+### 2.3 Strangling order and the retirement criterion
+
+Migration is bottom-up. `mace-core` foundations first; then the kernel Protocol + plain-torch reference backend (compile-first from day one); then the keystone vertical slice — `ScaleShiftMACE` energy+forces, reference backend, in-memory XYZ producing the flat-dict contract, single head, float64 — which front-loads every hard bet. On top of the keystone come the physics/observables axis (stress/virials, ZBL, per-model E0/scale-shift semantics), the backends axis (cueq/oeq behind the single Protocol, plus an out-of-tree example backend as a gate), the data axis (HDF5/LMDB, `mace_prepare_data`, DDP), the extra readouts and foundation-model conversion, and finally deployment.
+
+Each capability reaches **full fp64 parity** in v1 while its legacy counterpart runs as the oracle under `--engine=legacy`. After it has been default-`v1` through a deprecation window with green parity, its legacy modules are **physically deleted** in a deletion-only PR (zero new v1 logic), and its parity test degrades to the frozen golden. `git ls-files mace/` decreases monotonically. **Done = `git ls-files mace/ == 0` with the 1.0 release gate satisfied.**
+
+### 2.4 Alternatives considered
+
+- **In-tree coexistence with adapters/shims** is rejected: it requires editing the legacy package to expose adapters, which *moves* the numerical oracle and opens a structural-recontamination path where new code inherits legacy structure through a shim. Freezing legacy and forbidding all imports across the boundary is what makes the oracle trustworthy.
+- **A long-lived rewrite branch** was initially rejected, and is now the approach: the rewrite lives on `mace-reforge`, with `mace/` frozen there and `develop` continuing to ship v0.3. Two of the three original objections do not apply to that shape. `develop` is neither stale nor broken, because it keeps taking bug fixes and self-contained features and releases through `main`; and parity stays continuous, because the frozen oracle travels **on the branch**, so the harness compares against it every day rather than at milestones. The third objection stands and is accepted as a cost: the final merge is large. It is mitigated by keeping every PR into `mace-reforge` ticket-sized, so the work is reviewed continuously and only the merge itself is bulk, and by an explicit migration pass that carries whatever landed on `develop` into v1 before the branches meet.
+- **A new repository** is rejected: it loses history, issues, and the GPU-runner setup, and contradicts the workshop's unanimous monorepo decision (roadmap Ch. 3).
+
+## 3. Prerequisites (before the Phase 0 gate closes)
+
+1. **CI branches are merged into `develop`** — already done. The capability-marker test layout (`tests/{unit,workflows,backends,extensions,foundations,integrations,benchmarks}`), the `.github/actions/run-tests` composite action (a job's `with:` block maps 1:1 to pytest flags and is its local reproduction recipe), and the `ci-core`/`ci-extensions`/`ci-integrations`/`ci-gpu-mpcdf`/`nightly`/`release` workflows are all on `develop`.
+2. **GPU coverage — closed (2026-08-03).** Both gaps this section used to track are gone, and the mechanism that tracked them is gone with them: the self-hosted single-host fleet (`.github/gpu-fleet.json` + `ci-gpu.yaml`) was replaced by `ci-gpu-mpcdf.yaml`, which drives MPCDF's shared GitLab runners from GitHub and surfaces **one independent check per vendor**. There is no fleet file and no `enabled` flag any more; a vendor is a job in `.github/gitlab/ci.yml`.
+   - **Nvidia** (A30 MIG): `-m gpu`, caps `gpu,cueq,oeq,les,schedulefree,network` — **49 passed / 1 xfailed**, first green run driven from GitHub 2026-08-03 (PR #1546).
+   - **AMD** (MI210): `-m "gpu and not cueq"`, caps `gpu,oeq,schedulefree` — **38 passed / 0 skipped**. AMD had never run before.
+   - What the change actually bought: **`oeq` now runs at all** (the vendor jobs override the base image with a real toolkit — `nvidia/cuda:*-devel`, `rocm/dev-ubuntu-*` — because OpenEquivariance JIT-compiles its kernels; the retired host had only a driver). The 24 `oeq` tests had been dead everywhere until then. Network is enabled too (`MACE_CI_ALLOW_NETWORK=1`, `network` in the required caps).
+   - Backend-parity gating (P0-4, BKD-3) therefore covers **cueq on Nvidia and oeq on both vendors** from the outset — it is no longer waiting on a human to provision anything.
+   - Caveat for any cross-vendor claim: the two jobs are **not on the same torch** (`2.13.0+cu130` vs `2.9.1+rocm6.3`, because the `rocm6.3` wheel index tops out at 2.9.1). A vendor comparison that omits this is measuring the wheel, not the vendor.
+
+## 4. Phases and exit gates
+
+Dependency-ordered. "Phase N+1 starts" means its critical-path tickets start; independent tracks (EDU, GOV, RFCs) run whenever someone is free. Every phase leaves `mace-reforge` installable and useful; `--engine` defaults to `legacy` until a capability reaches full parity, at which point it can flip to `v1` with opt-out. Full ticket definitions are in [`tickets.md`](https://github.com/orgs/ACEsuit/projects/2).
+
+### Phase 0 — Behavioural safety net and frozen design
+
+Golden characterization of v0.3.x physics behaviour + targeted coverage of port-worthy modules + the **functionality inventory** — this is what makes the rewrite falsifiable and complete. Tickets **P0-0..P0-8** and **RFC-A..D**.
+
+- **P0-0** enumerates every v0.3.16 feature mechanically from the code (all `arg_parser` flags, entry points, module registries, calculator options, extras, documented tutorials) with a KEEP/MERGE/DROP disposition and its pinning test.
+- **P0-1** builds the framework-agnostic golden harness, the per-dtype tolerance table, and a tiny `ScaleShiftMACE` checkpoint trained once and committed as the parity anchor. **P0-2/P0-3** add goldens for MACE-MP/OFF and dipole/polar/MDP models; **P0-4** adds cueq/oeq parity goldens on GPU CI.
+- **P0-5** pins E2E CLI contracts (train smoke with loss-decrease, resume, eval, ASE calculator, fine-tuning replay, LAMMPS export). **P0-6/P0-7** characterize loss math, the forces/stress-via-autograd glue, E0s, radial bases, parsing, neighbour lists, and batching. **P0-8** wires per-module coverage floors and performance baselines.
+
+**Exit gate:**
+- [ ] Functionality inventory complete (count cross-check passes); every KEEP/MERGE row pinned; DROP list reviewed.
+- [ ] Golden harness merged; references committed (e3nn CPU fp64) for the tiny anchor, MACE-MP-small, MACE-OFF-small, tiny dipole, MACE-Polar, MACE-MDP; the **virial sign convention is pinned**.
+- [ ] The anchor fixture set includes **ZBL/`--pair_repulsion` enabled for BOTH `MACE` and `ScaleShiftMACE`** (the two differ in whether the ZBL term is inside or outside the scale-shift), and **explicit E0/scale-shift goldens in fp32 AND fp64, per-model and per-quantity** (total energy vs node energy — see §7).
+- [ ] Backend golden parity green on `ci-gpu-mpcdf.yaml` for **both vendor checks** (cueq+oeq on Nvidia, oeq on AMD); E2E CLI contracts green on `ci-core`.
+- [ ] **Training numerics pinned, not just behaviour**: beyond the P0-5 loss-decrease smoke and the committed error table, the **single-step `d(loss)/d(params)` gradient golden** (P0-6, fixed seed + committed weights, fp64, both anchors, exercising `create_graph=True`) is committed, and `gradgradcheck` is green on the tiny fixture — this closes the §7 training-numerics gap that a JSON-of-errors cannot see.
+- [ ] Per-module coverage floors enforced for `mace/modules/{loss,radial,utils}.py` and `mace/data/{utils,neighborhood,atomic_data}.py`.
+- [ ] **RFC-A..D Accepted** (R2). RFC-A fixes the final shape of the kernel Protocol, `custom_op` contract, and canonical layout.
+
+### RFC track (roadmap Appendix A)
+
+Eight RFC **documents** — internal decision records whose decisions are inlined into the tickets they block — delivered by four bundled tickets pairing RFCs that share context: **RFC-A** (backend dispatch + Clebsch–Gordan), **RFC-B** (neighbour lists + canonical data format), **RFC-C** (E0 specification + pseudolabel caching), **RFC-D** (JAX scope + deployment). Acceptance = both records at status `Accepted` and the blocked tickets writable against the interface sketches.
+
+A ninth RFC surfaced during implementation, outside the roadmap's Appendix-A eight: **RFC-E** (**RFC-09** — electrostatics / long-range solver backend dispatch), motivated by [`ACEsuit/mace#1524`](https://github.com/ACEsuit/mace/pull/1524). It generalizes RFC-01's dispatch pattern to the electrostatics solver op class (k-space/PME + SCF fixed point) so the solver is swappable between a plain-torch reference (`graph_longrange` successor) and accelerated libraries (NVIDIA `nvalchemiops`), and pins the one place the analogy breaks — a non-bit-parity accelerated solver is model-affecting state, not a free backend choice. It **blocked ELEC-1/ELEC-2/ELEC-3** and is **Accepted (2026-07-29)** — 10 decisions closed, mirroring RFC-01 (separate registry, bit-parity→free / non-parity→model-state, build-time selection, k-space op + optional SCF span, reference = `graph_longrange` successor, v1.0 = reference + dispatch, `nvalchemiops` follow-on); the electrostatics tickets are unblocked as of that acceptance. It **is** on the critical path: ELEC-1/ELEC-2 are Phase 3 and GATE-3 covers them, so this RFC has to be accepted before Phase 3 opens; only ELEC-3 waits for Phase 5.
+
+### Phase 1 — Coexistence scaffold and mace-core foundations
+
+Tickets **INF-1..INF-5, CORE-1..CORE-3, CORE-4**. INF-1 is a **non-destructive scaffold** ticket: it creates `packages/` and installs the three packages + `mace-launcher` alongside a frozen `mace/`; it deletes nothing. INF-2 is the launcher; INF-3 the import guard (import-linter + audit-hook + anti-structural meta-lint); INF-4 the path-scoped dual toolchain; INF-5 the debt book. CORE-1..3 build typed outputs + observable spec, the config/metadata skeleton, and the framework-agnostic `Configuration` type; CORE-4 vendors the reduced Clebsch-Gordan basis and a pure-torch `SegmentedPolynomial` evaluator (see §6).
+
+**Exit gate:**
+- [ ] The three packages + `mace-launcher` install editable **alongside** `mace/`; `import mace, mace_core, mace_torch, mace_jax` succeed in one process.
+- [ ] `git ls-files mace/` unchanged; the legacy suite is green; `--engine=legacy` is byte-identical to calling `mace.cli.*`.
+- [ ] **Exactly one installed distribution provides each `mace_*` entry point**: `console_scripts` are removed from the root `setup.cfg`; `mace-launcher` is the sole owner (asserted in CI).
+- [ ] `import-linter` green; the runtime audit-hook operational; the dual path-scoped toolchain green; the anti-structural meta-lint green.
+- [ ] `MACEOutput`, the observable spec, the config round-trip, `Configuration`, and **CORE-4** merged — the reduced basis golden-locked against an **independent** CPU Clebsch-Gordan derivation (never against itself), with a parameter-count golden per `(irreps, correlation)` so the basis can no longer vary with `CUET_AVAILABLE`, and no `cuequivariance` import left in `mace_core`.
+- [ ] A dummy backend registered via an entry point is discovered.
+- [ ] The branch model is recorded in `CONTRIBUTING.md`: `main` carries releases and stays on v0.3 until v1 ships, `develop` keeps taking 0.3.x work, `mace-reforge` carries the rewrite with `mace/` frozen. There is no maintenance branch, and **no announced EOL date**; the debt book (INF-5) carries the rewrite's own internal countdowns.
+
+### Phase 2 — Keystone slice: architecture, backends, data
+
+Tickets **ARCH-1..4, BKD-1..4, DATA-1..3, FM-00, PAR-1, PAR-2**. ARCH-1 ports radial/embedding/spherical-harmonics blocks; BKD-1 builds the reference backend + Clebsch-Gordan module per RFC-A; ARCH-2 assembles the backbone (interaction + symmetric contraction on the dispatch interface) with equivariance tests; ARCH-3 the output layer (`MACEOutputs`, readout-only E0s, dipole/polarizability as observables); ARCH-4 the two-phase forward + derivative engine (strain injected before edge vectors). FM-00 is the in-process keystone converter; BKD-2 adds the compile path + `PrecisionConfig`; BKD-3/4 the cueq/oeq backends and the out-of-tree example backend; DATA-1..3 the dataset API, HDF5/LMDB, and neighbour lists/batching without vendored `torch_geometric`. PAR-1/PAR-2 are the continuous parity harness.
+
+**Exit gate (the keystone):**
+- [ ] **FM-00**: the committed anchor converts **in-process** (importing the in-tree frozen `mace/`, no separate venv) and reproduces the Phase 0 E/F/stress goldens at fp64, **and** matches the live legacy model loaded in the same process — with the full→reduced conversion pinned to an **independent** Clebsch-Gordan derivation, never to CORE-4's own basis.
+- [ ] **PAR-1**: in-process legacy-vs-v1 parity green on tiny fixtures, with **global process-state isolation** between the two runs (snapshot/restore of env vars, default dtype, e3nn optimization defaults, and RNG, or a forked subprocess).
+- [ ] **Single-step, init-agnostic gradient parity test** (per-PR): byte-identical weights in both stacks, one forward+backward on an E+F loss, `d(loss)/d(params)` allclose at fp64 — this exercises the `create_graph=True` second-derivative path.
+- [ ] Forces/stress validated by finite differences against v1; equivariance passes; compiled == eager with no graph break; cueq/oeq parity (fwd + bwd + **double-bwd**) green on GPU; **BKD-4** passes with zero core edits.
+- [ ] Data axis: **zero `torch_geometric` at the model interface** (active fitness function); a golden verifies the v1 collater reproduces `ptr`/`batch` bit-exact.
+- [ ] The energy+forces+stress capability can flip its default to `v1` with opt-out; legacy retained as oracle. Opt-in **explicitly excludes LAMMPS export/checkpoint until DEP-2** (documented in the debt book).
+
+### Phase 3 — Training pipeline, config/CLI, electrostatics core, fine-tuning
+
+Tickets **CFG-1, TRN-1..4, CLI-1, FT-1..3, ELEC-1/2, DEP-1, MAG-1, GATE-3**. Full training config schema (CFG-1); the staged pipeline with typed stage contracts replacing the >1,100-line `run()` and an explicit training loop, no Lightning (TRN-1); composable losses from the observable spec (TRN-2); multi-dataloader balancing + metrics/logging (TRN-3); safetensors checkpointing + DDP (TRN-4); the hierarchical `mace train/eval/model/data/export` CLI via the launcher (CLI-1); heads-as-modules fine-tuning, pseudolabels, all-species weights (FT-1..3); the **electrostatics core** — graph_longrange behind the `[electrostatics]` extra with its solver-dispatch layer and its own CI job (ELEC-1) and PolarMACE on the new architecture with golden parity and the polar user surface (ELEC-2); the ASE calculator (DEP-1, which starts once ARCH-4 lands); the MagneticMACE family re-landed declaratively as magmom-input-feature + magnetic-moment observable + `dE/dm` derivative, rather than as the forked class family it is in legacy (MAG-1, added to this list 2026-07-29 — the ticket existed but the plan did not name it); the phase gate (GATE-3).
+
+ELEC-1/2 sit here rather than with the rest of electrostatics because Phase 3 consumes them: the polar and LES calculator surfaces are a Phase 3 deliverable, so is MDP fine-tuning, and GATE-3 gates both — leaving the two ports in Phase 5 made the Phase 3 gate wait on most of Phase 5. Their MACE-Polar **artifact conversion** does not come with them; it runs on the FM-1 tool and therefore stays in Phase 4 with the rest of the roster (FM-2). ELEC-3 (split-charge/SCF) and ELEC-4 (MACELES) stay in Phase 5.
+
+**Exit gate:**
+- [ ] `mace train --engine v1` trains the tiny task end-to-end: loss decreases, checkpoint + resolved-config metadata written, resume works, errors comparable to legacy (`tiny_scaleshift_training_errors.json`) — reinforced by the single-step gradient test.
+- [ ] `mace eval` and the new ASE calculator agree numerically; multihead replay and CPU-DDP smokes pass.
+- [ ] The must-have example works: a new spherical-tensor observable declared purely in config, trained and evaluated (GATE-3).
+- [ ] Electrostatics installable via the `[electrostatics]` extra with its own CI job green; the reference solver resolves once at build time with nothing dispatching in `forward`; the ported PolarMACE reproduces the P0-3a polar golden at fp64 and its user surface (density-cube CLI, the seven polar result keys, Fukui output, the polar Hessian) is reachable under `--engine v1`.
+- [ ] The **65 black-box tests** (54 in `tests/workflows` + 11 in `tests/integrations`) pass with `--engine v1` for the migrated capabilities.
+- [ ] From Phase 3 onward, CI requires `git ls-files mace/` to be **strictly non-increasing on `mace-reforge`** on the schedule set in the debt book. It says nothing about `develop`, where `mace/` keeps growing until the merge back.
+
+### Phase 4 — Foundation models and JAX
+
+Tickets **FM-1..3, JAX-1..2**. The production two-step converter generalizing FM-00 (in-process for development; a pinned `mace-torch==0.3.16` venv only at the end-user packaging boundary, for old pickles) with golden verification (FM-1); conversion of the MACE-MP/OFF/MDP/Polar families with parity vs Phase 0 goldens (FM-2); the model registry with naming, deprecation warnings, DOIs, loaders, and a nightly validation badge matrix (FM-3); the mace-jax skeleton + weight import + inference forward with torch parity (JAX-1); the jitted static-shape pipeline + minimal JAX ASE calculator (JAX-2). MACE-Polar conversion stays here with the rest of the roster: the model it converts onto is ELEC-2's, delivered in Phase 3, but the conversion itself runs on FM-1's two-step tool, so FM-2 adds the `PolarMACE` source path and gates the three artifacts on the P0-3a polar golden.
+
+**Exit gate:**
+- [ ] MACE-MP + MACE-OFF + MACE-MDP + MACE-Polar converted, matching Phase 0 goldens on CPU and GPU **and** the live legacy in-process; an **fp32 bit-reproduction golden** with a deterministic `segment_reduce` is matched at fp32 machine epsilon (see §7).
+- [ ] The model registry is live with metadata and deprecation mechanics; mace-jax reproduces the torch goldens for the RFC-D model list.
+
+### Phase 5 — Electrostatics extensions, deployment, legacy retirement, release
+
+Tickets **ELEC-3/4, DEP-2/3/4, RET-1..6, REL-1..3**. The electrostatics *core* — the reference solver, its dispatch layer and PolarMACE — moved to Phase 3 (ELEC-1/2); what remains here builds on it: the split-charge / SCF charge-aware families from `ACEsuit/mace-scf` reimplemented on the two-layer + model-transform-hook design (ELEC-3) and MACELES with its `[les]` extra, BEC, latent multipoles and external-field path (ELEC-4). LAMMPS via `torch.export`/MLIAP with an emergency exit (DEP-2); OpenMM/Symmetrix/libmace (DEP-3); the torch-sim backend on the new engine, promoted to a first-class deployment path by the P0-0 disposition pass (DEP-4); the capability-by-capability retirement in deletion-only PRs (RET-1..6, in the order energy models → data layer → the five `convert_*` CLIs → dipole/polar/`extensions.py` → LAMMPS jit → the `mace/tools` god-module + the launcher's legacy branch); the migration guide (REL-1, no release); the package release pipeline and the v1.0.0 tag + DOI (REL-2); docs consolidation (REL-3). REL-1 publishes the guide and ships no release.
+
+**Exit gate:**
+- [ ] The `[les]` extra installs and its BEC / latent-multipole / external-field surface is green against the P0-3c golden, and every `mace-scf` family has a recorded disposition (reimplemented or version-tagged) — the `[electrostatics]` extra itself was gated at Phase 3; LAMMPS MLIAP numerics match the ASE calculator; no `jit.*` in the live v1 path (except an isolated export adapter if the emergency exit applies).
+- [ ] RET-1..6 merged; `git ls-files mace/ == 0`; each parity test degraded to its frozen golden; `import-linter` trivially satisfied; a single toolchain; coverage floors over `packages/` only.
+- [ ] The migration guide published with the DROP list; mace-docs tutorials executed against the v1.0.0 build. (REL-1 ships **no release**, and no deprecation warning will ever name a v1 command — the last 0.3.x binary predates v1's CLI — so the guide is the only signpost and must be linked from the README, the docs landing page and the PyPI description.)
+- [ ] **Hard release gate**: the 1.0 tag is blocked until `git ls-files mace/ == 0`.
+- [ ] v1.0.0 tagged and published with DOI (no release candidate).
+
+### Independent tracks (no phase gate)
+
+- **EDU** — educational JAX implementation in `tutorials/` (top-level, a sibling of `packages/`; **not** the "reference backend", which is the plain-torch/jax kernel oracle inside the packages): a pure-function forward, **evaluation/inspection-only** — for chemists/physicists to read the model blocks, not a training path (there is no JAX training anywhere) nor a mirror of the latest architecture (EDU-1); marimo notebooks with CI execution and a numerics cross-check vs mace-torch (EDU-2, only the cross-check depends on the new stack).
+- **GOV** — CONTRIBUTING.md + governance doc (GOV-1); agent-friendly repo layout + issue automation + a PR-review bot (GOV-2).
+
+## 5. Critical path and de-scope line
+
+**Critical path:**
+```
+Phase 0 → RFC-A → CORE-4 → BKD-1 → ARCH-2 → ARCH-3 → ARCH-4
+       → FM-00 → PAR-1 → TRN-1/2 → FT-1 → FM-1/2 → RET-1..RET-6 → REL-1/2
+```
+Any slip here slips v1.0.0. **CORE-4** (computing/vendoring `reduced_symmetric_tensor_product_basis` from first principles, a bounded numpy job) is on the path: it is what lets `mace_core` fix the basis for every device with **no e3nn and no cuequivariance** (§6.5). It pins the canonical path order and per-path normalization (that is the on-disk weight format, §6.5) and also owns the native `full ↔ reduced` conversion used at load; **BKD-1a** implements the canonical serializer against it before FM-00. There is no separate `SegmentedPolynomial` evaluator ticket — the reference keeps its Horner cascade.
+
+**De-scope line** — if capacity runs out, scope is cut in a recorded order rather than silently: several items are roadmap must-haves, so invoking a cut is an explicit, recorded deviation. **The critical path is never cut**, and **RET-6 (`git ls-files mace/ == 0`) is non-negotiable for 1.0** — the retirement is de-scopable but never silent, because the hard release gate blocks the tag.
+
+## 6. The backend / kernel layer
+
+The layer that lets a third party bring a different library or a custom GPU kernel (CUDA/HIP/SYCL/Triton) **without touching the core, without breaking `torch.compile`, and with correct force-training (double-backward)**. It subsumes and simplifies what `mace/modules/wrapper_ops.py` does today, where the backend leaks into the model in at least eight places: `blocks.py:687,790,909,1033` branch on `hasattr(self, "conv_fusion")`, and `wrapper_ops.py:130,157,205,227` monkeypatch `.forward` with `types.MethodType`. RFC-01 (RFC-01) is the full design; the summary below is normative.
+
+### 6.1 The ops contract
+
+A **small, closed** set of primitives — exactly the ops that differ between backends:
+
+- **`ChannelwiseTPConv`** — always node-level: it returns `[n_nodes, …]`. Whether it fuses the scatter into one kernel is a backend-internal choice the model never sees; this deletes the `hasattr(conv_fusion)` branching and the monkeypatch. `num_nodes` is passed explicitly, never inferred from `edge_index.max()`.
+- **`SymmetricContractionOp`**, **`LinearOp`** (bias is first-class, because `cuet.Linear` has none, which is why the legacy bias readouts hardcode `o3.Linear(biases=True)` outside the wrapper), **`FullyConnectedTPOp`** (skip_tp), and **`SegmentReduceOp`** (the one op with no irreps semantics, reused for the energy and pair-repulsion reductions).
+- **`SphericalHarmonicsOp`** and **`RadialBasisOp`** are **reference-only**: closed-form, cheap, never dispatched today; a backend *may* override them but is not required to. Their authoritative reference implementations live in `mace_torch/backends/reference` (the torch-free *spec* — descriptors, Clebsch-Gordan data, tolerances — lives in `mace_core`), which is what removes the CPU-only e3nn dependency from the hot path. **`sphericart` is the concrete candidate for an *accelerated* `SphericalHarmonicsOp`** (fast, CPU+GPU, differentiable to second order) — evaluate it in ARCH-1/BKD-1; it is already an in-tree dependency via the `[magnetic]` extra (#1244), so adopting it as an optional SH override is cheap. The native plain-torch SH stays the reference.
+
+An optional **span factory** `make_interaction_layer(descriptors) -> InteractionLayerOp | NotImplemented` lets a backend fuse the whole interaction layer (`linear_up → conv → linear → symmetric_contraction → linear_out`, with the residual `skip_tp` reading the *pre-conv* input and added after the contraction) into a single kernel (the direction `cue.SegmentedPolynomial` is headed). The model prefers it when present and falls back to the op-by-op path otherwise, using the same `NotImplemented` negotiation as the per-op fallback.
+
+### 6.2 Capability negotiation and dispatch
+
+The authoritative predicate receives the **full descriptor**: `supports(descriptor) -> bool`. Real constraints depend on the irreps' multiplicity structure, not on `(op, device, dtype, lmax)` — cueq's fused conv fails at runtime on non-uniform-multiplicity irreps (`mace_torchsim.py:126-135` catches this and falls back to the hybrid path), which a coarse predicate cannot express. Coarse `ops`/`dtypes`/`max_lmax` is kept only as a cheap first filter. **`vendor` is not a capability**: a ROCm/HIP backend still declares `device="cuda"`.
+
+Backends register via setuptools entry points, per-framework groups **`mace.kernel_backends.torch`** / **`mace.kernel_backends.jax`** — a third party ships a wheel and needs zero repo edits; an import failure (a missing CUDA library) is recorded, not raised. Dispatch is resolved **once at model build time** and frozen into the module tree; nothing resolves in `forward` (no dtype/device/isinstance checks on the hot path — a requirement for clean compiled graphs). A `CompositeBackend` falls back op-by-op to the reference for any op/dtype/device/irreps the primary declines. The one non-fallback rule: a backend lacking double-backward is **hard-rejected at build time for force/stress training** — a loud error, never silently wrong forces.
+
+### 6.3 Compile-safety and custom kernels
+
+Every hot op is a `torch.library.custom_op` with a `register_fake` (meta) impl, so Dynamo propagates shapes without launching the kernel and the op is a single opaque node — no graph break, no `allow_in_graph` gymnastics. `num_nodes` enters as a **symbolic dimension** (a `SymInt`/tensor dim, never a Python `int` and never `edge_index.max()`), and `register_fake` builds the output at the symbolic size, so dynamic shapes do not trigger a recompile. **Data-dependent host work inside an op body is forbidden by contract** — it silently breaks CUDA-graph capture under `reduce-overhead` — and is caught by `test_cudagraph_safe` (capture + replay with the same shapes and different values). A hand-written kernel that declares `supports_double_backward=True` must supply forward, backward, and backward-of-backward (each itself a differentiable op); a first-order-only kernel declares `supports_double_backward=False` and is a first-class **inference** path. The reference backend publishes the analytic second-derivative descriptors so writing that third kernel is transcription, not research.
+
+### 6.4 Two kinds of layout conversion, and only one is free
+
+**Weights** convert once, at the save/load boundary, and are cached in the op: `to_canonical` / `from_canonical` never run in `forward`. Runtime cost, zero.
+
+**Activations** are a different matter. A `mul_ir ↔ ir_mul` permute of node features is bandwidth-bound and happens *every layer, every step*: measured on CPU with 20 000 nodes, 128 channels and `irreps = 0e+1o+2e`, it costs 4.7 ms and moves 369 MB at fp64 — **30–48 % of the equivariant `Linear` over the same tensor**. MACE defaults to fp64. The legacy hybrid path pays exactly this: `wrapper_ops.py:192-202` runs `layout_transpose_in`/`layout_transpose_out` inside `forward`.
+
+So the activation layout is resolved **once for the whole op chain**, not per op, and features carry it end to end. The accelerated backend's native layout wins; the reference backend adapts, because for plain torch a layout is only an einsum index order and costs nothing — the inverse of today's arrangement. Op-level fallback in `CompositeBackend` is numerically sound but can create a seam between two layouts; where it does, the transpose is explicit, counted, and reported at build time, never inserted silently. `test_no_layout_transpose_in_forward` in the conformance suite enforces it. See RFC-01 §3.4.1.
+
+### 6.5 Canonical weights kill the conversion CLIs
+
+A checkpoint stores **canonical weights + the descriptor spec** (safetensors + a JSON sidecar), never a backend-specific `state_dict` — which also resolves the `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD` hazard and decouples weights from the LAMMPS jit. `to_canonical`/`from_canonical` run only at the save/load boundary. One checkpoint loads into any backend, so the five cross-backend converters in `mace/cli/` (two installed console scripts + three importable modules) disappear; the layout conversion becomes an internal, build-time step inside whichever backend needs it.
+
+**The canonical parametrization of the symmetric contraction** (RFC-01 §2.4). The `a1 @ pinv(a2)` map in `cg_cueq_tools.py:109` is a change of *parametrization* over the same basis (`poly1`, which "replicates the behavior of the original MACE implementation" at `cg_cueq_tools.py:75`, ↔ cueq's fused `poly2`), and it applies precisely on the reduced-basis path. **The basis is decided — reduced** — and the on-disk form follows from it with no further parametrization choice:
+
+**The defect it must also repair.** Which Clebsch-Gordan basis a model uses is decided today by three independent inputs — the `--use_reduced_cg` flag (`arg_parser.py:235`, default **`False`**), the `MACE_USE_CUEQ_CG` environment variable (`cg.py:23`, consulted when the argument is `None`), and whether `cuequivariance` happens to be importable (`wrapper_ops.py:385`: `use_reduced_cg = use_reduced_cg and CUET_AVAILABLE`) — with signature defaults that disagree along the chain (`models.py:66` → `True`, `symmetric_contraction.py:34` → `False`, `blocks.py:446` → `None`). Two consequences: **by default every MACE model, on every device, is built over the full, redundant basis**; and an explicit `--use_reduced_cg True` on a host without `cuequivariance` is **silently downgraded** to `False` — the user asked for one architecture and trained another. Measured: the symmetric contraction carries 29 parameters on the reduced basis versus 86 on the full one at `lmax=3`, and checkpoints from the two are not interchangeable without a rectangular map. v1 makes the basis explicit model state, with **one** value for every device and every backend.
+
+**Where the backend/model boundary falls.** Layout (`mul_ir` ↔ `ir_mul`) and parametrization (`poly1` ↔ `poly2`) are *bijections*: same dimension, exact both ways, so a backend may hold whichever it likes and convert at the `to_canonical`/`load_canonical` boundary. The Clebsch-Gordan basis is a *surjection* — it changes the trainable parameter count — so it is **model state, not a backend choice**: `ModelConfig.clebsch_gordan_basis`, serialized with the checkpoint. A backend declares which bases it supports and the build fails loudly on a mismatch; it never selects one. The current code already treats it this way — `use_reduced_cg` is passed to both implementations, and cueq accepts either basis via `original_mace` (`wrapper_ops.py:399`) — which is why line 385 is a defect rather than a design. See RFC-01 §2.4.3.
+
+**Decided: the reduced basis.** `ModelConfig.clebsch_gordan_basis = "reduced"` is the only value for new training. Both the reduced basis and the `full ↔ reduced` conversion are computed **from first principles (Clebsch–Gordan / Wigner) in pure numpy — no e3nn, no cuequivariance** (elementary group theory; neither library is required, and the caveat that the serializer must store the zeroed paths — `symmetric_contraction.py:218-233` — or record the mask in the descriptor stands regardless). The reduced basis is 2.05× faster forward, 1.80× with backward, carries 54–66 % fewer contraction parameters, and gives identical predictions.
+
+**A model may be stored in full basis** — a v0.3 foundation model, or an external artifact. Loading it performs the exact `full → reduced` conversion **at load time** (explicit, function-preserving, fp64), so runtime is always reduced; the persisted v1 checkpoint is reduced. `reduced → full` exists only as an explicit export for external full-basis consumers (Symmetrix/libmace, DEP-3), never at load. **CORE-4** stays ahead of BKD-1 because it **pins the path order and the per-path normalization — that is the on-disk weight format** — and golden-locks the tensors, not the path counts.
+
+The **on-disk layout is not a decision**: measured across the production grid, the `poly1↔poly2` map is a **permutation times a diagonal** — one non-zero per row and column, scales that are square roots of small integers — and the nested tensors are contiguous slices of a flat `[Z, A, mul]` tensor (`convert_e3nn_cueq.py:117-127` concatenates before projecting). The canonical form is that flat tensor. The reference `cat`s and `split`s and keeps its Horner cascade; the cueq backend permutes and rescales once at build time. `mace_core` needs no `SegmentedTensorProduct` machinery and no `SegmentedPolynomial` evaluator. If cueq changes its internal segmentation, only its index buffer changes: **MACE owns its format**. See RFC-01 §2.4.1 and §2.4.5.
+
+### 6.6 Conformance suite
+
+`run_backend_conformance(backend_name, …)` is a parametrized suite any backend runs over itself with one flag: `test_equivariance`, `test_parity_vs_reference`, `test_gradcheck`/`test_gradgradcheck` (the double-backward gate), `test_weight_roundtrip` (cross-backend, the executable proof the converters are unnecessary), `test_compile_no_graph_break` under `torch.compile(fullgraph=True)`, `test_cudagraph_safe`, `test_no_layout_transpose_in_forward`, and `test_capabilities_honest`. Its `ToleranceTable` is edit-locked. The **out-of-tree example backend (BKD-4)** runs the full suite in CI as a **permanent extensibility gate** that exposes exactly what cueq/oeq mask: correct double-backward and a fullgraph-clean compile with zero core edits.
+
+## 7. Risk register
+
+| Risk | Mitigation |
+|------|------------|
+| **`develop` and `mace-reforge` diverge faster than the migration can absorb.** Every fix and self-contained feature that lands on `develop` is work the migration pass owes v1, and the debt grows for the length of the rewrite. | `CONTRIBUTING.md` restricts what `develop` accepts to exactly what can be carried: bug fixes, and self-contained features whose tests pin numbers a port can be checked against. Core and shared changes are refused against v0.3 and go straight to v1, so the divergence stays in additive, portable pieces. A fix that changes numbers also changes the goldens it is pinned by, so the migration regenerates those in its own PR. |
+| **The retirement stalls and the dual toolchain becomes permanent.** | Three gates, none of which depends on anyone remembering: a fitness test that goes **red** when a debt-book date expires; a CI check requiring `git ls-files mace/` to be strictly non-increasing from Phase 3 onward; and the hard 1.0 release gate on `git ls-files mace/ == 0`. |
+| **Path-scoped dual toolchain/CI during the overlap** (`mace/**` → black/isort/pylint/mypy; `packages/**` → ruff/ty/prek). | Accepted; the only recurring, non-self-inflicted cost. Held in check by 1:1 entry-point ownership and the anti-structural meta-lint. |
+| **Global process-state contaminates the in-process oracle** — `mace/__init__` sets `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD`; `e3nn.set_optimization_defaults` is process-wide; default dtype/RNG are global. | The parity harness snapshots and restores **all** global state between runs (env vars, default dtype, e3nn optimization defaults, torch/np RNG), or forks a subprocess and diffs serialized outputs. |
+| **fp32 GPU non-determinism invisible to an fp64 CPU net** — `scatter_add_` is order-nondeterministic on CUDA, so ~1e-4 fp32 differences hide under fp64 tolerance. | A frozen **fp32 bit-reproduction golden** with a deterministic `segment_reduce`; FM release is gated on max-abs-error vs that golden at fp32 machine epsilon, not a loose tolerance. |
+| **Training-numerics gap** — a comparison against a JSON cannot see a gradient bug the size of init noise. | A **one-step, init-agnostic gradient parity test** (per-PR): byte-identical weights in both stacks, one forward+backward on an E+F loss, `d(loss)/d(params)` allclose at fp64 — exercising the `create_graph=True` path — plus a model-level gradgrad/finite-diff of the force+stress loss on the tiny fixture. |
+| **Internally inconsistent legacy energy** — `models.py:581` computes `total_energy = e0 + inter_e` in the model dtype but `node_energy` via an unconditional `.double()`; no single accumulate dtype matches both. | Both quantities are pinned as **separate goldens** (total in model dtype, node in fp64), in **fp32 and fp64**, for both `MACE` and `ScaleShiftMACE` (which further differ in whether the ZBL term is inside or outside the scale-shift). v1 replicates precision per-quantity via `PrecisionConfig.reduction.accumulate_dtype`, not a single global policy. |
+| **Console-script ownership collision** — two distributions declaring the same `console_scripts` is undefined in pip. | Exactly one distribution provides each `mace_*` entry point: `console_scripts` are removed from the root `setup.cfg`, `mace-launcher` is the sole owner, and `packages/mace-torch` ships under a distinct distribution name while keeping the `mace_torch` import name. Asserted in CI. |
+| **No v1 deployment path until DEP-2 lands** — v1 blocks are born without `@compile_mode`, so `jit.compile`/`jit.save` (`create_lammps_model.py:109`, `run_train.py:1145,1160`) cannot script them. | The `--engine=v1` opt-in for the energy capability **explicitly excludes** LAMMPS export/checkpoint until DEP-2 (`torch.export`); deployment stays legacy-only during the window; recorded as a dated burn-step in the debt book. |
+| **Flat-dict couples `torch_geometric` semantics** — several forwards read `num_graphs = data['ptr'].numel()-1`; `ptr`/`batch` are `Batch` collation artifacts. | `ptr`, `batch`, `shifts`, `unit_shifts` are explicit fields of RFC-B's flat-dict contract with a schema validator, plus a golden verifying the v1 collater reproduces `ptr`/`batch` bit-exact. |
+| **CORE-4 is the central mathematical risk** and sits on the critical path. | It is bounded (numpy, self-contained; compute Clebsch–Gordan / Wigner and the reduced basis from first principles — e3nn's MIT routine is one porting reference, but the result depends on **no** runtime library). Golden-locked against an **independent** CPU Clebsch-Gordan derivation — never against itself — reviewed by someone with group-theory expertise, with the cueq round-trip as best-effort nightly confirmation only. `mace_core` depends on **neither e3nn nor cuequivariance** at any point (no interim dependency). |
+| **CORE-4 pins the on-disk weight format.** Not a vendor-algorithm port — `e3nn.o3.ReducedTensorProducts` computes the reduced basis (path counts verified in 21 cases; span verified including `l>0`; `correlation=4` verified). The residual risk is that the **path order and per-path normalization**, which MACE must now invent, are got wrong. | Golden-lock the **tensors**, not the path counts. Review by someone with group-theory/e3nn expertise. Bounded: correcting it later is a `CanonicalSpec.schema_version` bump with an in-repo migration, possible because `full ↔ reduced` is exact in both directions. `wrapper_ops.py:385` and `cg.py:119-126`, which silently substitute the full basis, are bugs to be removed. |
+| **The Clebsch-Gordan basis is decided by three uncoordinated inputs** — a CLI flag defaulting to `False`, an environment variable, and whether `cuequivariance` is importable (`wrapper_ops.py:385`) — so every model defaults to a ~3× over-parametrized symmetric contraction, and an explicit `--use_reduced_cg True` is silently downgraded on a host without cueq. | The canonical-basis decision (§6.5) removes the branch: one basis on every device and backend. A Phase 0 golden pins the parameter count per `(irreps, correlation)` so the coupling cannot reappear. |
+| **The parity harness is a substantial, permanent-until-retirement deliverable** with hand-tuned fp64 tolerances. | Tolerances edit-locked (R5); property/fuzz inputs run nightly (PAR-2), not just tiny goldens. |
+| **torch.compile instability upstream.** | The eager reference path is authoritative; the compiled path is an optimization guarded by a parity smoke, never the only path. |
+
+## 8. Open questions from the roadmap, and how this plan resolves them
+
+1. **"Remove e3nn" vs the CPU-required test matrix** (Ch. 11). cueq is CUDA-only. Resolution (team decision, tightening Ch. 5's "remove **or reduce**" to **remove entirely**): **e3nn and e3nn-jax are removed from the whole project — not used anywhere, not even as a backend.** The plain-PyTorch reference backend is mandatory and native (TP, linear, **gated nonlinearity**, symmetric contraction, spherical harmonics, radial — every e3nn-provided block reimplemented in plain torch, differentiable to second order); `mace_core` computes the Clebsch-Gordan/reduced basis from first principles (numpy, no e3nn, no cueq); mace-jax mirrors torch (native jax reference backend, `cuequivariance_jax` an optional backend). cueq/oeq stay as optional **acceleration** backends and a best-effort nightly oracle — never a requirement for the basis. No transitional e3nn backend.
+2. **`BaseMACE` "no gradients" vs stress-via-strain.** The strain displacement is injected *before* edge vectors are computed (`prepare_graph`), so the derivative engine is not purely downstream of the backbone. ARCH-4 carries a design note reviewed before implementation.
+3. **Principle 4 "foundation models remain loadable" vs D2.** Loadable = one-shot convertible; REL-1 states this explicitly.
+4. **JAX CI burden.** Ch. 11 marks JAX "Required" on both vendors while Ch. 3 makes mace-jax minimal. RFC-D sets the model list and CI tier (recommendation: required NVIDIA, best-effort AMD for v1.0.0).
+5. **"Electrostatics" conflates two things.** PolarMACE lives in-repo (`mace/modules/extensions.py`) and is golden-gated (ELEC-2); graph_longrange is external and can slip to beta (ELEC-1).
+6. **E0s "readout-only" vs current ScaleShiftMACE semantics** — a real numerical-equivalence question for the converter. RFC-C resolves it before ARCH-3; FM-00 enforces it.
+7. **Tooling schism.** Ch. 11 mandates ruff+ty+prek; the legacy tree uses black/isort/pylint/mypy. Resolved by the path-scoped dual toolchain during the overlap (R1/INF-4): `mace/**` keeps the frozen legacy toolchain, `packages/**` runs ruff+ty+prek; no mixed state on one path. The schism ends when RET-* removes `mace/`.
+8. **External dependencies with no code owner:** fine-tuning data hosting, DOI repository choice, MPI GPU-node security hardening, steering-committee funding, and the GPU-fleet gaps (§3). Tracked here as external dependencies needing named human owners before FT-2, FM-3, and GOV work can finish.
+9. **Metadata scope ambiguity** ("at minimum foundation models, possibly all"). Decided: mandatory for **all** models — nearly free once CORE-2/CLI-1 exist.
+10. **v1 naming.** The import names `mace_core`/`mace_torch`/`mace_jax` never collide with `mace` by construction; the distribution name for the new torch package is distinct (§7, console-script row). Decided and not revisited.
+
+## 9. Traceability
+
+| Roadmap chapter/axis | Plan section / tickets |
+|---|---|
+| Ch. 3 package structure | §2, [`target_layout.md`](target_layout.md), INF-* |
+| Ch. 4 model architecture (Axis A) | ARCH-*, CORE-1 |
+| Ch. 5 backend/perf (B, I, K) | §6, BKD-*, RFC-A |
+| Ch. 6 training/loss (C, G) | TRN-*, CFG-1 |
+| Ch. 7 electrostatics (L) | ELEC-1/2 |
+| Ch. 8 data pipeline (E) | DATA-*, RFC-B |
+| Ch. 9 config/CLI/fine-tuning/FM usability (D, F, O) | CORE-2, CFG-1, CLI-1, FT-*, FM-3, RFC-C |
+| Ch. 10 deployment (H) | DEP-*, RFC-D |
+| Ch. 11 testing/CI (M) | Phase 0, P0-*, PAR-*, FM-3 (badge matrix) |
+| Ch. 12 educational reference | EDU-1/2 |
+| Ch. 13 community/governance (N) | GOV-1/2 |
+| Ch. 14–15 timeline/dependencies | §4–§5 |
+| Ch. 16 risks | §7 |
+| Appendix A open questions | RFC docs 01…08 via tickets RFC-A…D |
+| Appendix B CLI migration map | CLI-1, REL-1 |
+
+## 10. Ticket index
+
+Every ticket ID in this document is a GitHub issue in `ACEsuit/mace`, tracked on the [board](https://github.com/orgs/ACEsuit/projects/2). Phase 0 and the RFC-track tickets are not on the board: Phase 0 characterized the frozen legacy before the plan opened, and the RFC decisions are inlined into the tickets they block.
+
+| Family | Tickets |
+|---|---|
+| **ARCH** | [ARCH-1](https://github.com/ACEsuit/mace/issues/1559) · [ARCH-2](https://github.com/ACEsuit/mace/issues/1561) · [ARCH-3](https://github.com/ACEsuit/mace/issues/1562) · [ARCH-4](https://github.com/ACEsuit/mace/issues/1563) · [ARCH-5](https://github.com/ACEsuit/mace/issues/1633) |
+| **BKD** | [BKD-1](https://github.com/ACEsuit/mace/issues/1560) · [BKD-1a](https://github.com/ACEsuit/mace/issues/1564) · [BKD-2](https://github.com/ACEsuit/mace/issues/1566) · [BKD-3](https://github.com/ACEsuit/mace/issues/1567) · [BKD-4](https://github.com/ACEsuit/mace/issues/1568) |
+| **CFG** | [CFG-1](https://github.com/ACEsuit/mace/issues/1574) |
+| **CLI** | [CLI-1](https://github.com/ACEsuit/mace/issues/1579) |
+| **CORE** | [CORE-1](https://github.com/ACEsuit/mace/issues/1555) · [CORE-2](https://github.com/ACEsuit/mace/issues/1556) · [CORE-3](https://github.com/ACEsuit/mace/issues/1557) · [CORE-4](https://github.com/ACEsuit/mace/issues/1558) |
+| **DATA** | [DATA-1](https://github.com/ACEsuit/mace/issues/1569) · [DATA-2](https://github.com/ACEsuit/mace/issues/1570) · [DATA-3](https://github.com/ACEsuit/mace/issues/1571) |
+| **DEP** | [DEP-1](https://github.com/ACEsuit/mace/issues/1583) · [DEP-1a](https://github.com/ACEsuit/mace/issues/1634) · [DEP-2](https://github.com/ACEsuit/mace/issues/1594) · [DEP-3](https://github.com/ACEsuit/mace/issues/1595) · [DEP-4](https://github.com/ACEsuit/mace/issues/1596) |
+| **EDU** | [EDU-1](https://github.com/ACEsuit/mace/issues/1607) · [EDU-2](https://github.com/ACEsuit/mace/issues/1608) |
+| **ELEC** | [ELEC-1](https://github.com/ACEsuit/mace/issues/1591) · [ELEC-2](https://github.com/ACEsuit/mace/issues/1592) · [ELEC-3](https://github.com/ACEsuit/mace/issues/1593) · [ELEC-4](https://github.com/ACEsuit/mace/issues/1635) |
+| **FM** | [FM-00](https://github.com/ACEsuit/mace/issues/1565) · [FM-1](https://github.com/ACEsuit/mace/issues/1586) · [FM-2](https://github.com/ACEsuit/mace/issues/1587) · [FM-3](https://github.com/ACEsuit/mace/issues/1588) · [FM-4](https://github.com/ACEsuit/mace/issues/1636) |
+| **FT** | [FT-1](https://github.com/ACEsuit/mace/issues/1580) · [FT-2](https://github.com/ACEsuit/mace/issues/1581) · [FT-3](https://github.com/ACEsuit/mace/issues/1582) · [FT-4](https://github.com/ACEsuit/mace/issues/1637) |
+| **GATE** | [GATE-3](https://github.com/ACEsuit/mace/issues/1585) |
+| **GOV** | [GOV-1](https://github.com/ACEsuit/mace/issues/1609) · [GOV-2a](https://github.com/ACEsuit/mace/issues/1638) · [GOV-2b](https://github.com/ACEsuit/mace/issues/1610) |
+| **INF** | [INF-1](https://github.com/ACEsuit/mace/issues/1550) · [INF-2](https://github.com/ACEsuit/mace/issues/1551) · [INF-3](https://github.com/ACEsuit/mace/issues/1552) · [INF-4](https://github.com/ACEsuit/mace/issues/1553) · [INF-5](https://github.com/ACEsuit/mace/issues/1554) |
+| **JAX** | [JAX-1](https://github.com/ACEsuit/mace/issues/1589) · [JAX-2](https://github.com/ACEsuit/mace/issues/1590) |
+| **MAG** | [MAG-1](https://github.com/ACEsuit/mace/issues/1584) |
+| **PAR** | [PAR-1](https://github.com/ACEsuit/mace/issues/1572) · [PAR-2](https://github.com/ACEsuit/mace/issues/1573) |
+| **REL** | [REL-1](https://github.com/ACEsuit/mace/issues/1603) · [REL-2](https://github.com/ACEsuit/mace/issues/1604) · [REL-3](https://github.com/ACEsuit/mace/issues/1605) · [REL-4](https://github.com/ACEsuit/mace/issues/1606) |
+| **RET** | [RET-1](https://github.com/ACEsuit/mace/issues/1597) · [RET-2](https://github.com/ACEsuit/mace/issues/1598) · [RET-3](https://github.com/ACEsuit/mace/issues/1599) · [RET-4](https://github.com/ACEsuit/mace/issues/1600) · [RET-5](https://github.com/ACEsuit/mace/issues/1601) · [RET-6](https://github.com/ACEsuit/mace/issues/1602) |
+| **TRN** | [TRN-1](https://github.com/ACEsuit/mace/issues/1575) · [TRN-2](https://github.com/ACEsuit/mace/issues/1576) · [TRN-3](https://github.com/ACEsuit/mace/issues/1577) · [TRN-4](https://github.com/ACEsuit/mace/issues/1578) · [TRN-5](https://github.com/ACEsuit/mace/issues/1639) |

--- a/docs/reforge/run_train_rewrite.md
+++ b/docs/reforge/run_train_rewrite.md
@@ -1,0 +1,114 @@
+# Rewriting `run_train`: from a 1,090-line `run(args)` to a staged pipeline
+
+**Status:** design note · **Expands:** the Phase 3 tickets **CFG-1** (config schema), **TRN-1**
+(staged pipeline + explicit loop), **TRN-2/3/4** (losses, dataloaders, checkpoint/DDP) and
+**CLI-1** (`mace train`) for the training driver specifically. **Companions:**
+[`plan.md`](plan.md) §4 (Phase 3), the [ticket board](https://github.com/orgs/ACEsuit/projects/2), roadmap Ch. 6/9.
+
+This is a design note, not a new decision surface. The staged-pipeline direction is already
+decided (roadmap Ch. 6, plan Phase 3); this doc pins *how* it lands for `run_train`, block by
+block, so TRN-1/CFG-1 are writable without re-deriving the mapping. Behavior is pinned by **P0-5**
+(E2E CLI contracts) and **PAR-1** (in-process parity vs frozen legacy); the rewrite reproduces
+numbers, not structure.
+
+## 1. The mess, concretely
+
+`mace/cli/run_train.py` is **1,181 lines**; `run(args)` is a single function spanning lines
+**88→1181** (~1,090 lines — the roadmap's headline number). Measured properties of that function,
+all on frozen `mace/` (read in place, never edited):
+
+- **The argparse `Namespace` is the data model.** `run()` reads **71 distinct `args.*`
+  attributes** and **mutates `args` in place in ~25 sites** — the namespace is both input and
+  scratch state. Examples (absolute line numbers):
+  - `args.heads = prepare_default_head(args)` (`:237`), `args.r_max = model_foundation.r_max...`
+    (`:187`), `args.loss = "universal"` (`:383`), `args.enable_oeq = False` (`:797`),
+    `args.avg_num_neighbors = get_avg_num_neighbors(...)` (`:752`).
+  - Foundation-model presets silently overwrite user inputs: `args.lr = 0.0001`,
+    `args.ema = True`, `args.ema_decay = 0.99999` (`:208-210`).
+- **Model identity is a string that rewrites the observable set.** `:536-573` branches on
+  `args.model == "AtomicDipolesMACE" | "AtomicDielectricMACE" | "EnergyDipolesMACE" | "PolarMACE"`
+  and sets six `args.compute_*` booleans by hand per class. Adding an output means editing this
+  ladder.
+- **Everything is interleaved in one scope.** Foundation-model resolution → head prep → data
+  loading (xyz / h5 / aselmdb branching, ASE-vs-non-ASE file splitting) → z-table → atomic
+  energies / E0s (multiple branches incl. foundation, estimated, padding) → pseudolabels →
+  dataloaders → `configure_model` → cueq/oeq conversion → optimizer/scheduler → SWA/stage-two →
+  EMA → checkpoint resume → `tools.train(...)`. No stage boundary; a change in E0 handling sits
+  next to a change in the optimizer.
+- **The parser matches.** `mace/tools/arg_parser.py` is **1,316 lines** of untyped flags, config
+  lives only as an optional `configargparse` YAML path.
+
+The failure mode this produces: no place to validate before running, no typed contract between
+"what data do we have" and "what model do we build", and foundation-model/fine-tuning logic
+smeared across the whole function instead of isolated.
+
+## 2. Target: three stages with typed boundaries
+
+Roadmap Ch. 6 / TRN-1. `run()` becomes an **orchestrator of ~40 lines** that wires three stages;
+the argparse namespace never crosses a stage boundary. Each stage takes and returns a typed object
+(Pydantic / dataclass, defined in `mace_core`):
+
+```
+ResolvedConfig ──▶ DataStage ──▶ DataBundle ──▶ ModelStage ──▶ BuiltModel ──▶ TrainStage ──▶ TrainedModel
+   (CFG-1)          (TRN-1)      (typed)        (TRN-1)        (typed)         (TRN-1)         (+ metadata)
+```
+
+- **`ResolvedConfig` (CFG-1, CORE-2).** One Pydantic object with `data / model / loss / optimizer /
+  schedule / runtime / finetune` sections; config-file-first (TOML/YAML/JSON) with dotted CLI
+  overrides; unknown keys are hard errors. All defaults filled and **saved into model metadata**
+  (mandatory for every model, plan flag #10). A `from_namespace(args)` shim maps the legacy flag
+  surface onto it so the legacy CLI keeps working during coexistence.
+- **`DataStage` → `DataBundle`.** Owns everything from §1's data block: backends yield
+  `Configuration`s (RFC-05), graph building/collation once above the backend (RFC-03), z-table,
+  **E0 resolution as a typed `E0Spec` union** (RFC-07, replacing the six stringly-typed `--E0s`
+  paths and their silent fallbacks), statistics (avg neighbors, mean/std) via the single
+  `mace_core` implementation. Pseudolabel generation is a **callable stage** here (RFC-06), not
+  `requires_grad` juggling welded into training.
+- **`ModelStage` → `BuiltModel`.** The successor to `configure_model`: `ResolvedConfig` +
+  statistics → a two-layer `BaseMACE` + `MACEOutputs`. **Observables are declared, not
+  hand-set** — the `args.compute_*` ladder (§1) disappears; declaring `energy, forces, dipole`
+  in config creates the heads (ARCH-3, CORE-1). Backend dispatch resolves here, once, at build
+  time (RFC-01); the in-place cueq/oeq conversion goes away.
+- **`TrainStage` → `TrainedModel`.** An **explicit train/validate/checkpoint/EMA/stage-two loop**
+  (a few hundred readable lines, no Lightning, reproducible by a power user), losses composed from
+  observable specs (TRN-2), multi-dataloader balancing (TRN-3), checkpoint/resume on
+  **safetensors** + DDP (TRN-4). Fine-tuning is not a special case: replay vs real head differ
+  only in their data source (FT-1).
+
+## 3. Responsibility map (current `run()` block → v1 destination)
+
+| Current `run()` responsibility (frozen `mace/`) | v1 home | Ticket |
+|---|---|---|
+| Parse + mutate `args` namespace | `ResolvedConfig` (immutable, validated) + `from_namespace` shim | CFG-1, CORE-2 |
+| Foundation-model resolution + preset overrides (`:187-210`) | `finetune` config section + `ModelStage`; presets are declared defaults, never silent mutations | CFG-1, FT-1 |
+| Head prep / multihead / `pt_head` (`:226-237`) | typed head configs; replay head = same interface, different source | FT-1 |
+| Data loading, xyz/h5/aselmdb + ASE-file splitting (`:248-660`) | `DataStage`; backends yield `Configuration` (RFC-05), graph build once (RFC-03) | DATA-1/2/3 |
+| z-table + atomic energies + E0s + padding (`:329-495`) | `E0Spec` typed union + resolver; silent fallbacks become hard errors | RFC-07, CFG-1 |
+| Pseudolabels (`:595`) | callable `generate_pseudolabels` stage, rank-0, persisted artifact | RFC-06, FT-2 |
+| `args.compute_*` set by model-class string (`:536-573`) | declarative observables → automatic heads | CORE-1, ARCH-3 |
+| `configure_model` (`:755`) | `ModelStage` (`ResolvedConfig` + stats → model) | TRN-1, ARCH-2/3 |
+| cueq/oeq in-place conversion (`:806`) | backend resolved once at build time; no conversion CLIs | RFC-01, BKD-1/3 |
+| optimizer / LRScheduler / SWA / EMA / resume (`:780-890`) | `TrainStage` setup, per-stage schedules | TRN-1/2 |
+| `tools.train(...)` + checkpoint + save (`:942…`) | explicit loop, safetensors checkpoint, resolved-config metadata | TRN-1/4 |
+
+## 4. Coexistence and how it ships
+
+- **Launcher (INF-2).** `mace_run_train` is owned by `mace-launcher`; `--engine legacy` (default)
+  calls the frozen `mace.cli.run_train:run` **byte-identically**; `--engine v1` calls
+  `mace_torch.cli.run_train`. Day-one behavior is unchanged.
+- **CLI-1** exposes it as `mace train` with a faithful port of the pinned legacy flag surface, so
+  the 65 black-box workflow tests re-run under `--engine v1` unchanged (one indirection in
+  `tests/helpers.py`).
+- **Gate (GATE-3).** `mace train --engine v1` on the tiny task reaches legacy-comparable
+  loss/errors (`tiny_scaleshift_training_errors.json`), reinforced by PAR-1's single-step gradient
+  parity. The default flips to `v1` only when parity is green; legacy stays as the oracle until
+  RET-1 deletes it.
+
+## 5. Out of scope / open
+
+- **Not this doc:** the full `arg_parser` → config field mapping (CFG-1 owns it, driven by the P0-0
+  inventory), the derivative engine seam (ARCH-4), the loss algebra (P0-6/TRN-2).
+- **CLI surface reduction** (eval/plot/active-learning, marked REVIEW in the inventory) is decided
+  in the broader CLI redesign, not here — this note only covers the training driver.
+- **Open:** exact stage-boundary object schemas (TRN-1 first PR), and whether `DataStage` and
+  `ModelStage` share a single `Statistics` object or recompute — settled when TRN-1 is written.

--- a/docs/reforge/target_layout.md
+++ b/docs/reforge/target_layout.md
@@ -1,0 +1,681 @@
+# MACE v1 final layout: three packages, one-way dependency, registry-based extensibility
+
+## 0. Scope and guiding principle
+
+This is the **destination** (not the path). It covers everything `mace/` does today (75 modules) regrouped into three packages with a **strict one-way dependency direction**. The rule that shapes the entire tree:
+
+```
+mace_jax ─┐
+          ├──▶ mace_core  ◀── mace_torch
+          (mace_core does not import torch, jax, e3nn, or matscipy-with-torch)
+```
+
+`mace_core` is the shared contract and pure math (numpy). `mace_torch` and `mace_jax` are *implementations* of the same contract. Neither imports the other. Legacy `mace/` is unreachable from all three. The glue lives in `mace-launcher` (entry points) and `tests/parity/` (oracle), both on the double-import allowlist.
+
+---
+
+## 1. Final directory tree (file-level)
+
+> Paths below use the `packages/` container — the name in force through the entire migration
+> (Milestones A–B), while the frozen legacy `mace/` still lives at the root. The optional final
+> step **REL-4** renames `packages/ → mace/` once `git ls-files mace/ == 0` (§5, Milestone C);
+> import names (`mace_core`/`mace_torch`/`mace_jax`) are unaffected either way.
+
+### 1.1 `packages/mace-core/` — contract + pure math, **no torch/jax/e3nn**
+
+```
+packages/mace-core/
+├── pyproject.toml                      # import name `mace_core`; deps: numpy, pydantic, matscipy; NO torch
+├── src/mace_core/
+│   ├── __init__.py                     # re-exports public types/config/registries; does NOT import heavy submodules
+│   ├── _version.py                     # contract version (semver of the weights format/spec)
+│   │
+│   ├── types.py                        # MACEOutputs (typed dataclass, replaces the get_outputs dict); GRAPH_SCHEMA + GraphInfo/GraphView (rfc-03 flat-dict contract)
+│   ├── graph.py                        # flat-dict contract {node_attrs,edge_index,positions,batch,cell,shifts,...} + shape/dtype validation
+│   │
+│   ├── config/
+│   │   ├── __init__.py                 # ModelConfig.from_namespace(args) shim from legacy argparse → Pydantic
+│   │   ├── model.py                    # ModelConfig Pydantic (replaces the ~100 args.* of configure_model)
+│   │   ├── precision.py                # PrecisionConfig (default_dtype, float64 accumulation, tf32) — replaces the scattered .double()
+│   │   ├── training.py                 # TrainConfig, StageTwoConfig (ex-SWA), EMAConfig, OptimizerConfig, SchedulerConfig
+│   │   ├── data.py                     # DataConfig (E0s: average/estimated/dict), heads, cutoff, num_workers
+│   │   ├── loss.py                     # LossConfig (energy/forces/stress/virials/dipole weights)
+│   │   └── backend.py                  # BackendConfig (kernel backend name + options; replaces CuEquivarianceConfig/OEQConfig)
+│   │
+│   ├── elements/
+│   │   ├── number_table.py             # AtomicNumberTable (reimplemented; mirror of tools/utils.py, without dragging in train.py)
+│   │   └── default_keys.py             # DefaultKeys (reimplemented; mirror of tools/default_keys.py)
+│   │
+│   ├── observables/
+│   │   ├── __init__.py                 # OBSERVABLE_REGISTRY (declarative: name → spec)
+│   │   ├── base.py                     # Observable protocol: output irreps, how it's derived (readout | autograd | grad-strain)
+│   │   ├── energy.py                   # Energy, SiteEnergy (readout+scatter_sum)
+│   │   ├── forces.py                   # Forces (=-dE/dx via autograd) — spec only, the physics is executed by mace_torch/mace_jax
+│   │   ├── stress.py                   # Stress, Virials (grad w.r.t. strain; sign convention PINNED here)
+│   │   ├── dipole.py                   # Dipole, AtomicDipole
+│   │   ├── polarizability.py           # Polarizability (dielectric/polar)
+│   │   └── hessian.py                  # Hessian (second derivative)
+│   │
+│   ├── kernels/
+│   │   ├── protocol.py                 # KernelBackend Protocol, generic over TensorT: make_* factories + capabilities (§3.1)
+│   │   ├── precision.py                # Precision = Literal["float64","float32",…] — dtype NAMES, never torch.dtype
+│   │   ├── descriptors.py              # IrrepsDescriptor, TPDescriptor, ContractionDescriptor (irreps+instructions, no weights)
+│   │   ├── registry.py                 # get_backend(name, framework) via entry_points('mace.kernel_backends.{torch,jax}')
+│   │   └── canonical.py               # canonical weight layout + to_canonical/load_canonical spec (kills the 5 convert_* modules)
+│   │
+│   ├── clebsch_gordan/
+│   │   ├── coefficients.py             # Clebsch-Gordan coefficients / Wigner (mirror of tools/cg.py: U_matrix_real, pure numpy)
+│   │   ├── reduced_basis.py            # reduced symmetric TP basis + the PINNED path order and normalization (the file format, RFC-01 §2.4.1)
+│   │   └── irreps.py                   # e3nn-independent irreps utilities (parse, dim, mul_ir/ir_mul layout)
+│   │
+│   ├── neighbors/
+│   │   └── neighborhood.py             # matscipy neighbor construction (mirror of data/neighborhood.py; numpy, no torch)
+│   │
+│   ├── data_spec/
+│   │   ├── configuration.py            # Configuration (raw parsed structure; mirror of data/utils.py without torch)
+│   │   ├── xyz.py                       # XYZ / extxyz parser → Configuration (E0s, energy/forces/stress keys)
+│   │   ├── statistics.py               # avg_num_neighbors, energy-forces mean/std; statistics.json format
+│   │   └── shard_format.py             # HDF5/LMDB shard spec (schema, not torch I/O)
+│   │
+│   ├── weights/
+│   │   ├── neutral_format.py           # neutral safetensors + JSON format (stable spec; basis for the FM converter)
+│   │   └── extract_spec.py             # declarative description of which weights each model has (replaces extract_config_mace_model via reflection)
+│   │
+│   └── registries.py                   # string→spec registries: MODEL_REGISTRY, READOUT_REGISTRY, INTERACTION_REGISTRY, LOSS_REGISTRY, TRANSFORM_REGISTRY, DATASET_REGISTRY, SCALING_REGISTRY (specs/names only; torch classes are registered in mace_torch)
+│
+└── tests/                              # pure core tests (no torch) — see §4.1
+    ├── test_clebsch_gordan.py          # golden Clebsch-Gordan vs hand-computed values (P0-6 fragments)
+    ├── test_reduced_basis.py           # golden-locks the basis TENSORS, order and scales (not just path counts)
+    ├── test_neighborhood.py            # P0-7 neighbors/batching
+    ├── test_config_from_namespace.py   # ModelConfig.from_namespace round-trip of all legacy args
+    ├── test_observable_registry.py     # each observable declares consistent irreps/derivation
+    └── test_canonical_layout.py        # to_canonical/load_canonical round-trip (golden)
+```
+
+`clebsch_gordan/reduced_basis.py` computes the reduced symmetric tensor-product basis and — the numerics-critical part — **pins its path order and per-path normalization**, which *is* the on-disk weight format (RFC-01 §2.4.1). The basis is computed **from first principles (Clebsch–Gordan / Wigner) in pure numpy — no e3nn, no cuequivariance** (both are elementary group theory; neither library is required). The `full ↔ reduced` conversion is likewise native (full→reduced exact, reduced→full min-norm), so **loading a full-basis artifact converts it to reduced at load time** with no accelerated dependency. No `SegmentedPolynomial` evaluator is needed: the reference keeps a Horner cascade, and the cueq backend applies its own scaled-permutation at its boundary (§1.2, `backends/cueq/canonical.py`).
+
+### 1.2 `packages/mace-torch/` — models, training, backends, deployment
+
+```
+packages/mace-torch/
+├── pyproject.toml                      # import name `mace_torch`; deps: torch, ase, mace_core; NO e3nn (removed entirely); CLI and kernel_backends entry_points
+├── src/mace_torch/
+│   ├── __init__.py                     # public API: MACE model factory, Calculator; does NOT set TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD globally
+│   │
+│   ├── graph/
+│   │   ├── batch.py                    # torch tensorization of the rfc-03 flat graph dict; replaces AtomicData+torch_geometric in the model INTERFACE
+│   │   └── collate.py                  # collation of configurations → flat graph dict (no torch_geometric.data.Data)
+│   │
+│   ├── kernels/
+│   │   ├── dtypes.py                   # binds mace_core's Precision names to torch.dtype — the framework seam
+│   │   ├── ops.py                      # the 3 hot ops as torch.library.custom_op: channelwise_tp_conv, symmetric_contraction, segment_reduce
+│   │   ├── fake.py                     # register_fake (shape-only meta impls) → torch.compile with no graph-break
+│   │   └── autograd_ref.py             # reference autograd.Function (double-backward) for the 3 hot ops
+│   │
+│   ├── backends/
+│   │   ├── reference/
+│   │   │   ├── backend.py              # ReferenceBackend: implements KernelBackend in plain torch — NO e3nn (native TP/linear/contraction; the correctness oracle, CPU-ok)
+│   │   │   └── sph_harm.py             # spherical harmonics + reference radial basis (non-hot)
+│   │   ├── cueq/
+│   │   │   ├── backend.py              # CuEqBackend: wraps cuequivariance behind the Protocol (kills the types.MethodType monkeypatch)
+│   │   │   └── canonical.py            # to_canonical/load_canonical ONLY at the boundary (mul_ir↔ir_mul reshape; the canonical→fused-basis map is a scaled permutation applied once at build time, rfc-01 §2.4.1)
+│   │   ├── oeq/
+│   │   │   ├── backend.py              # OEQBackend: wraps OpenEquivariance behind the Protocol
+│   │   │   └── canonical.py            # oeq layout boundary
+│   │   └── example/
+│   │       └── backend.py             # EXAMPLE backend, out-of-tree-shaped (permanent extensibility gate; zero core edits)
+│   │
+│   ├── nn/                             # blocks WITHOUT @compile_mode('script') from day 1
+│   │   ├── embedding.py                # LinearNodeEmbeddingBlock, RadialEmbeddingBlock
+│   │   ├── radial.py                   # BesselBasis, ChebychevBasis, GaussianBasis, PolynomialCutoff, ZBLBasis, AgnesiTransform, SoftTransform, RadialMLP
+│   │   ├── interaction.py              # the 6 RealAgnostic*InteractionBlock (fusion-agnostic forward: calls channelwise_tp_conv)
+│   │   ├── product_basis.py            # EquivariantProductBasisBlock (uses the symmetric_contraction op; no layout torch.transpose)
+│   │   ├── symmetric_contraction.py    # SymmetricContraction as a native op (no fx.symbolic_trace, no CodeGenMixin)
+│   │   ├── readout.py                  # LinearReadoutBlock, NonLinearReadoutBlock, NonLinearBiasReadoutBlock, GeneralNonLinearBiasReadoutBlock, LinearDipoleReadoutBlock, NonLinearDipoleReadoutBlock
+│   │   ├── scale_shift.py              # ScaleShiftBlock (E0-after-shift semantics PINNED per-model)
+│   │   ├── gate.py                     # equivariant gates (mirror of modules/gate.py)
+│   │   ├── field.py                    # field_blocks (LES/external field)
+│   │   ├── irreps_layout.py            # reshape_irreps/transpose layout (only called by the backend boundary, not the forward)
+│   │   └── lora.py                     # LoRA adapters for fine-tuning
+│   │
+│   ├── models/
+│   │   ├── base.py                     # two-layer BaseMACE: forward→MACEOutputs; built from ModelConfig; declarative observables
+│   │   ├── energy.py                   # MACE, ScaleShiftMACE
+│   │   ├── dipole.py                   # AtomicDipolesMACE, EnergyDipolesMACE
+│   │   ├── dielectric.py               # AtomicDielectricMACE
+│   │   ├── electrostatics.py           # PolarMACE (ex-extensions.py; electrostatics/LES)
+│   │   └── build.py                    # configure_model equivalent: ModelConfig + statistics → model instance
+│   │
+│   ├── physics/
+│   │   └── outputs.py                  # get_outputs torch: forces via autograd, virial/stress via strain; displacement injection (prepare_graph)
+│   │
+│   ├── data/
+│   │   ├── dataset_xyz.py              # in-memory dataset from XYZ → flat graph dicts
+│   │   ├── hdf5_dataset.py             # on-line HDF5 shards
+│   │   ├── lmdb_dataset.py             # on-line LMDB shards
+│   │   ├── fairchem_dataset.py         # fairchem-style loader (ex-tools/fairchem_dataset)
+│   │   ├── padding.py                  # padding_tools (fixed-size batches for compile/LAMMPS)
+│   │   ├── dataloader.py               # DataLoader (own collation; no vendored tools/torch_geometric)
+│   │   └── distributed_sampler.py      # multi-GPU DDP sampler
+│   │
+│   ├── train/
+│   │   ├── loop.py                     # train()/evaluate() by stage (stage-two ex-SWA)
+│   │   ├── ema.py                      # EMA
+│   │   ├── metrics.py                  # MACELoss torchmetric
+│   │   ├── loss.py                     # WeightedEnergyForces(Stress/Virials/Dipole/Huber/L1L2)Loss, UniversalLoss, DipolePolarLoss (registered in LOSS_REGISTRY)
+│   │   ├── checkpoint.py               # checkpoint I/O (canonical tensors: safetensors + JSON sidecar per rfc-01 §2.1 — no pickle, NO jit.save)
+│   │   ├── schedulers.py               # LR schedulers + schedulefree
+│   │   ├── stage_two.py                # stage-two switch (start_stage_two)
+│   │   ├── ddp.py                      # distributed_tools (CPU/GPU DDP setup)
+│   │   └── slurm.py                    # slurm_distributed
+│   │
+│   ├── finetune/
+│   │   ├── foundations.py              # load_foundations / load_foundations_elements (copies compatible weights)
+│   │   ├── multihead.py                # HeadConfig, prepare_default_head, prepare_pt_head, multihead_tools
+│   │   ├── replay.py                   # assemble_replay_data, pt_head replay
+│   │   ├── pseudolabels.py             # generate_pseudolabels_for_configs
+│   │   └── select_subset.py            # fine_tuning_select (farthest-point sampling / fpsample)
+│   │
+│   ├── calculators/
+│   │   ├── ase_calculator.py           # ASE Calculator (ex-calculators/mace.py)
+│   │   ├── foundations.py              # mace_mp / mace_off / mace_polar (download+cache; ~/.cache/mace)
+│   │   ├── torchsim.py                 # backend torchsim
+│   │   ├── lammps.py                   # LAMMPS runtime adapter: translates LAMMPS real/ghost partitioning into the rfc-03 graph contract (LocalityInfo) — NO lammps_class/lammps_natoms branches in the model (rfc-01 §6b.1)
+│   │   └── lammps_mliap.py             # ML-IAP runtime adapter (the Python object LAMMPS calls; boundary-only)
+│   │
+│   ├── deploy/
+│   │   ├── export.py                   # torch.export/AOTInductor for LAMMPS (default + mliap); replaces jit.compile
+│   │   ├── export_adapter.py           # EMERGENCY ESCAPE HATCH: the one scriptable module isolated in case torch.export slips
+│   │   ├── select_head.py              # select_head for multihead export
+│   │   └── neutral_io.py               # save/load to mace_core.weights' neutral safetensors+JSON format
+│   │
+│   └── cli/
+│       ├── run_train.py                # training main (thin adapter: parse args → ModelConfig → train.loop)
+│       ├── eval_configs.py             # eval over XYZ
+│       ├── preprocess_data.py          # mace_prepare_data (shards + statistics.json)
+│       ├── create_lammps_model.py      # LAMMPS export (uses deploy/export.py)
+│       ├── select_head.py              # mace_select_head
+│       ├── convert_device.py           # mace_convert_device (still useful: cpu↔cuda)
+│       ├── fine_tuning_select.py       # mace_finetuning_select
+│       ├── active_learning_md.py       # active learning MD
+│       ├── plot_train.py               # training plots (ex-plot_train/visualise_train)
+│       └── arg_parser.py               # argparse parser (source of flags; delegates to ModelConfig/TrainConfig)
+│
+└── tests/                              # see §4 (backend conformance, parity, equivariance, E2E)
+    ├── unit/                           # value-tests ported from the ~18 legacy white-box tests
+    ├── backends/                       # KernelBackend conformance + backend-vs-reference parity
+    ├── workflows/                      # E2E CLI (subprocess), auto-slow
+    ├── extensions/{polar,les,torchsim,schedulefree}/
+    ├── foundations/                    # network-marked
+    └── integrations/lammps/            # contract + bin_lammps
+```
+
+### 1.3 `packages/mace-jax/` — parallel destination, off the critical path
+
+```
+packages/mace-jax/
+├── pyproject.toml                      # import name `mace_jax`; deps: jax, mace_core; NO e3nn-jax (removed entirely); cuequivariance_jax is an OPTIONAL backend, never a base dep; NEVER imports mace_torch
+├── src/mace_jax/
+│   ├── __init__.py
+│   ├── graph.py                        # flat-dict graph contract bound to jax.Array (same schema as mace_core.graph, rfc-03)
+│   ├── kernels/
+│   │   ├── ops.py                      # jax primitives (jax.lax scatter/segment_sum, NATIVE tp/contraction over mace_core's irreps/Clebsch-Gordan — no e3nn-jax)
+│   │   └── reference.py               # jax reference backend
+│   ├── nn/                             # equivalent blocks in flax/haiku-like
+│   │   ├── interaction.py
+│   │   ├── product_basis.py
+│   │   ├── symmetric_contraction.py
+│   │   ├── readout.py
+│   │   └── radial.py
+│   ├── models/
+│   │   ├── base.py                     # BaseMACE jax → MACEOutputs
+│   │   └── energy.py                   # MACE / ScaleShiftMACE jax
+│   ├── physics/outputs.py              # forces/stress via jax.grad (first derivatives only — inference-only per D1)
+│   ├── data/dataset.py                 # jax loader
+│   ├── deploy/neutral_io.py            # loads from the neutral safetensors+JSON format
+│   └── cli/eval.py                     # CLI jax, inference-only (validated against goldens + the neutral format, NOT against the legacy E2E harness). NO training loop / run_train here: mace-jax is inference-only (plan D1, rfc-02 §1.1). There is no JAX training anywhere — the educational `tutorials/` (EDU-1) is evaluation/inspection-only
+└── tests/
+    ├── test_parity_neutral.py          # v1-jax loaded from the neutral format == fp64 goldens
+    └── test_equivariance.py            # jax equivariance
+```
+
+### 1.4 `packages/mace-launcher/` — the glue (double-import allowlist)
+
+```
+packages/mace-launcher/
+├── pyproject.toml                      # OWNS all console entry points (mace_run_train, mace_eval_configs, mace_prepare_data, mace_create_lammps_model, mace_select_head, mace_convert_device, mace_finetuning_select)
+└── src/mace_launcher/
+    ├── __init__.py
+    ├── dispatch.py                     # ~50 LOC: --engine {legacy,v1} / MACE_ENGINE → mace.cli.* | mace_torch.cli.*
+    └── audit.py                        # sys.addaudithook: fails if it detects an importlib/entry-point reach-in from packages→mace
+```
+
+**What it does.** During coexistence two full stacks are installed side by side — the frozen legacy
+`mace/` and the new `mace_torch`/`mace_core` — and the hard rule is that they **never import each
+other** (`packages ⊥ mace`). The launcher is the *single operational meeting point*, one of only two
+modules on the double-import allowlist (the other is `tests/parity/`). It is deliberately tiny
+(~50 LOC):
+
+- **Owns every console script.** The root `setup.cfg` `console_scripts` are removed and re-pointed
+  at `mace_launcher:*`, so exactly one installed distribution provides each `mace_*` command (two
+  distributions declaring the same script is undefined in pip). Asserted in CI.
+- **Dispatches on `--engine {legacy,v1}` / `MACE_ENGINE`**, default **`legacy`** → day-one behaviour
+  is byte-identical to calling `mace.cli.*` directly. The flag is consumed *before* the target's
+  argparse; `legacy` calls `mace.cli.<mod>:main`, `v1` calls `mace_torch.cli.<mod>:main`. `--engine v1`
+  on a not-yet-migrated capability raises a clear "capability X not yet available on the v1 engine".
+- **Closes the dynamic reach-in.** `audit.py` registers a `sys.addaudithook` that fails if anything
+  under `packages/` dynamically imports `mace.*` in v1 mode — the runtime backstop behind
+  import-linter's static check (INF-3).
+
+**It is temporary.** The launcher exists *only* for the coexistence window: its whole job is to pick
+between two engines. As each capability reaches parity its `--engine` default flips to `v1` (opt-out);
+at **RET-6**, once the legacy `mace/` is deleted (`git ls-files mace/ == 0`), there is no second engine
+to choose — the legacy dispatch branch is removed and the launcher collapses to a **trivial shim**
+(entry points → `mace_torch.cli.*` directly), at which point it can be folded into `mace-torch`
+entirely. In the Milestone C end-state it carries no logic. The `--engine` flag and this whole package
+are migration scaffolding, not part of the v1 architecture.
+
+### 1.5 `tests/` (repo root) — cross-package parity and the fitness suite
+
+```
+tests/
+├── parity/                             # double-import allowlist: legacy-vs-v1 oracle comparison
+│   ├── conftest.py                     # tiny XYZ fixtures, --engine legacy/v1 harness
+│   ├── test_energy_forces_stress.py    # fp64 tolerance, legacy vs v1
+│   ├── test_equivariance.py            # rotation/translation/parity of MACEOutputs
+│   └── test_reduced_basis_oracle.py    # cross-checks clebsch_gordan.reduced_basis vs an independent Clebsch-Gordan derivation and (best-effort, nightly) vs cueq — never against e3nn (removed)
+└── architecture/                       # fitness suite (fast CPU, gates every PR)
+    ├── test_import_contracts.py        # import-linter contract checks
+    ├── test_model_shape.py             # "forward returns MACEOutputs", "models built via ModelConfig"
+    └── test_no_legacy_leak.py          # no v1 file references legacy class names
+```
+
+### 1.6 `tutorials/` (repo root) — the educational implementation
+
+An **independent track** (EDU-1/EDU-2, no phase gate), a top-level sibling of `packages/` and the
+frozen `mace/` — **not** a package and **not** the "reference backend" (that is the plain-torch/jax
+kernel oracle inside the packages, `mace_torch/backends/reference/` and `mace_jax/kernels/reference.py`).
+Pure-function JAX, readable over fast, **evaluation-only**: it exists so chemists/physicists can read
+and inspect the model blocks, not as a training path nor a mirror of the latest architecture. There is
+**no JAX training anywhere** — the `mace_jax` package is inference-only (plan D1) and the tutorials are
+inspection/eval-only. It may cross-check its forward numerics against `mace_torch` on a golden fixture,
+but nothing in `packages/` depends on it.
+
+```
+tutorials/                              # top-level, independent track (roadmap Ch. 12)
+├── mace_forward.py                     # pure-function JAX MACE forward (energies), nanoGPT-style, no closures — eval/inspection only (EDU-1)
+├── notebooks/                          # marimo notebooks: SH/Clebsch-Gordan/message-passing/many-body walkthrough + a forward/eval demo (EDU-2)
+└── tests/                              # CI executes the scripts/notebooks + numerics cross-check vs mace-torch (EDU-2)
+```
+
+---
+
+## 2. Layer diagram and dependency direction
+
+### 2.1 Layers (bottom-up; one arrow = "can import")
+
+```
+        ┌───────────────────────────────────────────────────────────┐
+  L0    │  mace_core   (numpy, pydantic, matscipy)  — no torch/jax    │
+        │  types, config, observables, kernels.protocol+registry,     │
+        │  clebsch_gordan.reduced_basis, neighbors, weights.neutral_format         │
+        └───────────────▲───────────────────────────▲─────────────────┘
+                        │                           │
+        ┌───────────────┴───────┐       ┌───────────┴───────────────┐
+  L1    │  mace_torch.kernels    │       │  mace_jax.kernels          │
+        │  + backends (custom_op)│       │  (jax primitives)          │
+        └───────────▲───────────┘       └───────────▲───────────────┘
+                    │                               │
+  L2    │  mace_torch.nn / models / physics │  mace_jax.nn / models  │
+                    │                               │
+  L3    │  mace_torch.{data,train,finetune,calculators,deploy} │  mace_jax.{data,deploy} │
+                    │                               │
+  L4    │  mace_torch.cli │                 │  mace_jax.cli │
+                    └───────────┬───────────────────┘
+                                │  (only from the launcher/tests-parity)
+  L5    │  mace-launcher (entry points, --engine)  +  tests/parity/  │
+        │           — ONLY ONES with double-import legacy/v1 —        │
+                                │
+  Lx    │  mace/ (legacy)  — FROZEN, does not import packages, nobody imports it except launcher+parity │
+```
+
+### 2.2 Import rules (invariants)
+
+1. `mace_core` **does not import** torch, jax, e3nn, `mace_torch`, `mace_jax`, or `mace`.
+2. `mace_torch` imports `mace_core`; **never** `mace_jax` or `mace`.
+3. `mace_jax` imports `mace_core`; **never** `mace_torch` or `mace`.
+4. Within `mace_torch`: L(n) only imports L(≤n). `nn`/`models` do not import `train`/`cli`; `kernels` does not import `nn`. (kills the god-module: there is no `__init__` that eagerly imports `train`).
+5. `packages/**` **never** imports `mace` (legacy). `mace` (legacy) is **never** edited to import `packages/**`.
+6. Double-import exception: **only** `mace_launcher.dispatch` and `tests/parity/**`.
+
+### 2.3 CI verification (four gates)
+
+- **import-linter** (`.importlinter`, whole tree): `forbidden`/`layers` contracts:
+  - `mace_core` ⊥ {torch, jax, e3nn, mace_torch, mace_jax, mace}
+  - `packages` ⊥ `mace` (with allowlist `mace_launcher.dispatch`, `tests.parity`)
+  - `mace_jax` ⊥ `mace_torch`
+  - internal layers of `mace_torch` (`layers: cli > train,data > models > nn > kernels > mace_core`)
+- **runtime audit-hook** (`mace_launcher.audit`, active in `tests/parity`): closes the static false-negative — a dynamic `importlib.import_module("mace...")` from packages fails the test.
+- **fitness suite** (`tests/architecture/`, fast CPU job, gating every PR): always-green asserts about the target shape — "forward returns `MACEOutputs`", "models are built via `ModelConfig`", "zero `torch_geometric` in the model interface", "zero `jit.*`/`@compile_mode('script')` in the live v1 path", "no v1 file references legacy class names".
+- **toolchain meta-lint**: no file matches two toolchains (1:1 ownership: `mace/**`→black+isort+pylint+mypy; `packages/**`→ruff+ty+prek).
+
+---
+
+## 3. Extension points
+
+**The extension spectrum — most of it is config, not code.** Extending MACE runs a ladder from a
+plain config knob to a genuinely new model. The common cases touch **zero code**; only new physics
+in the forward is a real code change:
+
+| You want to… | How | New code? |
+|---|---|---|
+| **Tune a parameter** — a loss weight, a Huber `delta`, a cutoff, a schedule, any hyperparameter | set a field in config | **none** |
+| **Train a new property** — any well-defined spherical-tensor observable (a dipole, a rank-2 tensor, spectra, a magnetic moment) | add a **row to the observable table** (`ObservableSpec` in config, canonical defaults in `defaults/observables.yaml`) — it auto-creates the head, the loss term, and the derivative names | **none** |
+| **A new loss** — a non-standard reduction, or a data/relative-energy/mask transform | `@register_loss` / `@register_transform` + select it in config | a small module |
+| **A new readout / head** | `@register_readout` + config | a small module |
+| **A new backend** — kernel, data format, neighbour list, electrostatics solver | ship a wheel with one entry-point line (`mace.kernel_backends.torch`, `mace.data_backends`, `mace.neighbor_backends`, `mace.electrostatics_backends.torch`) | a backend module, **zero core edits** |
+| **A new model** — new physics in the forward (electrostatics k-space, an SCF loop, magnetic-with-new-physics) | a `BaseMACE` subclass + `@register_model` (+ a model-transform hook) | a real model — **the one non-free case** |
+
+Principle: **extending the system touches ZERO core files** — everything enters via a config field, a
+registry decorator, or an entry point + a test that inherits a parametrized harness. Two clarifications
+that come up a lot:
+
+- **Tuning an existing loss is config, not a new loss.** A loss carries its own parameters — the
+  per-observable weights *and* its own hyperparameters (e.g. Huber `delta`) — set from config
+  (`LossConfig`, §3.3). Adding a knob to an existing loss is a field, not a `@register_loss`. Losses
+  are also **generated from the observable table**, so a new spherical-tensor property needs no loss
+  code at all — its loss term appears automatically with a default weight you can override.
+- **A new property is a table row, not an add-on.** The framework is property-agnostic by
+  construction: the observable table maps a property name to its mathematical structure (irreps,
+  per-atom vs total, units, normalization), and everything downstream (head, loss, derivatives) is
+  derived from that row.
+
+The sections below give the worked examples for each row of the ladder; for a single **end-to-end
+example of a complex feature** (a new input + observable + derivative + augmentation + loss + an SCF
+model, change by change), see [`extending_mace.md`](extending_mace.md).
+
+### 3.1 A new kernel backend (e.g. a custom Triton/SYCL one)
+
+- **Contract** (`mace_core.kernels.protocol.KernelBackend`, authoritative definition in `rfcs/rfc-01-backend-dispatch.md` §3.2/§3.3): a closed set of `make_*` factories, resolved once at model build time, each returning an op instance; `capabilities()` returns a `BackendCapabilities` record — coarse fields (`ops`, `devices`, `dtypes`, `max_lmax`, `layouts`, `bases`, `supports_double_backward`) as a cheap first filter, plus the authoritative `supports(descriptor)` predicate that sees the full op descriptor, so a backend can accept or decline down to the exact shape being built:
+
+  ```python
+  class KernelBackend(Protocol):
+      name: str
+      def capabilities(self) -> BackendCapabilities: ...   # .supports(OpDescriptor) -> bool is authoritative;
+                                                           # .supports_double_backward / .bases drive hard-reject rules
+      # factories: descriptor -> op instance, resolved ONCE at model build time
+      def make_linear(self, d: LinearDescriptor) -> LinearOp: ...
+      def make_channelwise_tp_conv(self, d: ChannelwiseTPConvDescriptor) -> ChannelwiseTPConv: ...  # ALWAYS node-level; there is no per-edge variant
+      def make_symmetric_contraction(self, d: SymmetricContractionDescriptor) -> SymmetricContractionOp: ...
+      def make_fully_connected_tp(self, d: FullyConnectedTPDescriptor) -> FullyConnectedTPOp: ...
+      def make_segment_reduce(self, d: SegmentReduceDescriptor) -> SegmentReduceOp: ...
+      def make_spherical_harmonics(self, d: SphericalHarmonicsDescriptor) -> SphericalHarmonicsOp: ...  # reference-only, may decline
+      def make_radial_basis(self, d: RadialBasisDescriptor) -> RadialBasisOp: ...                        # reference-only, may decline
+      # optional span factory: a backend MAY fuse a whole interaction layer instead of composing it op-by-op
+      def make_interaction_layer(self, descriptors: "InteractionLayerDescriptors") -> "InteractionLayerOp | NotImplemented": ...
+  ```
+
+  Internal-weight ops (`linear`, `symmetric_contraction`, `fully_connected_tp`) additionally implement `to_canonical()` / `load_canonical()`, applied only at the checkpoint save/load boundary, never on the forward path.
+- **Extender touches:** your own package (or `mace_torch/backends/mybackend/backend.py`) + one line in its `pyproject.toml`:
+  ```toml
+  [project.entry-points."mace.kernel_backends.torch"]
+  mybackend = "my_pkg.backend:MyBackend"
+  ```
+- **Core touched:** **zero**. It is discovered via `mace_core.kernels.registry.get_backend("mybackend")`.
+- **Test covering it:** inherits the parametrized `tests/backends/conftest.py::BackendConformance` — forward + backward + **double-backward** == `ReferenceBackend` at fp64, and **torch.compile with no graph-break** (forces `register_fake`). The **example** backend already runs this harness as a permanent gate, so a third party only needs to register and the harness picks it up.
+
+**Worked example — define, install, select.** A minimal third-party backend that only accelerates the
+symmetric contraction and lets everything else fall back to the reference:
+
+```python
+# my_pkg/backend.py
+from mace_core.kernels import BackendCapabilities   # data-about-ops only; no torch types here
+
+class MyBackend:
+    name = "mybackend"
+
+    def capabilities(self) -> BackendCapabilities:
+        return BackendCapabilities(
+            ops={"symmetric_contraction"},          # coarse first filter: only this op
+            devices={"cuda"}, dtypes={"float32", "float64"},
+            supports_double_backward=True,          # REQUIRED for force training, else hard-rejected at build
+            supports=lambda d: d.op == "symmetric_contraction" and d.uniform_multiplicity,
+        )
+
+    def make_symmetric_contraction(self, d):        # called once at build time, only for ops `supports` accepted
+        return MySymmetricContractionOp(d)          # a torch.library.custom_op + register_fake + register_autograd
+    # every other make_* may raise NotImplementedError: `supports` already declined them,
+    # and the CompositeBackend routes those ops to the reference backend automatically.
+```
+
+```toml
+# my_pkg/pyproject.toml — the ONLY registration step; zero edits to mace
+[project.entry-points."mace.kernel_backends.torch"]
+mybackend = "my_pkg.backend:MyBackend"
+```
+
+```bash
+pip install my-backend-pkg        # ships the entry point; MACE discovers it, no repo edits
+```
+
+Selecting and **switching** between backends is a build-time config choice, resolved once and frozen
+into the module tree (nothing dispatches in `forward`). Because weights are canonical, **the same
+checkpoint loads into any backend** — switching never reconverts weights:
+
+```python
+from mace_torch import build_model
+build_model(ModelConfig(..., backend="reference"))   # default: plain torch, CPU-ok, the oracle
+build_model(ModelConfig(..., backend="cueq"))         # NVIDIA cueq where it applies, reference elsewhere
+build_model(ModelConfig(..., backend="mybackend"))    # your wheel, picked up via the entry point
+```
+
+```bash
+mace train --model.backend cueq  ...      # same choice from the CLI (dotted override)
+```
+
+Any op/dtype/device/irreps a backend declines is served by the reference backend through a
+`CompositeBackend` — so a partial backend (one op, one dtype) is a first-class citizen. A backend that
+lacks double-backward is **hard-rejected at build time for force/stress training** (loud error, never
+silently wrong forces); it stays usable for inference (`supports_double_backward=False`).
+
+### 3.2 A new observable (config only)
+
+- **Extender touches:** a `mace_core/observables/myobs.py` file with an `Observable` (declares output irreps and derivation mode: `readout` | `autograd(energy, wrt=positions)` | `grad_strain`) + `@register_observable("myobs")`.
+- **Core touched:** zero existing files (only the new module is added). The model exposes it automatically because `BaseMACE` iterates over `config.observables`; `MACEOutputs` is a dataclass with optional fields populated by name.
+- **Enabling it:** `ModelConfig(observables=["energy","forces","myobs"])`.
+- **Test:** `mace_core/tests/test_observable_registry.py` validates irreps/derivation consistency (pure); if it is autograd-derived, `tests/parity` verifies finite-diff.
+
+### 3.3 A new loss / transform (plugin registry)
+
+- **Tuning an existing loss is config, not a new loss.** `LossConfig` carries the per-observable **weights** *and* the loss's own **parameters** (e.g. `params={"huber_delta": 0.02}`) — this preserves the legacy `--energy_weight`/`--forces_weight`/`--huber_delta` knobs as config fields. Changing a coefficient never needs a `@register_loss`. And a well-defined spherical-tensor observable needs **no** loss code at all — its term is generated from the observable table with `default_loss_weight`.
+- **A genuinely new loss:** `mace_torch/train/loss.py` (or an external package) with `@register_loss("myloss")` on a `torch.nn.Module`; select via `LossConfig(name="myloss", weights=..., params=...)`.
+- **Data transform:** `@register_transform("mytransform")` in `mace_torch/data/`; chained via `DataConfig(transforms=[...])`.
+- **Core touched:** the registries (`LOSS_REGISTRY`, `TRANSFORM_REGISTRY`) live in `mace_core.registries` as specs; **adding one does not edit the registry**, only the decorator populates it at import time. Zero core edits.
+- **Test:** `tests/unit/test_loss_registry.py` (value test: the loss produces the expected scalar over a fixed batch).
+
+**Worked example — define and register.** The registry pattern is the same as observables; a loss
+registers itself with a decorator at import time, and is then selected in config via
+`LossConfig(name=...)` (the bullet above):
+
+```python
+# mace_torch/train/loss.py
+import torch
+from mace_torch.train import register_loss
+
+@register_loss("my_huber_ef")                       # the decorator IS the registration — no registry edit
+class MyHuberEnergyForces(torch.nn.Module):
+    def __init__(self, delta: float = 0.01):
+        super().__init__()
+        self.delta = delta
+
+    def forward(self, pred, ref, weights):          # typed batch of MACEOutputs; returns a scalar
+        e = torch.nn.functional.huber_loss(pred.total_energy, ref.total_energy, delta=self.delta)
+        f = torch.nn.functional.huber_loss(pred.forces, ref.forces, delta=self.delta)
+        return weights.energy * e + weights.forces * f
+```
+
+A well-defined spherical-tensor observable needs **no** new loss at all — TRN-2 generates the loss term
+from the observable spec; a custom `@register_loss` is only for non-standard reductions/transforms.
+
+### 3.4 A new data format
+
+- **Extender touches:** a `DataBackend` implementation yielding `Configuration`s (rfc-05 protocol) registered via the `mace.data_backends` entry-point group; optionally a shard-writer in `mace_core.data_spec.shard_format`.
+- **Core touched:** zero (the model only consumes the flat-dict; no `torch_geometric` in the interface). Selected with `DataConfig(format="myfmt")`.
+- **Test:** `tests/workflows/test_preprocess_myfmt.py` (E2E: preprocess→train→eval) + a value test asserting that the produced graph dict passes the `GRAPH_SCHEMA` validator (rfc-03).
+
+**Worked example — define, install, select.** A backend yields framework-free `Configuration`s;
+graph building (neighbours, one-hot, collation) happens once *above* every backend, so the same
+backend feeds torch and jax:
+
+```python
+# my_pkg/backend.py
+from mace_core.data import Configuration, DataBackendError
+
+class ZarrBackend:                                  # map-style: lazy, picklable, exact __len__
+    name = "zarr"
+
+    @staticmethod
+    def sniff(path) -> bool:                        # format="auto" runs each backend's sniff() in priority order
+        return str(path).endswith(".zarr")
+
+    def open(self, path): self._store = ...; return self
+    def __len__(self) -> int: ...
+    def __getitem__(self, i: int) -> Configuration:  # RAISES DataBackendError on a corrupt row (never returns None)
+        ...
+    def iter_range(self, start, stop): ...           # rank-contiguous reads for DDP (sampler's concern, not the backend's)
+    def statistics(self): ...                        # or None → mace_core computes them
+```
+
+```toml
+# my_pkg/pyproject.toml — one line, discovered like a kernel backend (RFC-05 mirrors RFC-01 §3.1)
+[project.entry-points."mace.data_backends"]
+zarr = "my_pkg.backend:ZarrBackend"
+```
+
+```bash
+pip install mace-zarr
+mace train --data.format zarr  --data.train path/to/set.zarr  ...   # or format="auto" sniffs it
+```
+
+`mace data prepare` still writes exactly **one** blessed format (HDF5 v2 shards); a custom backend is a
+first-class *read* path for external corpora, not a new write schema.
+
+### 3.5 A new head / readout
+
+- **Extender touches:** `mace_torch/nn/readout.py` (or its own module) with `@register_readout("MyReadout")`; for a head, `HeadConfig(readout="MyReadout", ...)` in `mace_torch/finetune/multihead.py`.
+- **Core touched:** zero — `READOUT_REGISTRY` is populated by decorator; `BaseMACE` builds readouts by name from `ModelConfig`. Bias readouts force `mul_ir`; the `linear_irreps(..., bias=)` contract covers this explicitly instead of the legacy's hardcoded `o3.Linear(biases=True)`.
+- **Test:** `tests/unit/test_readout_registry.py` (value) + equivariance (`tests/parity/test_equivariance.py` includes the new head if it is in the registry).
+
+### 3.6 A new model (e.g. electrostatics)
+
+- **Extender touches:** `mace_torch/models/mymodel.py` subclassing `BaseMACE` (block composition + `observables`), + `@register_model("MyModel")`. Real example: `PolarMACE` lives in `models/electrostatics.py` as just another entry, not as an `extensions.py` bolt-on.
+- **Core touched:** zero — `MODEL_REGISTRY` by decorator; `build.py` instantiates via `ModelConfig(model="MyModel")`.
+- **Test:** per-model harness in `tests/parity` (fp64 parity vs legacy if a legacy counterpart exists; if brand-new, finite-diff + equivariance + committed goldens).
+
+**Worked example — define and register.** Unlike the first five rows, a new model is **not free** (see
+the honest-boundary note below): it subclasses the backbone and may add a model-transform hook. It is
+still registered, not patched:
+
+```python
+# mace_torch/models/electrostatics.py
+from mace_torch.models import BaseMACE, register_model
+
+@register_model("MyElectrostatic")                  # decorator registers it; build.py finds it by name
+class MyElectrostatic(BaseMACE):
+    def forward(self, graph):
+        features = super().forward(graph)           # the equivariant backbone (node features)
+        # add a k-space / SCF term that depends on positions and cell and couples into the
+        # derivative engine — this is why a model is more than a readout (RFC-01 §6b.2)
+        return features
+```
+
+```python
+build_model(ModelConfig(model="MyElectrostatic", observables=["energy", "forces"]))
+```
+
+No entry-point/pip step is shown because a model ships **inside** `mace-torch` (or a package that
+depends on it), not as a drop-in kernel/data plugin; the electrostatics solver *inside* it is the part
+that is backend-swappable, and that goes through RFC-09, not here.
+
+**Summary of "core files touched by extension": 0 in all 6 cases.** Everything enters via entry_point or registry decorator; the core only defines Protocols/registries.
+
+**Honest boundary.** This holds for the first five rows. A **new model** is different: `MACELES` and `PolarMACE` subclass `ScaleShiftMACE` and override its forward (`mace/modules/extensions.py:78,307`), and `PolarMACE` adds k-space electrostatic energies that depend on positions and cell and couple into the derivative engine. A model is therefore a `BaseMACE` subclass plus a `MACEOutputs` plus, for electrostatics, a model-transform hook — registered rather than patched, but not free. See RFC-01 §6b.2.
+
+---
+
+## 4. Test strategy by layer
+
+| Layer | What it tests | Depends on | Speed |
+|------|-----------|-----------|-----------|
+| **Pure unit (core)** | `mace_core/tests`: Clebsch-Gordan, reduced basis, neighbors, `ModelConfig.from_namespace`, observable/canonical registries | numpy only | **fast** (no torch, no GPU) |
+| **Backend conformance** | `tests/backends`: every `KernelBackend` satisfies the Protocol; fwd+bwd+**double-bwd** == reference; compile with no graph-break | torch + backend | fast (CPU for reference/example) / slow on GPU (cueq/oeq) |
+| **Numerical parity** | `tests/parity`: same tiny XYZ via `--engine legacy` and `--engine v1` → energy/forces/stress at fp64 tolerance; oracle = frozen legacy in-process | torch + legacy | **fast** on PR (tiny), **slow** on nightly (property/fuzz: PBC, mixed float32/64, high L, empty neighborhood) |
+| **Equivariance** | `tests/parity/test_equivariance.py`: rotation/translation/parity of MACEOutputs; energy invariant, forces covariant | torch/jax | fast |
+| **CLI E2E contracts** | `tests/workflows` (65 black-box functions: 54 in `tests/workflows` + 11 in `tests/integrations`) + `integrations/lammps`: subprocess to `mace_run_train` with `--engine v1`, returncode + loss-decrease + ASE `get_potential_energy` | subprocess, PYTHONPATH=REPO_ROOT | **slow** (auto-slow) |
+| **Goldens** | P0-2/P0-3 (external FM snapshots, network), P0-6 (finite-diff, virial sign PINNED), P0-7 (neighbors/radial/batching) | edit-locked | fast; foundations = network (opt-in) |
+
+Fast/slow split:
+- **Every PR (fast, CPU):** unit core + reference/example conformance + tiny parity + equivariance + fitness suite + goldens P0-6/P0-7.
+- **Nightly (slow):** property/fuzz parity, cueq/oeq on the GPU vendor jobs (`ci-gpu-mpcdf.yaml`: `-m gpu` on Nvidia, `-m "gpu and not cueq"` on AMD, skip-o-fail `MACE_REQUIRE_CAPS`), full-matrix workflows, `bin_lammps` real tier, network foundations.
+
+Reuse of the existing machinery: the live harness is the **65 black-box functions in `tests/workflows` + `integrations/`** run with `--engine v1` via the `PYTHONPATH=REPO_ROOT` harness, without writing a new E2E test or touching `tests/helpers.py`. The capability contract in `tests/conftest.py` (`CAPABILITY_PROBES`, auto-marked by directory, zero-collection guard) is inherited as-is; a new backend enters as a probe+marker.
+
+Multiple oracles for the reduced basis and its pinned order/normalization: `test_reduced_basis.py` compares it against (1) live legacy in-process, (2) cueq round-trip on GPU (alive for one release), (3) committed goldens — before any backend relies on it. This oracle sits on the critical path (RFC-A → CORE-4 → BKD-1): the pinned path order and per-path normalization *are* the on-disk weight format (rfc-01 §2.4.1).
+
+---
+
+## 5. The tree at three migration milestones
+
+The legacy `mace/` package stays frozen as the behavioral oracle through Milestones A and B. It is retired capability-by-capability in Milestone C, gated by the hard release requirement `git ls-files mace/ == 0` before the 1.0 tag.
+
+### Milestone A — packages scaffolded, legacy the only live path
+
+```
+mace/                         ← FROZEN byte-for-byte, legacy suite green (oracle)
+packages/
+  mace-core/                  ← installable scaffold, nearly empty (types.py, kernels/registry.py, config/ stubs)
+  mace-torch/                 ← installable scaffold, nearly empty
+  mace-jax/                   ← empty scaffold
+  mace-launcher/              ← OWNS all entry points, default --engine=legacy (zero-change behavior)
+tests/
+  parity/                     ← in-process legacy-vs-v1 harness (still trivial)
+  architecture/               ← first fitness functions + import-linter contract
+  (unit,workflows,backends,extensions,foundations,integrations,benchmarks)  ← legacy, unchanged
+.importlinter, .pre-commit dual-path, audit hook
+```
+`git ls-files mace/` = maximum. Everything goes through `mace.cli.*`. import-linter is green because `packages/` is empty.
+
+### Milestone B — data, kernels, and models complete in `mace_torch`; deployment remains legacy
+
+```
+mace/                         ← frozen and complete; remains the default for non-migrated capabilities
+packages/
+  mace-core/                  ← complete: clebsch_gordan.reduced_basis with pinned order, observables, config Pydantic, kernels.protocol, neighbors
+  mace-torch/
+    kernels/ (custom_op) ✓    backends/{reference,cueq,oeq,example} ✓
+    nn/ models/ physics/ ✓    data/ (hdf5/lmdb/xyz, no torch_geometric) ✓
+    train/ calculators/ ✓     finetune/ (partial)   deploy/ (LAMMPS export remains in legacy)
+  mace-jax/                   ← energy+forces parallel, validated against the neutral format
+  mace-launcher/              ← default --engine=v1 for energy/forces/stress/data (opt-out); legacy for dipole/polar/LAMMPS
+tests/
+  parity/                     ← dense: energy+forces+stress+data at fp64, property/fuzz in nightly
+  backends/                   ← conformance + double-backward gate (permanent example backend)
+  workflows/                  ← running with --engine v1 for what's migrated
+```
+`git ls-files mace/` = maximum: the legacy package is untouched and continues to serve as the oracle. Dual toolchain active. The 5 `convert_*` CLIs remain alive only for legacy (redundant for v1: single canonical layout).
+
+### Milestone C — capability-by-capability retirement complete, release gate satisfied
+
+```
+packages/
+  mace-core/   mace-torch/   mace-jax/      ← only live paths; deploy/ with torch.export (or isolated export_adapter)
+  mace-launcher/                            ← flat shim: entry points → mace_torch.cli.* directly (legacy branch deleted)
+tests/
+  unit/ backends/ workflows/ extensions/ foundations/ integrations/ parity/ architecture/
+    parity/ degraded to frozen goldens (legacy counterparts no longer exist)
+  (SINGLE toolchain: ruff+ty+prek; per-package --cov floors)
+mace/                                        ← REMOVED (git ls-files mace/ == 0)
+```
+Deletion order (delete-only PRs): energy models → data layer → `convert_*` CLIs → dipole/polar → LAMMPS jit → `mace/tools` god-module + launcher legacy branch. The hard release gate blocks the 1.0 tag until `git ls-files mace/ == 0`. The extensibility layer (kernels) is native from the start — `custom_op + register_fake` — and was never deformed by TorchScript.
+
+Once `git ls-files mace/ == 0`, the freed `mace` name no longer shadows anything, so the container `packages/` may be renamed to `mace/` as a final cosmetic step (**REL-4**) — container directory only; import names stay `mace_core`/`mace_torch`/`mace_jax`. Optional: keeping `packages/` is equally valid (LangChain `libs/`, uv `packages/`).


### PR DESCRIPTION
Adds the rules for working on the rewrite, plus the documents they point at.

* `.claude/skills/mace-reforge*`: five skills. Shared context and the hard rules, ticket to PR workflow, the golden and parity tests, numerics, and the kernel backend contract. Each loads on its own.
* `docs/reforge/`: the execution plan, the target layout, and the extension and `run_train` notes. Ticket IDs resolve to issues through the plan's ticket index.
* `.gitignore`: one rule so nobody commits their own `settings.local.json`.

The skills hold rules only. Phase and ticket status stay on the board, so nothing here can go stale. Rules that must always hold belong in CI, not in a skill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and gitignore only; no executable code, tests, or enforcement changes in this diff.
> 
> **Overview**
> Introduces **tracked contributor/agent guidance** for the MACE v1 rewrite: five composable Claude skills under `.claude/skills/` (`mace-reforge` plus ticket, goldens, numerics, and backend companions) that encode workflow rules without duplicating live board state.
> 
> Adds **`docs/reforge/`** as the human-readable planning layer the skills reference: **`plan.md`** (phases, gates, risks, ticket index), **`target_layout.md`** (destination package tree and extension points), **`extending_mace.md`** / **`extending_plugin.md`** (in-tree extra vs external plugin), and **`run_train_rewrite.md`** (staged training driver design). No runtime, CI, or `mace/` / `packages/` code changes.
> 
> **`.gitignore`** now ignores **`.claude/settings.local.json`** so shared skills stay committed while per-machine Claude settings do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29111881d2fe84e4abbce030ba7214b4a28a8bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->