### PR TITLE
[codex] Reject HTML before caching model downloads

### DIFF
--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -64,10 +64,13 @@ def _urlretrieve_with_timeout(url, filename, timeout=_DOWNLOAD_TIMEOUT):
         with urllib.request.urlopen(
             _normalize_github_download_url(url), timeout=timeout
         ) as response:
+            info = response.info()
+            content_type = info.get("Content-Type", "").split(";", 1)[0].strip().lower()
+            if content_type == "text/html":
+                raise RuntimeError(f"Model download failed, please check the URL {url}")
             total = int(response.headers.get("Content-Length", 0))
             downloaded = 0
             block_size = 256 * 1024  # 256 KB
-            info = response.info()
             with open(tmp, "wb") as out:
                 while True:
                     block = response.read(block_size)

--- a/tests/unit/test_download_http.py
+++ b/tests/unit/test_download_http.py
@@ -1,0 +1,143 @@
+"""Exercise the real checkpoint downloader with offline HTTP responses."""
+
+import io
+from email.message import Message
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from mace.calculators import foundations_models as fm
+
+
+class Response(io.BytesIO):
+    """Minimal context-managed HTTP response; no network or model needed."""
+
+    def __init__(self, body, content_type="application/octet-stream"):
+        super().__init__(body)
+        self.headers = Message()
+        if content_type is not None:
+            self.headers["content-type"] = content_type
+        self.headers["Content-Length"] = str(len(body))
+
+    def info(self):
+        return self.headers
+
+
+@pytest.mark.parametrize(
+    "content_type", ["text/html", "text/html; charset=utf-8", "Text/HTML"]
+)
+@pytest.mark.parametrize("existing", [False, True])
+def test_html_is_rejected_before_reading_or_replacing_checkpoint(
+    tmp_path, monkeypatch, content_type, existing
+):
+    """A successful HTTP status must not publish an HTML body as a model."""
+    destination = tmp_path / "model.model"
+    if existing:
+        destination.write_bytes(b"existing checkpoint")
+    response = Response(b"<html>login required</html>", content_type)
+    response.read = Mock(wraps=response.read)
+    urlopen = Mock(return_value=response)
+    monkeypatch.setattr(fm.urllib.request, "urlopen", urlopen)
+    url = "https://example.test/model.model"
+
+    with pytest.raises(RuntimeError, match="Model download failed") as error:
+        fm._urlretrieve_with_timeout(url, str(destination))
+
+    assert url in str(error.value)
+    urlopen.assert_called_once_with(url, timeout=fm._DOWNLOAD_TIMEOUT)
+    response.read.assert_not_called()
+    assert response.closed
+    assert not destination.with_suffix(".model.part").exists()
+    if existing:
+        assert destination.read_bytes() == b"existing checkpoint"
+    else:
+        assert not destination.exists()
+
+
+@pytest.mark.parametrize(
+    "loader",
+    [fm.mace_mp, fm.mace_polar, fm.mace_off, fm.mace_omol, fm.mace_mdp, fm.mace_anicc],
+)
+def test_loader_retries_html_then_reuses_successful_cache(
+    tmp_path, monkeypatch, loader
+):
+    """Every loader uses the common guard, retries, and then stays offline."""
+    monkeypatch.setattr(fm, "get_cache_dir", lambda: str(tmp_path))
+    calculator = Mock()
+    monkeypatch.setattr(fm, "MACECalculator", calculator)
+    html = Response(b"<html>login required</html>", "text/html; charset=utf-8")
+    checkpoint = Response(b"checkpoint bytes")
+    urlopen = Mock(side_effect=[html, checkpoint])
+    monkeypatch.setattr(fm.urllib.request, "urlopen", urlopen)
+    if loader is fm.mace_anicc:
+        kwargs = {"model_path": str(tmp_path / "model.model")}
+    else:
+        kwargs = {"model": "https://example.test/model.model"}
+
+    with pytest.raises(RuntimeError, match="download"):
+        loader(device="cpu", **kwargs)
+
+    calculator.assert_not_called()
+    assert list(tmp_path.iterdir()) == []
+    assert urlopen.call_count == 1
+
+    loader(device="cpu", **kwargs)
+    saved = Path(calculator.call_args.kwargs["model_paths"])
+    assert saved.parent == tmp_path
+    assert saved.read_bytes() == b"checkpoint bytes"
+    assert not Path(str(saved) + ".part").exists()
+    assert urlopen.call_count == 2
+
+    loader(device="cpu", **kwargs)
+    assert urlopen.call_count == 2
+    assert calculator.call_count == 2
+    assert Path(calculator.call_args.kwargs["model_paths"]) == saved
+
+
+@pytest.mark.parametrize("content_type", ["application/octet-stream", None])
+def test_binary_download_preserves_bytes_headers_timeout_and_progress(
+    tmp_path, monkeypatch, capsys, content_type
+):
+    """Valid downloads still publish exact bytes and report progress."""
+    body = b"checkpoint bytes"
+    response = Response(body, content_type)
+    urlopen = Mock(return_value=response)
+    monkeypatch.setattr(fm.urllib.request, "urlopen", urlopen)
+    destination = tmp_path / "model.model"
+    url = "https://github.com/example/models/blob/main/model.model?raw=true"
+
+    path, info = fm._urlretrieve_with_timeout(url, str(destination), timeout=17)
+
+    assert path == str(destination)
+    assert info is response.headers
+    assert destination.read_bytes() == body
+    assert not Path(str(destination) + ".part").exists()
+    assert response.closed
+    urlopen.assert_called_once_with(
+        "https://raw.githubusercontent.com/example/models/main/model.model", timeout=17
+    )
+    assert "Downloading: 100.0%" in capsys.readouterr().out
+
+
+def test_interrupted_binary_download_is_cleaned_up_and_can_retry(tmp_path, monkeypatch):
+    """Keep atomic-download cleanup while adding the content-type guard."""
+    destination = tmp_path / "model.model"
+    interrupted = Response(b"unused")
+    interrupted.read = Mock(
+        side_effect=[b"partial bytes", TimeoutError("read timed out")]
+    )
+    success = Response(b"complete checkpoint")
+    urlopen = Mock(side_effect=[interrupted, success])
+    monkeypatch.setattr(fm.urllib.request, "urlopen", urlopen)
+    url = "https://example.test/model.model"
+
+    with pytest.raises(TimeoutError, match="read timed out"):
+        fm._urlretrieve_with_timeout(url, str(destination))
+
+    assert list(tmp_path.iterdir()) == []
+    assert interrupted.closed
+    fm._urlretrieve_with_timeout(url, str(destination))
+    assert destination.read_bytes() == b"complete checkpoint"
+    assert not Path(str(destination) + ".part").exists()
+    assert urlopen.call_count == 2


