### PR TITLE
Add import contracts and a legacy-name check for packages

### DIFF
--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -124,13 +124,48 @@ jobs:
           # next morning. They are CPU-only, network-free, carry no capability
           # marker and no `slow` mark, so they collect on all four versions.
           #
-          # tests/architecture is the fitness suite: structural invariants of
-          # the two-stack tree that no functional test can see. It runs here
-          # because it needs the repository and this job already has it, and
-          # it costs milliseconds.
-          tests: tests/unit tests/golden tests/architecture
+          # tests/architecture is NOT here: it moved to the `architecture` job
+          # below, which is the only one that installs both trees editable and
+          # can therefore run the import contracts alongside it.
+          tests: tests/unit tests/golden
           markers: not slow
           numprocs: auto
+
+  architecture:
+    # The guard that keeps the frozen legacy package unreachable from the v1
+    # stack: the static import contracts, and the meta-lint that catches a
+    # legacy symbol named in a v1 file with or without an import.
+    #
+    # It needs BOTH trees installed editable, which is what separates it from
+    # every other job: import-linter resolves each root package on the
+    # filesystem, so a missing one is reported as a broken contract rather than
+    # as a missing install, and the gate would fail for the wrong reason.
+    #
+    # Fast and CPU-only, so it gates every pull request. It does not depend on
+    # `lint`: a formatting failure and an import-direction failure are
+    # different answers and waiting for one to hear the other helps nobody.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # hatch-vcs derives each package version from git describe.
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-mace
+        with:
+          python-version: "3.12"
+          extras: dev
+      - name: Install the v1 packages
+        run: |
+          python -m pip install -e packages/mace-core \
+                                -e packages/mace-torch \
+                                -e packages/mace-jax
+      - name: Check the import contracts
+        run: lint-imports --config .importlinter
+      - uses: ./.github/actions/run-tests
+        with:
+          tests: tests/architecture
+          numprocs: "0"
 
   packages:
     # The v1 stack under packages/. It installs no legacy package and no

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,85 @@
+; Import contracts for the two-stack tree. Run with `lint-imports`.
+;
+; The rewrite keeps the legacy `mace` package in the tree, byte-frozen, as the
+; numerical oracle the new stack is measured against. That only works while the
+; two are physically unreachable from one another: a legacy class that can be
+; imported can be subclassed, re-exported and quietly ported, and then the
+; oracle is no longer independent of the thing it judges.
+;
+; This file is the static half of that guard. The runtime half lives in
+; `mace_launcher.audit`, because static analysis cannot see
+; `importlib.import_module("mace." + name)`.
+
+[importlinter]
+root_packages =
+    mace
+    mace_core
+    mace_torch
+    mace_jax
+    mace_launcher
+include_external_packages = True
+
+[importlinter:contract:no-legacy-from-v1]
+name = The v1 stack never imports the frozen legacy package
+type = forbidden
+source_modules =
+    mace_core
+    mace_torch
+    mace_jax
+forbidden_modules =
+    mace
+; `mace_launcher` is deliberately absent from the source modules: dispatching
+; into both stacks is its entire job, and it is one of the two allowlisted
+; crossers. The other is `tests/parity/`, which does not exist until PAR-1
+; creates it and cannot be named here before then.
+
+[importlinter:contract:no-v1-from-legacy]
+name = The frozen legacy package never imports the v1 stack
+type = forbidden
+source_modules =
+    mace
+forbidden_modules =
+    mace_core
+    mace_torch
+    mace_jax
+    mace_launcher
+
+[importlinter:contract:core-is-framework-free]
+name = mace_core depends on no framework and on no sibling
+type = forbidden
+source_modules =
+    mace_core
+forbidden_modules =
+    torch
+    jax
+    e3nn
+    mace_torch
+    mace_jax
+    mace_launcher
+
+[importlinter:contract:siblings-do-not-mix]
+name = The torch and jax implementations never import each other
+type = forbidden
+source_modules =
+    mace_torch
+    mace_jax
+forbidden_modules =
+    mace_jax
+    mace_torch
+
+[importlinter:contract:torch-internal-layering]
+name = mace_torch layers only import downwards
+type = layers
+; Every layer is optional, so the contract is written once and starts enforcing
+; each boundary the moment that layer appears. Without the parentheses a
+; contract naming a module that does not exist yet is simply broken, and the
+; gate would have to be added later, which is to say after the imports it is
+; meant to prevent.
+layers =
+    (cli)
+    (train) | (data)
+    (models)
+    (nn)
+    (kernels)
+containers =
+    mace_torch

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ dev =
     pytest-timeout
     pytest-xdist
     pylint==4.0.6
