### PR TITLE
Disable cuEquivariance convolution fusion for training

### DIFF
--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -124,12 +124,16 @@ class MaceTorchSimModel(ModelInterface):
             from mace.cli.convert_e3nn_cueq import run as run_cueq
 
             try:
-                self.model = run_cueq(self.model, device=self._device.type)
+                self.model = run_cueq(
+                    self.model,
+                    device=self._device.type,
+                    conv_fusion=True,
+                )
             except (RuntimeError, ValueError):
                 from mace.cli.convert_e3nn_hybrid import run as run_hybrid
 
                 log.warning(
-                    "cueq conv_fusion failed (non-uniform irreps), "
+                    "cuEquivariance conversion failed, "
                     "falling back to hybrid (cueq + oeq)"
                 )
                 self.model = run_hybrid(self.model, device=self._device.type)

--- a/mace/calculators/mace_torchsim.py
+++ b/mace/calculators/mace_torchsim.py
@@ -133,7 +133,7 @@ class MaceTorchSimModel(ModelInterface):
                 from mace.cli.convert_e3nn_hybrid import run as run_hybrid
 
                 log.warning(
-                    "cuEquivariance conversion failed, "
+                    "cueq conv_fusion failed (non-uniform irreps), "
                     "falling back to hybrid (cueq + oeq)"
                 )
                 self.model = run_hybrid(self.model, device=self._device.type)

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -220,6 +220,7 @@ def run(
     device="cpu",
     return_model=True,
     layout: str = "ir_mul",
+    conv_fusion: bool = False,
 ):
     # Setup logging
 
@@ -247,7 +248,7 @@ def run(
         layout=layout,
         group="O3_e3nn",
         optimize_all=True,
-        conv_fusion=(torch.device(device).type == "cuda"),
+        conv_fusion=conv_fusion and torch.device(device).type == "cuda",
     )
 
     # Create new model with cuequivariance config

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -220,7 +220,7 @@ def run(
     device="cpu",
     return_model=True,
     layout: str = "ir_mul",
-    conv_fusion: bool = False,
+    conv_fusion: bool = True,
 ):
     # Setup logging
 

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -888,7 +888,9 @@ def run(args) -> None:
             "MagneticScaleShiftMACE",
             "AtomicDielectricMACE",
         ]
-        model = run_e3nn_to_cueq(deepcopy(model), device=device)
+        model = run_e3nn_to_cueq(
+            deepcopy(model), device=device, conv_fusion=False
+        )
     if args.enable_oeq:
         logging.info("Converting model to OEQ for accelerated training")
         assert model.__class__.__name__ in [

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -889,7 +889,7 @@ def run(args) -> None:
             "AtomicDielectricMACE",
         ]
         model = run_e3nn_to_cueq(
-            deepcopy(model), device=device, conv_fusion=False
+            deepcopy(model), device=device, conv_fusion=args.cueq_conv_fusion
         )
     if args.enable_oeq:
         logging.info("Converting model to OEQ for accelerated training")

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -1112,6 +1112,12 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str2bool,
         default=False,
     )
