### PR TITLE
Scaffold the three v1 packages beside the frozen legacy tree

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -31,6 +31,17 @@ jobs:
           # The pylint hook is `language: system`: packages the linted code
           # imports must be importable in this environment.
           pip-packages: wandb
+      - name: Install the v1 packages
+        # Same rule as the extras above, for the other tree. pylint lints
+        # packages/** until INF-4 splits the toolchain, and without these
+        # installed every module there reports import-error rather than
+        # anything about the code. One invocation: mace-core is unpublished,
+        # so pip only resolves it as a sibling in the same run. The version
+        # falls back to 0.0.0 on this shallow clone, which lint does not read.
+        run: |
+          python -m pip install -e packages/mace-core \
+                                -e packages/mace-torch \
+                                -e packages/mace-jax
       - run: pre-commit run --all-files --show-diff-on-failure
 
   cueq-wheel-extras:

--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -111,9 +111,56 @@ jobs:
           # to fail the pull request that made it, not a run nobody reads the
           # next morning. They are CPU-only, network-free, carry no capability
           # marker and no `slow` mark, so they collect on all four versions.
-          tests: tests/unit tests/golden
+          #
+          # tests/architecture is the fitness suite: structural invariants of
+          # the two-stack tree that no functional test can see. It runs here
+          # because it needs the repository and this job already has it, and
+          # it costs milliseconds.
+          tests: tests/unit tests/golden tests/architecture
           markers: not slow
           numprocs: auto
