### PR TITLE
Avoid the [B, mul1, mul2] intermediate in SparseUvuTensorProduct (up to 2.6x less memory)

### DIFF
--- a/mace/modules/field_blocks.py
+++ b/mace/modules/field_blocks.py
@@ -445,11 +445,16 @@ class SparseUvuTensorProduct(torch.nn.Module):
             # mode_code determines whether out is scalar (d_out=1) or vector (d_out=d1).
             if mode_code == 0:
                 # (l x l -> 0): [B, mul1, d] · [B, mul2, d] -> [B, mul1]
+                # Contract the weight into x2 before contracting over d. Summing over v last
+                # would build a [B, mul1, mul2] intermediate only to contract it away on the
+                # next line; with multiplicities in the hundreds and d = 2l+1 in {1,3,5} that
+                # dominates the memory of the whole Polar model. Same leading flop count, and the same
+                # order e3nn's opt_einsum pass picks for its `zuv,zui,zvi->zu` form.
                 x1v = to_mul_ir(in1_block, mul1, d1)
                 x2v = to_mul_ir(in2_block, mul2, d1)
                 w = self.weight[w_start:w_stop].view(mul1, mul2)
-                pair = torch.einsum("bud,bvd->buv", x1v, x2v) / math.sqrt(float(d1))
-                mixed = torch.einsum("buv,uv->bu", pair, w)
+                weighted_x2 = torch.einsum("uv,bvd->bud", w, x2v)
+                mixed = (x1v * weighted_x2).sum(dim=-1) / math.sqrt(float(d1))
                 out[:, out_start:out_stop] = out_block + path_weight * mixed
             else:
                 # (l x 0 -> l): x1 scaled per channel by weighted scalar mixture from x2.