+    parser.add_argument(
+        "--cueq_conv_fusion",
+        help="Enable cuEquivariance convolution fusion during training",
+        type=str2bool,
+        default=False,
+    )
     # option for openequivariance acceleration
     parser.add_argument(
         "--enable_oeq",

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -184,7 +184,8 @@ def configure_model(
                 layout="ir_mul",
                 group="O3_e3nn",
                 optimize_all=True,
-                conv_fusion=(args.device == "cuda"),
+                conv_fusion=args.cueq_conv_fusion
+                and torch.device(args.device).type == "cuda",
             )
 
         model_config = dict(

--- a/tests/backends/test_cueq.py
+++ b/tests/backends/test_cueq.py
@@ -125,10 +125,7 @@ def test_cueq_cuda_multihead_matches_e3nn(head_name, backend):
         ).to(device=device, dtype=default_dtype)
 
     converter = run_e3nn_to_cueq if backend == "cueq" else run_e3nn_to_hybrid
-    conversion_kwargs = {"device": device}
-    if backend == "cueq":
-        conversion_kwargs["conv_fusion"] = True
-    model_accelerated = converter(model_e3nn, **conversion_kwargs).to(
+    model_accelerated = converter(model_e3nn, device=device).to(
         device=device, dtype=default_dtype
     )
 

--- a/tests/backends/test_cueq.py
+++ b/tests/backends/test_cueq.py
@@ -125,7 +125,10 @@ def test_cueq_cuda_multihead_matches_e3nn(head_name, backend):
         ).to(device=device, dtype=default_dtype)
 
     converter = run_e3nn_to_cueq if backend == "cueq" else run_e3nn_to_hybrid
-    model_accelerated = converter(model_e3nn, device=device).to(
+    conversion_kwargs = {"device": device}
+    if backend == "cueq":
+        conversion_kwargs["conv_fusion"] = True
+    model_accelerated = converter(model_e3nn, **conversion_kwargs).to(
         device=device, dtype=default_dtype
     )
 

--- a/tests/golden/feature_inventory.md
+++ b/tests/golden/feature_inventory.md
@@ -385,7 +385,7 @@ Group default: KEEP.
 | `train.save_all_checkpoints` | `--save_all_checkpoints` | `mace/tools/arg_parser.py:1052` | KEEP | `tests/workflows/test_checkpoint_retention.py::test_save_all_checkpoints_leaves_one_per_evaluation` |
 | `train.save_cpu` | `--save_cpu` | `mace/tools/arg_parser.py:1064` | DROP — safetensors checkpoints are device-agnostic, so there is nothing to choose | — |
 
-### 3.10 Acceleration (3)
+### 3.10 Acceleration (4)
 
 Group default: MERGE into backend-dispatch configuration; the numerics are pinned on GPU CI.
 
@@ -394,6 +394,7 @@ Group default: MERGE into backend-dispatch configuration; the numerics are pinne
 | `train.enable_cueq` | `--enable_cueq` | `mace/tools/arg_parser.py:1083` | MERGE — backend dispatch config | `tests/golden/test_backend_parity_golden.py::test_the_calculators_own_backend_flag_reaches_the_same_kernels` |
 | `train.enable_oeq` | `--enable_oeq` | `mace/tools/arg_parser.py:1096` | MERGE — idem | `tests/golden/test_backend_parity_golden.py::test_the_calculators_own_backend_flag_reaches_the_same_kernels` |
 | `train.only_cueq` | `--only_cueq` | `mace/tools/arg_parser.py:1089` | MERGE — idem: 'use cueq for every op, not just the ones that benefit' becomes a dispatch policy, not a second boolean. Its own row precisely because a group-level `--enable_cueq/--only_cueq/--enable_oeq` cell hides it | `tests/golden/test_backend_parity_golden.py::test_converting_for_the_cpu_leaves_cueq_unfused_and_the_audit_says_so` |
+| `train.cueq_conv_fusion` | `--cueq_conv_fusion` | `mace/tools/arg_parser.py:1116` | MERGE — idem: the fusion knob of the same dispatch policy. Its own row because it is the one acceleration flag whose default differs between training (unfused) and inference (fused), which a group-level cell would hide | `tests/unit/test_convert_e3nn_cueq.py::test_only_cueq_uses_training_fusion_policy` + `tests/unit/test_convert_e3nn_cueq.py::test_training_conversion_forwards_fusion_flag` |
 
 ### 3.11 wandb (6)
 

--- a/tests/unit/test_arg_parser.py
+++ b/tests/unit/test_arg_parser.py
@@ -96,6 +96,18 @@ def test_default_parser_critical_defaults():
     assert args.virials_key == "REF_virials"
 
 
+def test_cueq_convolution_fusion_is_opt_in():
+    parser = build_default_arg_parser()
+
+    assert parser.parse_args(MINIMAL_ARGV).cueq_conv_fusion is False
+    assert (
+        parser.parse_args(
+            MINIMAL_ARGV + ["--cueq_conv_fusion", "True"]
+        ).cueq_conv_fusion
+        is True
+    )
+
+
 def test_stage_two_alias_maps_to_swa_dest():
     # --stage_two_* is the current spelling of the old --swa_* flags; both
     # must land in the same destination.

--- a/tests/unit/test_convert_e3nn_cueq.py
+++ b/tests/unit/test_convert_e3nn_cueq.py
@@ -29,9 +29,10 @@ class _ConversionModelStub(torch.nn.Module):
 @pytest.mark.parametrize(
     ("device", "kwargs", "expected"),
     [
-        ("cuda", {}, False),
-        (torch.device("cuda"), {"conv_fusion": True}, True),
-        ("cpu", {"conv_fusion": True}, False),
+        ("cuda", {}, True),
+        (torch.device("cuda"), {}, True),
+        ("cuda", {"conv_fusion": False}, False),
+        ("cpu", {}, False),
     ],
 )
 def test_conversion_fusion_policy(monkeypatch, device, kwargs, expected):

--- a/tests/unit/test_convert_e3nn_cueq.py
+++ b/tests/unit/test_convert_e3nn_cueq.py
@@ -6,6 +6,9 @@ import torch
 
 from mace.calculators import mace_torchsim
 from mace.cli import convert_e3nn_cueq, run_train
+from mace.tools import model_script_utils
+from mace.tools.arg_parser import build_default_arg_parser
+from mace.tools.utils import AtomicNumberTable
 
 
 class _HiddenIrrepsStub:
@@ -51,7 +54,7 @@ def test_conversion_fusion_policy(monkeypatch, device, kwargs, expected):
     assert converted.cueq_config.conv_fusion is expected
 
 
-def test_training_conversion_explicitly_disables_fusion():
+def test_training_conversion_forwards_fusion_flag():
     tree = ast.parse(inspect.getsource(run_train.run))
     conversion_calls = [
         node
@@ -63,8 +66,56 @@ def test_training_conversion_explicitly_disables_fusion():
 
     assert len(conversion_calls) == 1
     keywords = {keyword.arg: keyword.value for keyword in conversion_calls[0].keywords}
-    assert isinstance(keywords["conv_fusion"], ast.Constant)
-    assert keywords["conv_fusion"].value is False
+    assert isinstance(keywords["conv_fusion"], ast.Attribute)
+    assert keywords["conv_fusion"].attr == "cueq_conv_fusion"
+
+
+@pytest.mark.parametrize(
+    ("device", "requested", "expected"),
+    [("cuda", False, False), ("cuda", True, True), ("cpu", True, False)],
+)
+def test_only_cueq_uses_training_fusion_policy(
+    monkeypatch, device, requested, expected
+):
+    args = build_default_arg_parser().parse_args(
+        [
+            "--name",
+            "test",
+            "--device",
+            device,
+            "--scaling",
+            "no_scaling",
+            "--hidden_irreps",
+            "4x0e",
+            "--only_cueq",
+            "True",
+            "--cueq_conv_fusion",
+            str(requested),
+        ]
+    )
+    args.compute_energy = True
+    args.compute_forces = False
+    args.compute_dipole = False
+    args.compute_polarizability = False
+    args.compute_magforces = False
+    args.mean = 0.0
+    monkeypatch.setattr(
+        model_script_utils,
+        "_build_model",
+        lambda _args, model_config, _foundation_config, _heads: model_config[
+            "cueq_config"
+        ],
+    )
+
+    cueq_config, _ = model_script_utils.configure_model(
+        args,
+        train_loader=None,
+        atomic_energies=[0.0],
+        heads=["Default"],
+        z_table=AtomicNumberTable([1]),
+    )
+
+    assert cueq_config.conv_fusion is expected
 
 
 def test_torchsim_requests_convolution_fusion(monkeypatch):

--- a/tests/unit/test_convert_e3nn_cueq.py
+++ b/tests/unit/test_convert_e3nn_cueq.py
@@ -1,7 +1,11 @@
+import ast
+import inspect
+
 import pytest
 import torch
 
-from mace.cli import convert_e3nn_cueq
+from mace.calculators import mace_torchsim
+from mace.cli import convert_e3nn_cueq, convert_e3nn_hybrid, run_train
 
 
 class _HiddenIrrepsStub:
@@ -23,7 +27,7 @@ class _ConversionModelStub(torch.nn.Module):
 
 
 @pytest.mark.parametrize("device", ["cuda", torch.device("cuda")])
-def test_conversion_enables_convolution_fusion_for_cuda_devices(monkeypatch, device):
+def test_conversion_defaults_to_unfused(monkeypatch, device):
     monkeypatch.setattr(
         convert_e3nn_cueq,
         "extract_config_mace_model",
@@ -36,4 +40,109 @@ def test_conversion_enables_convolution_fusion_for_cuda_devices(monkeypatch, dev
 
     converted = convert_e3nn_cueq.run(_ConversionModelStub(), device=device)
 
+    assert converted.cueq_config.conv_fusion is False
+
+
+@pytest.mark.parametrize("device", ["cuda", torch.device("cuda")])
+def test_conversion_enables_requested_cuda_fusion(monkeypatch, device):
+    monkeypatch.setattr(
+        convert_e3nn_cueq,
+        "extract_config_mace_model",
+        lambda model: {
+            "hidden_irreps": _HiddenIrrepsStub(),
+            "correlation": 2,
+            "num_interactions": 0,
+        },
+    )
+
+    converted = convert_e3nn_cueq.run(
+        _ConversionModelStub(), device=device, conv_fusion=True
+    )
+
     assert converted.cueq_config.conv_fusion is True
+
+
+def test_conversion_keeps_requested_cpu_fusion_disabled(monkeypatch):
+    monkeypatch.setattr(
+        convert_e3nn_cueq,
+        "extract_config_mace_model",
+        lambda model: {
+            "hidden_irreps": _HiddenIrrepsStub(),
+            "correlation": 2,
+            "num_interactions": 0,
+        },
+    )
+
+    converted = convert_e3nn_cueq.run(
+        _ConversionModelStub(), device="cpu", conv_fusion=True
+    )
+
+    assert converted.cueq_config.conv_fusion is False
+
+
+def test_training_conversion_explicitly_disables_fusion():
+    tree = ast.parse(inspect.getsource(run_train.run))
+    conversion_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "run_e3nn_to_cueq"
+    ]
+
+    assert len(conversion_calls) == 1
+    keywords = {keyword.arg: keyword.value for keyword in conversion_calls[0].keywords}
+    assert isinstance(keywords["conv_fusion"], ast.Constant)
+    assert keywords["conv_fusion"].value is False
+
+
+def test_torchsim_requests_convolution_fusion(monkeypatch):
+    class ConversionComplete(Exception):
+        pass
+
+    class ModelStub(torch.nn.Module):
+        pass
+
+    calls = []
+
+    def capture_conversion(model, **kwargs):
+        calls.append(kwargs)
+        raise ConversionComplete
+
+    monkeypatch.setattr(mace_torchsim, "_TORCHSIM_IMPORT_ERROR", None)
+    monkeypatch.setattr(convert_e3nn_cueq, "run", capture_conversion)
+
+    with pytest.raises(ConversionComplete):
+        mace_torchsim.MaceTorchSimModel(
+            ModelStub(),
+            device=torch.device("cuda"),
+            dtype=torch.float32,
+            enable_cueq=True,
+        )
+
+    assert calls == [{"device": "cuda", "conv_fusion": True}]
+
+
+def test_torchsim_fallback_reports_conversion_failure(monkeypatch, caplog):
+    class ModelStub(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("r_max", torch.tensor(5.0))
+            self.register_buffer("atomic_numbers", torch.tensor([1]))
+
+    def fail_conversion(*args, **kwargs):
+        raise ValueError("unsupported")
+
+    monkeypatch.setattr(mace_torchsim, "_TORCHSIM_IMPORT_ERROR", None)
+    monkeypatch.setattr(convert_e3nn_cueq, "run", fail_conversion)
+    monkeypatch.setattr(convert_e3nn_hybrid, "run", lambda model, **kwargs: model)
+
+    mace_torchsim.MaceTorchSimModel(
+        ModelStub(),
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        enable_cueq=True,
+    )
+
+    assert "cuEquivariance conversion failed" in caplog.text
+    assert "conv_fusion" not in caplog.text

--- a/tests/unit/test_convert_e3nn_cueq.py
+++ b/tests/unit/test_convert_e3nn_cueq.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from mace.calculators import mace_torchsim
-from mace.cli import convert_e3nn_cueq, convert_e3nn_hybrid, run_train
+from mace.cli import convert_e3nn_cueq, run_train
 
 
 class _HiddenIrrepsStub:
@@ -26,8 +26,15 @@ class _ConversionModelStub(torch.nn.Module):
         return self
 
 
-@pytest.mark.parametrize("device", ["cuda", torch.device("cuda")])
-def test_conversion_defaults_to_unfused(monkeypatch, device):
+@pytest.mark.parametrize(
+    ("device", "kwargs", "expected"),
+    [
+        ("cuda", {}, False),
+        (torch.device("cuda"), {"conv_fusion": True}, True),
+        ("cpu", {"conv_fusion": True}, False),
+    ],
+)
+def test_conversion_fusion_policy(monkeypatch, device, kwargs, expected):
     monkeypatch.setattr(
         convert_e3nn_cueq,
         "extract_config_mace_model",
@@ -38,46 +45,9 @@ def test_conversion_defaults_to_unfused(monkeypatch, device):
         },
     )
 
-    converted = convert_e3nn_cueq.run(_ConversionModelStub(), device=device)
+    converted = convert_e3nn_cueq.run(_ConversionModelStub(), device=device, **kwargs)
 
-    assert converted.cueq_config.conv_fusion is False
-
-
-@pytest.mark.parametrize("device", ["cuda", torch.device("cuda")])
-def test_conversion_enables_requested_cuda_fusion(monkeypatch, device):
-    monkeypatch.setattr(
-        convert_e3nn_cueq,
-        "extract_config_mace_model",
-        lambda model: {
-            "hidden_irreps": _HiddenIrrepsStub(),
-            "correlation": 2,
-            "num_interactions": 0,
-        },
-    )
-
-    converted = convert_e3nn_cueq.run(
-        _ConversionModelStub(), device=device, conv_fusion=True
-    )
-
-    assert converted.cueq_config.conv_fusion is True
-
-
-def test_conversion_keeps_requested_cpu_fusion_disabled(monkeypatch):
-    monkeypatch.setattr(
-        convert_e3nn_cueq,
-        "extract_config_mace_model",
-        lambda model: {
-            "hidden_irreps": _HiddenIrrepsStub(),
-            "correlation": 2,
-            "num_interactions": 0,
-        },
-    )
-
-    converted = convert_e3nn_cueq.run(
-        _ConversionModelStub(), device="cpu", conv_fusion=True
-    )
-
-    assert converted.cueq_config.conv_fusion is False
+    assert converted.cueq_config.conv_fusion is expected
 
 
 def test_training_conversion_explicitly_disables_fusion():
@@ -121,28 +91,3 @@ def test_torchsim_requests_convolution_fusion(monkeypatch):
         )
 
     assert calls == [{"device": "cuda", "conv_fusion": True}]
-
-
-def test_torchsim_fallback_reports_conversion_failure(monkeypatch, caplog):
-    class ModelStub(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.register_buffer("r_max", torch.tensor(5.0))
-            self.register_buffer("atomic_numbers", torch.tensor([1]))
-
-    def fail_conversion(*args, **kwargs):
-        raise ValueError("unsupported")
-
-    monkeypatch.setattr(mace_torchsim, "_TORCHSIM_IMPORT_ERROR", None)
-    monkeypatch.setattr(convert_e3nn_cueq, "run", fail_conversion)
-    monkeypatch.setattr(convert_e3nn_hybrid, "run", lambda model, **kwargs: model)
-
-    mace_torchsim.MaceTorchSimModel(
-        ModelStub(),
-        device=torch.device("cpu"),
-        dtype=torch.float32,
-        enable_cueq=True,
-    )
-
-    assert "cuEquivariance conversion failed" in caplog.text
-    assert "conv_fusion" not in caplog.text


### PR DESCRIPTION
## Summary

- keep convolution fusion enabled by default for normal CUDA conversion and inference;
- add `--cueq_conv_fusion` for training, defaulting to `False`;
- apply the flag to both converted training and native `--only_cueq` model construction.

Users can opt back in with `--cueq_conv_fusion=True` to retest future cuEquivariance releases.

## Motivation

Fusion helps fixed-shape inference, but profiling found a severe regression for variable-shape HDF5 training. cuEquivariance remains enabled; only convolution fusion is disabled by default during training.

## Testing

- focused parser/conversion tests: 27 passed;
- CUDA cuEq backend goldens: 4 passed, 1 skipped (PyTorch 2.10, cuEquivariance 0.9, RTX 5090).