+
+  packages:
+    # The v1 stack under packages/. It installs no legacy package and no
+    # torch, and that is the point rather than a saving: mace_core, mace_torch
+    # and mace_jax have to stand up on their own, and a job that installed the
+    # legacy environment first would keep passing on the day one of them grows
+    # a dependency on it.
+    #
+    # Same four versions as the unit job, for the same reason: what breaks
+    # across python versions here is import- and packaging-shaped, and the job
+    # takes seconds.
+    needs: lint
+    runs-on: ubuntu-latest
+    name: packages (py${{ matrix.python-version }})
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # hatch-vcs reads each version off `git describe`. The default
+          # shallow clone carries no tags, so every package would build as its
+          # fallback version and the metadata this job checks would be a
+          # constant.
+          fetch-depth: 0
+      - uses: actions/setup-python@e9d6f990972a57673cdb72ec29e19d42ba28880f # v6.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install the v1 packages
+        # One pip invocation, not three: mace-torch-v1 and mace-jax require
+        # mace-core, which is not published, so pip only resolves it when it
+        # sees the local path in the same run.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/mace-core \
+                                -e packages/mace-torch \
+                                -e packages/mace-jax
+          python -m pip install pytest
+      - name: Run the package suites
+        run: python -m pytest packages/*/tests -v
 
   workflows:
     # End-to-end CLI trainings via subprocess — the expensive suite. PRs run

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,90 @@
+# The MACE v1 packages
+
+Three packages, one direction of dependency:
+
+```
+mace-core            contract + pure math; no torch, no jax, no e3nn
+   ^        ^
+   |        |
+mace-torch  mace-jax
+```
+
+`mace_torch` and `mace_jax` are two implementations of one contract. Neither
+imports the other, and neither imports the legacy `mace` package, which stays
+in the tree as a frozen numerical oracle until it is retired.
+
+These are scaffolds. Each package installs, imports and runs one test; the
+library code arrives with the tickets that build it.
+
+## Names
+
+| Directory | Distribution | Import name | Tag prefix |
+|---|---|---|---|
+| `packages/mace-core` | `mace-core` | `mace_core` | `mace-core-v*` |
+| `packages/mace-torch` | `mace-torch-v1` | `mace_torch` | `mace-torch-v*` |
+| `packages/mace-jax` | `mace-jax` | `mace_jax` | `mace-jax-v*` |
+
+The import names never collide with the legacy import name `mace`, so both
+stacks live in one process.
+
+The distribution names cannot all match their import names. The legacy package
+holds the `mace-torch` distribution name, and two distributions cannot both
+hold one name in a single environment, so the v1 PyTorch package ships as
+**`mace-torch-v1`** while keeping the `mace_torch` import name.
+
+**`mace-torch-v1` is never published to PyPI.** It exists so the two stacks can
+be installed side by side while both are in the tree. `mace-torch` on PyPI is
+frozen at its final v0.3.x release and stays dormant for the whole rewrite, so
+the name is free the moment legacy leaves the tree: RET-6 renames the
+distribution to `mace-torch`, and the v1.0.0 release publishes under that name.
+PyPI has no rename operation, so publishing `mace-torch-v1` even once would
+turn that switch from a no-op into a permanent user migration.
+
+Tag prefixes are keyed on the directory rather than the distribution name, so
+each package versions independently from git tags and the RET-6 rename touches
+only the `name` field.
+
+A fourth distribution, `mace-launcher`, owns every `mace_*` console script.
+None of the three packages here declares one: two distributions declaring the
+same script name is undefined behaviour in pip.
+
+## Installing alongside the legacy package
+
+Both stacks in one environment, from a fresh venv at the repository root:
+
+```bash
+python -m venv .venv-v1 && source .venv-v1/bin/activate
+pip install -e packages/mace-core -e packages/mace-torch -e packages/mace-jax
+pip install -e .
+```
+
+One `pip install` for the three packages, not three: `mace-torch-v1` and
+`mace-jax` require `mace-core`, which is not on PyPI, so pip has to see it as a
+local requirement in the same resolution.
+
+Then, in one process:
+
+```bash
+python -c "import mace, mace_core, mace_torch, mace_jax; print('coexist ok')"
+```
+
+The legacy install is the same `pip install -e .` it has always been. Nothing
+about it changes, and the scaffold cannot enter the legacy wheel: its build
+discovers packages with `setuptools.find_packages()`, which prunes any path
+component that is not a Python identifier, and every directory here is
+hyphenated. `tests/architecture/test_packaging_isolation.py` asserts that
+rather than trusting it.
+
+## Test file names
+
+Test files are collected from several packages in one pytest run, under one
+rootdir, and none of the `tests/` directories is an importable package. Two
+files sharing a basename therefore collide on import. Prefix each test module
+with its package: `test_mace_core_scaffold.py`, not `test_scaffold.py`.
+
+## Dependencies
+
+The scaffolds declare only the dependency edge this layout is about:
+`mace-torch-v1` and `mace-jax` require `mace-core`. Torch and jax themselves
+are declared by the first ticket that imports them, so a torch environment does
+not pull in jax to install a package containing no code.

--- a/packages/mace-core/README.md
+++ b/packages/mace-core/README.md
@@ -1,0 +1,8 @@
+# mace-core
+
+Framework-agnostic contract and pure math for MACE v1: types, config,
+observables, the kernel-backend protocol, Clebsch-Gordan, neighbours and the
+data spec. It imports no torch, no jax and no e3nn, so both implementation
+packages can depend on it without depending on each other.
+
+Distribution `mace-core`, import name `mace_core`. Scaffold only for now.

--- a/packages/mace-core/pyproject.toml
+++ b/packages/mace-core/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mace-core"
+dynamic = ["version"]
+description = "Framework-agnostic contract and pure math for MACE v1."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "MACE developers" }]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/ACEsuit/mace"
+
+# No [project.scripts]. Every mace_* console entry point is owned by one
+# distribution, mace-launcher; two distributions declaring the same script name
+# is undefined behaviour in pip.
+
+[tool.hatch.version]
+source = "vcs"
+# Tag prefixes are keyed on the directory, not the distribution name, so each
+# package versions independently and renaming a distribution leaves the tag
+# scheme alone. --match stops git describe resolving a sibling's tag or a
+# legacy v0.3.x one, which tag-pattern would then reject outright.
+tag-pattern = "^mace-core-v(?P<version>.+)$"
+fallback-version = "0.0.0"
+raw-options = { root = "../..", git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "mace-core-v*"] }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mace_core"]

--- a/packages/mace-core/src/mace_core/__init__.py
+++ b/packages/mace-core/src/mace_core/__init__.py
@@ -1,0 +1,15 @@
+"""Framework-agnostic contract and pure math for MACE v1.
+
+Scaffold only. The public surface arrives with the tickets that build it.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+__all__ = ["__version__"]
+
+#: Version of the installed `mace-core` distribution. Read from installed metadata
+#: rather than hardcoded, so it cannot drift from what pip resolved.
+try:
+    __version__ = version("mace-core")
+except PackageNotFoundError:  # imported from a source tree that was never installed
+    __version__ = "0.0.0"

--- a/packages/mace-core/tests/test_mace_core_scaffold.py
+++ b/packages/mace-core/tests/test_mace_core_scaffold.py
@@ -1,0 +1,9 @@
+"""Proves the install, import and test wiring of the mace-core package."""
+
+import mace_core
+
+
+def test_version_is_exported():
+    """A string here means pip resolved the distribution and the import name maps to it."""
+    assert isinstance(mace_core.__version__, str)
+    assert mace_core.__version__

--- a/packages/mace-jax/README.md
+++ b/packages/mace-jax/README.md
@@ -1,0 +1,7 @@
+# mace-jax
+
+The JAX stack for MACE v1, inference only. It depends on `mace_core` and jax,
+and reproduces the torch numerics for published foundation models. There is no
+JAX training anywhere in v1.
+
+Distribution `mace-jax`, import name `mace_jax`. Scaffold only for now.

--- a/packages/mace-jax/pyproject.toml
+++ b/packages/mace-jax/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mace-jax"
+dynamic = ["version"]
+description = "The JAX stack for MACE v1, inference only."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "MACE developers" }]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+]
+dependencies = ["mace-core"]
+
+[project.urls]
+Homepage = "https://github.com/ACEsuit/mace"
+
+# No [project.scripts]. Every mace_* console entry point is owned by one
+# distribution, mace-launcher; two distributions declaring the same script name
+# is undefined behaviour in pip.
+
+[tool.hatch.version]
+source = "vcs"
+# Tag prefixes are keyed on the directory, not the distribution name, so each
+# package versions independently and renaming a distribution leaves the tag
+# scheme alone. --match stops git describe resolving a sibling's tag or a
+# legacy v0.3.x one, which tag-pattern would then reject outright.
+tag-pattern = "^mace-jax-v(?P<version>.+)$"
+fallback-version = "0.0.0"
+raw-options = { root = "../..", git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "mace-jax-v*"] }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mace_jax"]

--- a/packages/mace-jax/src/mace_jax/__init__.py
+++ b/packages/mace-jax/src/mace_jax/__init__.py
@@ -1,0 +1,15 @@
+"""The JAX stack for MACE v1, inference only.
+
+Scaffold only. The public surface arrives with the tickets that build it.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+__all__ = ["__version__"]
+
+#: Version of the installed `mace-jax` distribution. Read from installed metadata
+#: rather than hardcoded, so it cannot drift from what pip resolved.
+try:
+    __version__ = version("mace-jax")
+except PackageNotFoundError:  # imported from a source tree that was never installed
+    __version__ = "0.0.0"

--- a/packages/mace-jax/tests/test_mace_jax_scaffold.py
+++ b/packages/mace-jax/tests/test_mace_jax_scaffold.py
@@ -1,0 +1,9 @@
+"""Proves the install, import and test wiring of the mace-jax package."""
+
+import mace_jax
+
+
+def test_version_is_exported():
+    """A string here means pip resolved the distribution and the import name maps to it."""
+    assert isinstance(mace_jax.__version__, str)
+    assert mace_jax.__version__

--- a/packages/mace-torch/README.md
+++ b/packages/mace-torch/README.md
@@ -1,0 +1,9 @@
+# mace-torch-v1
+
+The PyTorch stack for MACE v1: models, training, kernel backends and
+deployment. It depends on `mace_core` and torch, and is the primary training
+and research backend.
+
+Distribution `mace-torch-v1`, import name `mace_torch`. The distribution name
+carries a suffix only because the frozen legacy package holds `mace-torch`; it
+is never published and loses the suffix at RET-6. Scaffold only for now.

--- a/packages/mace-torch/pyproject.toml
+++ b/packages/mace-torch/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mace-torch-v1"
+dynamic = ["version"]
+description = "The PyTorch stack for MACE v1: models, training, kernel backends, deployment."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "MACE developers" }]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+]
+dependencies = ["mace-core"]
+
+[project.urls]
+Homepage = "https://github.com/ACEsuit/mace"
+
+# No [project.scripts]. Every mace_* console entry point is owned by one
+# distribution, mace-launcher; two distributions declaring the same script name
+# is undefined behaviour in pip.
+
+[tool.hatch.version]
+source = "vcs"
+# Tag prefixes are keyed on the directory, not the distribution name, so each
+# package versions independently and renaming a distribution leaves the tag
+# scheme alone. --match stops git describe resolving a sibling's tag or a
+# legacy v0.3.x one, which tag-pattern would then reject outright.
+tag-pattern = "^mace-torch-v(?P<version>.+)$"
+fallback-version = "0.0.0"
+raw-options = { root = "../..", git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "mace-torch-v*"] }
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mace_torch"]

--- a/packages/mace-torch/src/mace_torch/__init__.py
+++ b/packages/mace-torch/src/mace_torch/__init__.py
@@ -1,0 +1,17 @@
+"""The PyTorch stack for MACE v1.
+
+Scaffold only. The public surface arrives with the tickets that build it.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+__all__ = ["__version__"]
+
+#: Version of the installed `mace-torch-v1` distribution. Read from installed metadata
+#: rather than hardcoded, so it cannot drift from what pip resolved. The import
+#: name and the distribution name differ for this package, which is why the
+#: lookup spells the distribution name out.
+try:
+    __version__ = version("mace-torch-v1")
+except PackageNotFoundError:  # imported from a source tree that was never installed
+    __version__ = "0.0.0"

--- a/packages/mace-torch/tests/test_mace_torch_scaffold.py
+++ b/packages/mace-torch/tests/test_mace_torch_scaffold.py
@@ -1,0 +1,9 @@
+"""Proves the install, import and test wiring of the mace-torch-v1 package."""
+
+import mace_torch
+
+
+def test_version_is_exported():
+    """A string here means pip resolved the distribution and the import name maps to it."""
+    assert isinstance(mace_torch.__version__, str)
+    assert mace_torch.__version__

--- a/tests/architecture/test_packaging_isolation.py
+++ b/tests/architecture/test_packaging_isolation.py
@@ -1,0 +1,52 @@
+"""The v1 scaffold must not leak into the legacy wheel.
+
+The legacy build is `setuptools.build_meta` with an unscoped `packages = find:`
+(`setup.cfg`), so it discovers whatever `setuptools.find_packages()` returns
+from the repository root. Nothing under `packages/` is discovered today, and
+the reason is worth pinning: `find_packages` walks only path components that
+are Python identifiers, and every v1 package directory is hyphenated. Rename
+one to `packages/mace_core/` and it silently ships inside the `mace-torch`
+wheel, with no error anywhere.
+"""
+
+from pathlib import Path
+
+import setuptools
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGES_DIR = REPO_ROOT / "packages"
+
+# Import names of the v1 packages, which are what a leak would look like.
+V1_IMPORT_NAMES = {"mace_core", "mace_torch", "mace_jax", "mace_launcher"}
+
+
+def test_scaffold_directories_are_not_python_identifiers():
+    """Hyphenated names are what keeps find_packages out; assert it, do not assume it."""
+    offenders = [
+        entry.name
+        for entry in sorted(PACKAGES_DIR.iterdir())
+        if entry.is_dir() and entry.name.isidentifier()
+    ]
+    assert not offenders, (
+        f"package directories {offenders} are Python identifiers, so "
+        f"setuptools.find_packages() will walk into them and ship their "
+        f"contents inside the legacy mace-torch wheel. Use a hyphen."
+    )
+
+
+def test_legacy_wheel_does_not_discover_the_v1_packages():
+    """The legacy distribution ships `mace` and its subpackages, never a v1 one."""
+    discovered = set(setuptools.find_packages(where=str(REPO_ROOT)))
+
+    assert "mace" in discovered, (
+        "the legacy package itself is no longer discovered from the repository "
+        "root, so this test can no longer prove anything about what the wheel ships"
+    )
+
+    top_level = {name.split(".")[0] for name in discovered}
+    leaked = top_level & (V1_IMPORT_NAMES | {"packages"})
+    assert not leaked, (
+        f"{sorted(leaked)} would be packaged into the legacy mace-torch wheel; "
+        f"the v1 stack is installed from packages/*/pyproject.toml, never from "
+        f"the legacy build"
+    )