+    import-linter
 schedulefree = schedulefree
 magnetic =
     sphericart-torch==1.0.9

--- a/tests/architecture/test_import_direction.py
+++ b/tests/architecture/test_import_direction.py
@@ -1,0 +1,69 @@
+"""The import contracts in `.importlinter`, run as a test.
+
+The contracts are the static half of the guard that keeps the frozen legacy
+package unreachable from the v1 stack. They are checked here as well as by the
+`lint-imports` step in CI, so that a developer running the architecture suite
+locally sees the same answer as the pull request will.
+"""
+
+import shutil
+import subprocess
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / ".importlinter"
+
+#: The two places allowed to import both stacks. `mace_launcher` holds the
+#: entry-point dispatcher and the runtime guard; `tests/parity/` is the harness
+#: that loads both stacks in one process to compare them numerically. A third
+#: entry defeats the guard, so the count is asserted rather than described.
+ALLOWED_DOUBLE_IMPORTERS = ("mace_launcher", "tests.parity")
+
+
+def test_the_config_exists():
+    assert CONFIG.exists(), f"no import contracts at {CONFIG}"
+
+
+def test_the_v1_packages_are_not_sources_of_a_legacy_import():
+    """`mace_launcher` must be absent from the forbidden contract's sources.
+
+    Its absence *is* the allowlist entry, which makes it easy to add by
+    accident and impossible to notice. Pinning it here means widening the
+    allowlist takes an edit to this test.
+    """
+    parser = ConfigParser()
+    parser.read(CONFIG, encoding="utf-8")
+    section = parser["importlinter:contract:no-legacy-from-v1"]
+    sources = set(section["source_modules"].split())
+    assert sources == {"mace_core", "mace_torch", "mace_jax"}, (
+        f"the forbidden contract's sources are {sorted(sources)}. Every v1 "
+        f"package belongs there; the only module allowed out is the launcher, "
+        f"and any other omission is a hole in the guard."
+    )
+    assert "mace" in section["forbidden_modules"].split()
+
+
+def test_exactly_two_modules_may_import_both_stacks():
+    assert len(ALLOWED_DOUBLE_IMPORTERS) == 2
+
+
+@pytest.mark.skipif(
+    shutil.which("lint-imports") is None,
+    reason="import-linter is not installed (it ships in the dev extra)",
+)
+def test_all_import_contracts_hold():
+    result = subprocess.run(
+        [sys.executable, "-m", "importlinter.cli", "lint-imports",
+         "--config", str(CONFIG)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "import contracts broken:\n" + result.stdout + result.stderr
+    )

--- a/tests/architecture/test_import_direction.py
+++ b/tests/architecture/test_import_direction.py
@@ -6,9 +6,9 @@ package unreachable from the v1 stack. They are checked here as well as by the
 locally sees the same answer as the pull request will.
 """
 
+import importlib.util
 import shutil
 import subprocess
-import sys
 from configparser import ConfigParser
 from pathlib import Path
 
@@ -51,19 +51,48 @@ def test_exactly_two_modules_may_import_both_stacks():
     assert len(ALLOWED_DOUBLE_IMPORTERS) == 2
 
 
+#: Every package the config declares as a root. import-linter resolves each on
+#: the filesystem, so one that is not installed is reported as a broken
+#: contract rather than as a missing install, which reads as a real violation.
+ROOT_PACKAGES = ("mace", "mace_core", "mace_torch", "mace_jax", "mace_launcher")
+
+
+def _missing_roots() -> list[str]:
+    return [name for name in ROOT_PACKAGES if importlib.util.find_spec(name) is None]
+
+
 @pytest.mark.skipif(
     shutil.which("lint-imports") is None,
     reason="import-linter is not installed (it ships in the dev extra)",
 )
 def test_all_import_contracts_hold():
+    """Run the contracts through the console script, not `python -m`.
+
+    `importlinter.cli` has no `__main__` guard, so `python -m importlinter.cli`
+    imports the module, does nothing and exits 0. A test asserting only on the
+    return code then passes without checking a single contract, which is worse
+    than not having it.
+    """
+    missing = _missing_roots()
+    if missing:
+        pytest.skip(
+            f"the import contracts need every root package installed; missing "
+            f"{missing}. The ci-core `architecture` job installs both trees; "
+            f"a job that only installs one cannot run this."
+        )
+
     result = subprocess.run(
-        [sys.executable, "-m", "importlinter.cli", "lint-imports",
-         "--config", str(CONFIG)],
+        [shutil.which("lint-imports"), "--config", str(CONFIG)],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
         check=False,
     )
-    assert result.returncode == 0, (
-        "import contracts broken:\n" + result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    # Assert the work happened, not just that nothing failed: the silent no-op
+    # above also returned 0.
+    assert "Contracts:" in output, (
+        "lint-imports produced no contract report, so nothing was checked:\n"
+        + output
     )
+    assert result.returncode == 0, "import contracts broken:\n" + output

--- a/tests/architecture/test_no_legacy_leak.py
+++ b/tests/architecture/test_no_legacy_leak.py
@@ -78,6 +78,10 @@ def names_used(source: str) -> set[str]:
     and `from x import ScaleShiftMACE as Y` are both caught. Non-docstring
     string constants count too, because `getattr(module, "ScaleShiftMACE")` is
     a reference that carries no identifier at all.
+
+    Definitions count as well. A file that declares `class ScaleShiftMACE` and
+    never mentions the name again refers to nothing, so collecting only
+    references would miss the wholesale copy this check exists to catch.
     """
     tree = ast.parse(source)
     docstrings = set()
@@ -89,7 +93,9 @@ def names_used(source: str) -> set[str]:
 
     used: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Name):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            used.add(node.name)