### PR DESCRIPTION
## Problem

An HTTP 200 response can still be an HTML login/error page. The common downloader currently saves such a response as a model file. Some loaders have a post-download string guard, but it is case-sensitive; OFF, OMOL and ANI-CC do not share that guard. Once an invalid file is cached, subsequent calls may reuse it instead of retrying the download.

## Cause and fix

Move response-header inspection into `_urlretrieve_with_timeout`, before reading the response body or opening the temporary file. Normalize the Content-Type media type (case and optional parameters), and raise the existing style of download error for `text/html`. Binary responses, including those without Content-Type, retain the existing timeout, progress, atomic replacement and return-value behavior.

This is a small v0.3 bug fix against `develop`, following the current contribution guide. It relates to download robustness noted in #1636, but does **not** implement or close the v1 FM-4 artifact/cache redesign. Existing loader-specific guards remain unchanged. The fix does not inspect arbitrary model bytes or repair previously cached invalid files.

## Regression coverage

Fifteen new offline cases exercise the real downloader and all six public loaders (MP, Polar, OFF, OMOL, MDP and ANI-CC). They cover canonical/parameterized/mixed-case HTML media types, case-insensitive header lookup, no body read on rejection, preservation of an existing destination, retry after an HTML response, reuse after a successful download, exact binary bytes, missing Content-Type, timeout/progress/header behavior and interrupted-download cleanup.

HTTP responses are fakes and calculator construction is mocked in the new loader tests; no remote model weights or GPU are required. Existing adjacent calculator/configuration tests are also included.

## Validation

On original production code, the new tests produced **12 failures and 3 passes** (missing HTML rejection). After the fix:

```bash
python -m pytest tests/unit/test_download_http.py tests/unit/test_download_cache.py tests/unit/test_download_urls.py tests/unit/test_calculator_mdp.py tests/unit/test_foundations_models.py -q --tb=short
# 37 passed, 226 warnings in 5.62s

pre-commit run --files mace/calculators/foundations_models.py tests/unit/test_download_http.py
black --check mace/calculators/foundations_models.py tests/unit/test_download_http.py
isort --check-only mace/calculators/foundations_models.py tests/unit/test_download_http.py
```

All applicable selected-file hooks pass. Black/isort were additionally run explicitly on the new test file because most repository hooks exclude tests. No mypy result is claimed. Environment: Ubuntu/WSL, Python 3.12.3, torch 2.11.0+cpu, numpy 2.3.5, e3nn 0.4.4. Warnings include dependency deprecations and the existing host's TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD setting; this patch changes neither that setting nor checkpoint loading policy.

No full test-suite, GPU, real remote checkpoint, training, accuracy or performance result is claimed. No golden references or tolerances changed.

Implementation, regression tests and this description were developed with AI assistance.