### PR DESCRIPTION
Adds `mace-core`, `mace-torch` and `mace-jax` as three almost empty packages that install and import next to the current `mace` package, in the same venv and the same process. It only adds files. It deletes nothing and contains no real code yet.

Each one has a `src` layout, a hatchling build, a short README, one exported symbol and one test. That is enough to prove the install and the imports work.

## Names

| Directory | Installs as | Imports as |
|---|---|---|
| `packages/mace-core` | `mace-core` | `mace_core` |
| `packages/mace-torch` | `mace-torch-v1` | `mace_torch` |
| `packages/mace-jax` | `mace-jax` | `mace_jax` |

The middle row looks odd on purpose. The current package already owns the name `mace-torch`, and two packages cannot share one name in the same venv, so the new one adds a suffix. **It must never be uploaded to PyPI.** Once the old code is gone the name is free again and the suffix goes away, and users notice nothing. If we ever publish the suffixed name, that quiet switch becomes a migration everyone has to do by hand.

None of them defines a command line script. Those belong to one package only, and `setup.cfg` is unchanged.

## The new test

`tests/architecture/test_packaging_isolation.py` guards one thing. The old build picks up any folder whose name is a valid Python name, and every folder here has a hyphen, so none of them is picked up. Name one `packages/mace_core` and it would silently end up inside the old wheel. The test checks both sides of that.