--- a/tests/unit/test_sparse_uvu_tensor_product.py
+++ b/tests/unit/test_sparse_uvu_tensor_product.py
@@ -1,0 +1,186 @@
+"""`SparseUvuTensorProduct` must agree with the `e3nn.o3.TensorProduct` it replaces.
+
+The class is a hand-written torch specialisation of the sparse `uvu` tensor
+products PolarMACE uses, written so that it can also read and write
+cuEquivariance's `ir_mul` layout. It builds its weights from a reference
+`o3.TensorProduct`, so that reference is the natural oracle: in `mul_ir` the two
+must agree elementwise, and in `ir_mul` they must agree once the layout is
+transposed on the way in and out.
+
+These tests cover both supported path types (`l x l -> 0` and `l x 0 -> l`), the
+degenerate `d = 1` case where the contraction over the irrep dimension is a
+no-op, and `l` up to 2 so that `d = 2l+1` takes all of 1, 3 and 5. They need
+nothing beyond e3nn, so they live here rather than under `tests/extensions`.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from e3nn import o3
+
+from mace.modules.field_blocks import (
+    SparseUvuTensorProduct,
+    instructions_for_sparse_tp,
+)
+
+# (mul, l_max). Multiplicity above the irrep dimension is the regime the model
+# runs in, and the one where the contraction order matters; the last case checks
+# the degenerate opposite.
+CASES = [
+    (8, 0),  # scalars only: every path has d = 1
+    (8, 1),  # adds d = 3
+    (7, 2),  # adds d = 5, and a multiplicity that is not a power of two
+    (1, 2),  # degenerate single channel
+]
+
+
+@pytest.fixture(name="float64")
+def _float64():
+    """Compare in double precision; the contraction orders differ by rounding."""
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
+    yield
+    torch.set_default_dtype(previous)
+
+
+def _irreps(mul: int, l_max: int) -> o3.Irreps:
+    return o3.Irreps([(mul, (l, (-1) ** l)) for l in range(l_max + 1)])
+
+
+def _reference_for(sparse: SparseUvuTensorProduct, instructions) -> o3.TensorProduct:
+    """The e3nn TensorProduct `sparse` stands in for, sharing its weights."""
+    reference = o3.TensorProduct(
+        sparse.irreps_in1,
+        sparse.irreps_in2,
+        sparse.irreps_out,
+        instructions=instructions,
+        shared_weights=True,
+        internal_weights=True,
+    )
+    with torch.no_grad():
+        reference.weight.copy_(sparse.weight)
+    return reference
+
+
+def _build(mul: int, l_max: int, layout: str):
+    irreps_in1 = _irreps(mul, l_max)
+    irreps_in2 = _irreps(mul, l_max)
+    irreps_out = o3.Irreps(f"{mul}x0e")
+    instructions = instructions_for_sparse_tp(irreps_in1, irreps_in2, irreps_out)
+    sparse = SparseUvuTensorProduct(
+        irreps_in1, irreps_in2, irreps_out, instructions=instructions, layout=layout
+    )
+    return sparse, _reference_for(sparse, instructions)
+
+
+def _transpose_layout(x: torch.Tensor, irreps: o3.Irreps, to_ir_mul: bool):
+    """Re-lay a [batch, irreps.dim] tensor between mul_ir and ir_mul ordering."""
+    batch = x.shape[0]
+    blocks = []
+    for (mul, ir), block in zip(irreps, irreps.slices()):
+        shape = (mul, ir.dim) if to_ir_mul else (ir.dim, mul)
+        blocks.append(
+            x[:, block].view(batch, *shape).transpose(1, 2).reshape(batch, -1)
+        )
+    return torch.cat(blocks, dim=-1)
+
+
+@pytest.mark.parametrize("mul,l_max", CASES)
+def test_it_matches_e3nn_in_the_mul_ir_layout(mul: int, l_max: int, float64):
+    torch.manual_seed(0)
+    sparse, reference = _build(mul, l_max, "mul_ir")
+    x1 = sparse.irreps_in1.randn(16, -1)
+    x2 = sparse.irreps_in2.randn(16, -1)
+    torch.testing.assert_close(sparse(x1, x2), reference(x1, x2))
+
+
+@pytest.mark.parametrize("mul,l_max", CASES)
+def test_it_matches_e3nn_in_the_ir_mul_layout(mul: int, l_max: int, float64):
+    """The ir_mul path must produce the same physics, only laid out differently."""
+    torch.manual_seed(0)
+    sparse, reference = _build(mul, l_max, "ir_mul")
+    x1 = sparse.irreps_in1.randn(16, -1)
+    x2 = sparse.irreps_in2.randn(16, -1)
+    got = sparse(
+        _transpose_layout(x1, sparse.irreps_in1, True),
+        _transpose_layout(x2, sparse.irreps_in2, True),
+    )
+    torch.testing.assert_close(
+        _transpose_layout(got, sparse.irreps_out, False), reference(x1, x2)
+    )
+
+
+@pytest.mark.parametrize("mul,l_max", CASES)
+def test_its_gradients_match_e3nn(mul: int, l_max: int, float64):
+    """Forces and fine-tuning reach this block through autograd, so the
+    backward must agree too -- in the weights as well as the inputs."""
+    torch.manual_seed(0)
+    sparse, reference = _build(mul, l_max, "mul_ir")
+    x1 = sparse.irreps_in1.randn(16, -1)
+    x2 = sparse.irreps_in2.randn(16, -1)
+
+    grads = []
+    for module in (sparse, reference):
+        module.zero_grad(set_to_none=True)
+        a, b = x1.clone().requires_grad_(True), x2.clone().requires_grad_(True)
+        module(a, b).square().sum().backward()
+        grads.append((a.grad, b.grad, module.weight.grad))
+    for got, want in zip(grads[0], grads[1]):
+        torch.testing.assert_close(got, want)
+
+
+def test_the_scalar_times_vector_path_matches_e3nn(float64):
+    """`l x 0 -> l` is the other supported path; CASES only reach `l x l -> 0`."""
+    torch.manual_seed(0)
+    irreps = o3.Irreps("8x0e+8x1o")
+    instructions = [(0, 0, 0, "uvu", True), (1, 0, 1, "uvu", True)]
+    sparse = SparseUvuTensorProduct(
+        irreps, irreps, irreps, instructions=instructions, layout="mul_ir"
+    )
+    modes = {meta[9] for meta in sparse._path_meta}  # pylint: disable=protected-access
+    assert modes == {0, 1}, f"expected both path modes, got {modes}"
+
+    reference = _reference_for(sparse, instructions)
+    x1 = irreps.randn(16, -1)
+    x2 = irreps.randn(16, -1)
+    torch.testing.assert_close(sparse(x1, x2), reference(x1, x2))
+
+
+def test_no_intermediate_reaches_the_squared_multiplicity(float64, monkeypatch):
+    """Guard the contraction order: nothing of size batch*mul1*mul2 is allocated.
+
+    Summing over `v` last builds a [B, mul1, mul2] tensor and contracts it away
+    immediately. That intermediate sets the peak allocation of a PolarMACE
+    forward, and a regression is silent -- it surfaces only as an OOM at a
+    system size that used to fit. Here the forbidden intermediate is 1048576
+    elements against 24576 for the largest legitimate one.
+    """
+    torch.manual_seed(0)
+    mul, batch = 128, 64
+    irreps_in1 = _irreps(mul, 1)
+    irreps_out = o3.Irreps(f"{mul}x0e")
+    instructions = instructions_for_sparse_tp(irreps_in1, irreps_in1, irreps_out)
+    sparse = SparseUvuTensorProduct(
+        irreps_in1, irreps_in1, irreps_out, instructions=instructions, layout="mul_ir"
+    )
+    x1 = irreps_in1.randn(batch, -1)
+    x2 = irreps_in1.randn(batch, -1)
+
+    sizes = []
+    original_einsum = torch.einsum
+
+    def recording_einsum(equation, *operands):
+        result = original_einsum(equation, *operands)
+        sizes.append(result.numel())
+        return result
+
+    monkeypatch.setattr(torch, "einsum", recording_einsum)
+    sparse(x1, x2)
+
+    assert sizes, "expected the forward to use einsum"
+    assert max(sizes) < batch * mul * mul, (
+        f"an intermediate of {max(sizes)} elements was allocated; anything "
+        f"reaching batch*mul1*mul2 = {batch * mul * mul} means the "
+        f"[B, mul1, mul2] outer product is back"
+    )


### PR DESCRIPTION
`SparseUvuTensorProduct`'s `l x l -> 0` path built a `[B, mul1, mul2]` outer product and
contracted it away on the very next line. Contracting the weight into `x2` first computes the
same thing with an intermediate no larger than the inputs.

Every `SparseUvuTensorProduct` in the MACE-Polar checkpoints is 512 channels wide
(`512x0e ⊗ 512x0e -> 512x0e` in `polar-1-s`), so `[B, 512, 512]` is the peak allocation of a
PolarMACE forward — a full 512×512 outer product per atom, summed away immediately.

### What it buys you

This OOMs on a 16 GB GPU before the change and runs after it:

```python
from ase.build import molecule
from mace.calculators import mace_polar

water = molecule("H2O")
water.set_cell([4.0, 4.0, 4.0])
water.pbc = True
atoms = water * (10, 10, 10)  # 3000 atoms
atoms.info["charge"] = 0
atoms.info["spin"] = 1

atoms.calc = mace_polar(
    model="polar-1-s", device="cuda", default_dtype="float64", enable_cueq=True
)
print(atoms.get_potential_energy())
```

Largest box that evaluates energy + forces, bisected on a Tesla T4 (16 GB), float64, that
same periodic water system:

| | before | after | peak MiB/atom |
|---|---:|---:|---|
| `polar-1-s`, stock install | 1368 atoms | **1887** | 9.21 → 8.32 |
| `polar-1-s`, `enable_cueq=True` | 1914 atoms | **4380** | 8.00 → **3.11** |
| `polar-1-m`, `enable_cueq=True` | 1593 atoms | **3393** | 9.43 → 4.07 |
| `polar-1-l`, `enable_cueq=True` | 1224 atoms | **1917** | 12.26 → 7.43 |

cueq gains most because it fuses the interaction blocks, which leaves this un-accelerated
block as the peak allocation; without it the peak sits elsewhere and only the transient outer
product disappears. Drop `enable_cueq=True` from the script and `(8, 8, 8)` — 1536 atoms — is
the equivalent before/after size on a stock install. Energy + forces is also 2.1–2.5× faster
across the three checkpoints with cueq.

### Correctness

The two orders are the same contraction reassociated, and `opt_einsum` picks this one for the
equivalent `uv,zui,zvi->zu` form. Verified against `e3nn.o3.TensorProduct`:

- values and gradients agree to roundoff across float32/float64, both `mul_ir` and `ir_mul`
  layouts, both supported path types, multiplicity 1–256 and `l` up to 3;
- `gradcheck` and `gradgradcheck` pass, and weight gradients and double backward — the
  fine-tuning and force-training paths — match to the same roundoff;
- end to end on `polar-1-s/m/l`: `dE = 0` and `max|dF| <= 2.4e-15` in float64. Every energy
  in the table above is identical before and after at each size that fits both.

### Tests

`SparseUvuTensorProduct` had no tests. This adds them against the `e3nn.o3.TensorProduct` it
stands in for — both path types, both layouts, values and gradients (inputs *and* weights) —
plus a guard that fails if the contraction order regresses, which is otherwise silent until it
OOMs. They import nothing but `torch` and `e3nn`, so they sit in `tests/unit` and run without
the polar extra.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