+        elif isinstance(node, ast.Name):
             used.add(node.id)
         elif isinstance(node, ast.Attribute):
             used.add(node.attr)
@@ -177,6 +183,9 @@ def test_names_v1_reuses_are_not_denied():
         "import mace\nmodel = mace.modules.ScaleShiftMACE()",
         "from x import ScaleShiftMACE as Backbone",
         "cls = getattr(module, 'ScaleShiftMACE')",
+        "class ScaleShiftMACE(Module):\n    pass",
+        "class MACELES(ScaleShiftMACE):\n    pass",
+        "def interaction_classes():\n    return {}",
         "from mace.modules import interaction_classes",
         "batch = AtomicData.from_config(config)",
     ],

--- a/tests/architecture/test_no_legacy_leak.py
+++ b/tests/architecture/test_no_legacy_leak.py
@@ -1,0 +1,200 @@
+"""No file under `packages/` may name a legacy symbol.
+
+The import guard stops the v1 stack importing the frozen legacy package. This
+catches the step before that: naming a legacy class or registry in new code,
+with or without an import. v1 reproduces legacy *behaviour*; a legacy symbol
+appearing in a v1 file is the tell of a structural port, and a port is how the
+oracle stops being independent of the thing it judges.
+
+Matching is done over the parsed syntax tree, never over the file's text. The
+denylist contains `MACE`, which is also the project's name and appears in
+almost every docstring and comment in the tree, so a textual search would flag
+the whole repository and be switched off within a week.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGES = REPO_ROOT / "packages"
+LEGACY_MODELS = REPO_ROOT / "mace" / "modules" / "models.py"
+LEGACY_EXTENSIONS = REPO_ROOT / "mace" / "modules" / "extensions.py"
+LEGACY_REGISTRIES = REPO_ROOT / "mace" / "modules" / "__init__.py"
+
+# Legacy symbols v1 does not carry over. Adding or removing an entry is a
+# reviewed edit to this list, deliberately, rather than an open-ended read of
+# the legacy public surface: the point is to name what must not be ported, not
+# to mirror whatever legacy happens to export.
+LEGACY_MODEL_CLASSES = frozenset(
+    {
+        "MACE",
+        "ScaleShiftMACE",
+        "AtomicDipolesMACE",
+        "AtomicDielectricMACE",
+        "EnergyDipolesMACE",
+        "MACELES",
+        "PolarMACE",
+        "MagneticMACE",
+        "MagneticScaleShiftMACE",
+        "MagneticSCFMACE",
+        "TimeReversalSymmetrizedMACE",
+    }
+)
+LEGACY_REGISTRY_NAMES = frozenset(
+    {"interaction_classes", "readout_classes", "scaling_classes", "gate_dict"}
+)
+LEGACY_DATA_TYPES = frozenset({"AtomicData", "AtomicDataDict"})
+
+DENYLIST = LEGACY_MODEL_CLASSES | LEGACY_REGISTRY_NAMES | LEGACY_DATA_TYPES
+
+# Names v1 reuses for its own ported code. They are legacy names too, and the
+# whole point is that v1 is allowed to reimplement the concept under the same
+# name, so they must never reach the denylist.
+DELIBERATELY_REUSED = frozenset(
+    {
+        "BesselBasis",
+        "PolynomialCutoff",
+        "ZBLBasis",
+        "RadialEmbeddingBlock",
+        "LinearNodeEmbeddingBlock",
+        "AtomicNumberTable",
+        "Configuration",
+        "KeySpecification",
+        "DefaultKeys",
+    }
+)
+
+# Blocks that happen to live in extensions.py. They are not model classes, and
+# nothing about them is forbidden to v1.
+NOT_MODELS = frozenset({"SHModule", "ChebyshevBasisGeneral"})
+
+
+def names_used(source: str) -> set[str]:
+    """Every identifier the code actually refers to, docstrings excluded.
+
+    Attribute access and import targets count, so `mace.modules.ScaleShiftMACE`
+    and `from x import ScaleShiftMACE as Y` are both caught. Non-docstring
+    string constants count too, because `getattr(module, "ScaleShiftMACE")` is
+    a reference that carries no identifier at all.
+    """
+    tree = ast.parse(source)
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc is not None:
+                docstrings.add(doc)
+
+    used: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            used.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used.add(node.attr)
+        elif isinstance(node, ast.alias):
+            used.add(node.name.rsplit(".", 1)[-1])
+            if node.asname:
+                used.add(node.asname)
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value not in docstrings:
+                used.update(part for part in node.value.replace(".", " ").split())
+    return used
+
+
+def package_sources() -> list[Path]:
+    return sorted(PACKAGES.rglob("*.py"))
+
+
+def legacy_top_level_classes() -> set[str]:
+    found: set[str] = set()
+    for path in (LEGACY_MODELS, LEGACY_EXTENSIONS):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        found.update(n.name for n in tree.body if isinstance(n, ast.ClassDef))
+    return found - NOT_MODELS
+
+
+def test_no_packages_file_names_a_legacy_symbol():
+    offenders: list[str] = []
+    for path in package_sources():
+        hits = names_used(path.read_text(encoding="utf-8")) & DENYLIST
+        if hits:
+            offenders.append(f"{path.relative_to(REPO_ROOT)}: {sorted(hits)}")
+    assert not offenders, (
+        "v1 files naming legacy symbols:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nReproduce the behaviour, not the structure. If a name here is one "
+        "v1 legitimately reuses for its own implementation, add it to "
+        "DELIBERATELY_REUSED and remove it from the denylist, in a reviewed edit."
+    )
+
+
+def test_the_denylist_covers_every_legacy_model_class():
+    """A model class added to legacy must not be able to slip past this file."""
+    actual = legacy_top_level_classes()
+    missing = actual - LEGACY_MODEL_CLASSES
+    assert not missing, (
+        f"legacy model classes with no denylist entry: {sorted(missing)}. "
+        f"A class that is not on the list can be ported into packages/ with "
+        f"nothing failing."
+    )
+    stale = LEGACY_MODEL_CLASSES - actual
+    assert not stale, (
+        f"denylist entries that no longer exist in legacy: {sorted(stale)}. "
+        f"A stale entry forbids a name v1 is now free to use."
+    )
+    assert len(LEGACY_MODEL_CLASSES) == 11
+
+
+def test_the_denylist_covers_every_legacy_registry():
+    tree = ast.parse(LEGACY_REGISTRIES.read_text(encoding="utf-8"))
+    declared = set()
+    for node in tree.body:
+        target = None
+        if isinstance(node, ast.AnnAssign):
+            target = node.target
+        elif isinstance(node, ast.Assign) and node.targets:
+            target = node.targets[0]
+        name = getattr(target, "id", None)
+        if name and name.endswith(("_classes", "_dict")):
+            declared.add(name)
+    assert declared == LEGACY_REGISTRY_NAMES, (
+        f"registries in legacy: {sorted(declared)}; on the denylist: "
+        f"{sorted(LEGACY_REGISTRY_NAMES)}"
+    )
+
+
+def test_names_v1_reuses_are_not_denied():
+    """v1 reimplements these concepts under the same name, by design."""
+    assert not (DELIBERATELY_REUSED & DENYLIST)
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        "from mace.modules import ScaleShiftMACE",
+        "import mace\nmodel = mace.modules.ScaleShiftMACE()",
+        "from x import ScaleShiftMACE as Backbone",
+        "cls = getattr(module, 'ScaleShiftMACE')",
+        "from mace.modules import interaction_classes",
+        "batch = AtomicData.from_config(config)",
+    ],
+)
+def test_the_check_fires_on_a_structural_port(snippet):
+    """Each spelling a port would actually use, including the string form."""
+    assert names_used(snippet) & DENYLIST
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        '"""The PyTorch stack for MACE v1."""',
+        "# MACE reproduces the behaviour of ScaleShiftMACE\nx = 1",
+        "from mace_core.radial import BesselBasis, PolynomialCutoff",
+        "table = AtomicNumberTable([1, 8])",
+    ],
+)
+def test_the_check_does_not_fire_on_prose_or_reused_names(snippet):
+    """A docstring, a comment and the names v1 keeps must all pass."""
+    assert not (names_used(snippet) & DENYLIST)


### PR DESCRIPTION
The old package stays in the tree as the reference the new code is measured against. That only holds while the new code cannot reach it: a legacy class you can import is one you can subclass and quietly copy, and then the reference is no longer independent of what it is judging. Two gates, so this stops depending on review attention.

**Import contracts.** `.importlinter` holds five: the v1 packages never import `mace`, `mace` never imports them, `mace_core` depends on no framework and no sibling, the torch and jax sides never import each other, and `mace_torch` layers only import downwards. Each was checked by breaking it and watching it fail on the right file and line.

Every layer in the layering contract is optional. `mace_torch` has none of `cli`, `train`, `models`, `nn` or `kernels` yet, and a contract naming a module that does not exist is simply broken, so the alternative was adding this gate after the imports it exists to prevent.

**Name check.** A file can copy structure without importing anything, so this catches a legacy symbol named in a v1 file at all. It reads the parsed syntax tree, not the text: the list contains `MACE`, which is also the project's name and is in nearly every docstring here, so a text search would flag the whole repository and be switched off within a week. `getattr(module, "ScaleShiftMACE")` is caught; `"""The PyTorch stack for MACE v1."""` is not. The model-class list is checked against the classes the old code declares, so one added there fails here.

**Where it runs.** `tests/architecture` moves out of `unit` into a new `architecture` job, so it runs once. That job is the only one installing both trees editable, which the contracts need: import-linter resolves each package on the filesystem, so a missing one reads as a broken contract rather than a missing install. It does not wait on `lint`, since a formatting failure and an import-direction failure are different answers.

## Checks run

| Check | Result |
|---|---|
| `lint-imports --config .importlinter` | 5 kept, 0 broken, over 147 files |
| `pytest tests/architecture` | 20 passed |
| `pytest tests/unit tests/golden -m "not slow" -n auto` | 1045 passed, 61 skipped, 1 xfailed |
| `pre-commit run --all-files` | passed |
| `git ls-files mace/` | 83, and the diff against `mace/` is empty |

The runtime half of the guard already exists in `mace_launcher.audit`. Its other activation point is the `tests/parity/` conftest, which PAR-1 (#1572) creates.

## What to look at

That exactly two things may import both stacks: `mace_launcher`, which holds the dispatcher and the guard, and `tests/parity/`. The launcher's entry is its *absence* from the contract's source list, which is easy to widen by accident and impossible to notice, so a test pins that list.

Closes #1552

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI and dev-tooling guardrails only; they do not alter training, inference, or user-facing runtime behavior.
> 
> **Overview**
> Adds **static enforcement** so the frozen legacy `mace` tree stays isolated from the v1 packages under `packages/`, complementing the existing runtime guard in `mace_launcher.audit`.
> 
> **Import contracts** (`.importlinter`, run via `lint-imports`): five rules—no cross-import between legacy and v1 (with `mace_launcher` intentionally outside the v1→legacy sources), framework-free `mace_core`, no `mace_torch`↔`mace_jax` mixing, and optional downward layering for `mace_torch`. `import-linter` is added to the **dev** extra.
> 
> **CI**: `tests/architecture` is removed from the **unit** matrix and moved to a dedicated **`architecture`** job that installs both stacks (legacy via `setup-mace`, v1 editable), runs `lint-imports`, then `pytest tests/architecture`—in parallel with **lint**, not behind it.
> 
> **New architecture tests**: mirror the contracts locally (including pinning that only `mace_core`/`mace_torch`/`mace_jax` are forbidden-from-legacy sources) and scan all `packages/**/*.py` with an **AST denylist** of legacy model/registry/data names so structural ports are caught even without imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef56d31459819929e2eccb9f797bff55591b9499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->