## CI

No job was running either suite, so they could break without any check going red.

`tests/architecture` now runs inside the `unit` job, which already has everything it needs.

The `packages` job is new. It installs no torch and not the old package, on purpose: the three new ones have to work on their own, and a job that installed everything first would hide the day that stops being true. It also needs the full git history, because the version comes from `git describe`, and it installs the three in one `pip install`, because two of them need `mace-core` and that is not on PyPI.

## Checks run

| Check | Result |
|---|---|
| Fresh venv, one `pip install -e` of the three | ok |
| `import mace, mace_core, mace_torch, mace_jax` together | ok, old package still 0.3.17 |
| `pytest packages/*/tests` with no torch and no old package | 3 passed |
| `pytest tests/unit tests/golden tests/architecture -m "not slow" -n auto` | 1047 passed, 61 skipped, 1 xfailed |
| `pre-commit run --all-files` | passed, new files included |
| `git ls-files mace/` | 83, and the diff against `mace/` is empty |

## What to look at

That nothing under `mace/` changed. The branch touches `packages/`, `tests/architecture/` and one workflow file.

Closes #1550

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffold packaging, docs, and CI only; legacy `mace/` is untouched and changes are guarded by architecture tests.
> 
> **Overview**
> Introduces **three installable v1 scaffolds** under `packages/` — `mace-core`, `mace-torch-v1` (import `mace_torch`), and `mace-jax` — each with hatchling + hatch-vcs, a `__version__` export, and a minimal pytest. Torch/JAX backends depend on `mace-core` only; **`mace-torch-v1` is documented as never for PyPI** so it can coexist with the legacy `mace-torch` distribution until RET-6.
> 
> Adds **`tests/architecture/test_packaging_isolation.py`** and wires **`tests/architecture`** into the unit job so hyphenated `packages/*` dirs stay out of the legacy `setup.cfg` `find:` wheel.
> 
> **CI:** lint installs the three editable packages so pylint can import `packages/**`; a new **`packages`** matrix job (Python 3.10–3.13, full git history for VCS versions) installs only the v1 stack (no legacy, no torch) and runs `pytest packages/*/tests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584701719a4bb895c4953d5bb44acec86f83c2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->