### PR TITLE
Warn about the surfaces MACE v1.0 removes or replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ over.
     - [Finetuning foundation models](#finetuning-foundation-models)
     - [Latest recommended foundation models](#latest-recommended-foundation-models)
   - [Caching](#caching)
+  - [What changes in MACE v1.0](#what-changes-in-mace-v10)
   - [Development](#development)
   - [Contributing](#contributing)
   - [References](#references)
@@ -358,6 +359,38 @@ If you want to finetune another model, the model will be loaded from the path pr
 
 By default automatically downloaded models, like mace_mp, mace_off and data for fine tuning, end up in `~/.cache/mace`. The path can be changed by using
 the environment variable XDG_CACHE_HOME. When set, the new cache path expands to $XDG_CACHE_HOME/.cache/mace
+
+## What changes in MACE v1.0
+
+MACE v1.0 is a rewrite, and it does not carry every surface of the 0.3.x line.
+The options, commands, classes and output keys that go away, or that survive
+only under a more general mechanism, now say so when you use them: they raise a
+`FutureWarning` and write the same text to the run log. Nothing changes about
+what they do in 0.3.x.
+
+A warning fires only for something you asked for. A flag warns when you pass it,
+not when it merely has a default, and a command warns when you run it. To see
+the whole list at once, including the parts that have no single moment to warn
+at, run:
+
+```sh
+python -m mace.tools.deprecation
+```
+
+Each entry says whether v1.0 removes the feature outright or replaces it with a
+more general mechanism, and why. The v1.0 migration guide will carry the new
+spellings; these warnings deliberately do not name v1 commands, because the
+last 0.3.x release ships before the v1 CLI exists.
+
+Every message starts with `MACE v1.0`, so one filter silences all of them:
+
+```python
+import warnings
+warnings.filterwarnings("ignore", message="MACE v1.0", category=FutureWarning)
+```
+
+`module="mace"` does not work here, because the warning is attributed to the
+caller that passed the option rather than to a module inside the package.
 
 ## Development
 

--- a/mace/calculators/foundations_models.py
+++ b/mace/calculators/foundations_models.py
@@ -9,6 +9,7 @@ import torch
 from ase import units
 from ase.calculators.mixing import SumCalculator
 
+from mace.tools.deprecation import warn
 from mace.tools.utils import get_cache_dir
 
 from .mace import MACECalculator
@@ -499,6 +500,11 @@ def mace_anicc(
         If you are using this function, please cite the relevant paper associated with the MACE model, ANI dataset, and also the following:
         - "Evaluation of the MACE Force Field Architecture by Dávid Péter Kovács, Ilyes Batatia, Eszter Sára Arany, and Gábor Csányi, The Journal of Chemical Physics, 2023, URL: https://doi.org/10.1063/5.0155322
     """
+    # The row for this loader already covers the model and the checkpoint that
+    # go with it, so fm.mace_anicc and pkg.anicc_checkpoint stay table-only.
+    warn("calc.export.mace_anicc")
+    if model_path is not None:
+        warn("kwarg.model_path")
     if model_path is None:
         model_path = os.path.join(
             module_dir, "foundations_models/ani500k_large_CC.model"

--- a/mace/calculators/lammps_mace.py
+++ b/mace/calculators/lammps_mace.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional
 import torch
 from e3nn.util.jit import compile_mode
 
+from mace.tools.deprecation import warn
 from mace.tools.scatter import scatter_sum
 
 
@@ -10,6 +11,7 @@ from mace.tools.scatter import scatter_sum
 class LAMMPS_MACE(torch.nn.Module):
     def __init__(self, model, **kwargs):
         super().__init__()
+        warn("calc.export.LAMMPS_MACE")
         self.model = model
         self.register_buffer("atomic_numbers", model.atomic_numbers)
         self.register_buffer("r_max", model.r_max)

--- a/mace/calculators/mace.py
+++ b/mace/calculators/mace.py
@@ -30,6 +30,7 @@ from mace.tools.compile import (
     simplify,
 )
 from mace.tools.default_keys import DefaultKeys
+from mace.tools.deprecation import warn
 from mace.tools.scripts_utils import extract_model
 
 try:
@@ -163,7 +164,7 @@ class MACECalculator(Calculator):
                 "'model_path' argument is deprecated, please use 'model_paths'"
             )
             if model_paths is None:
-                logging.warning(f"{deprecation_message} in the future.")
+                warn("calc.param.model_path")
                 model_paths = kwargs["model_path"]
             else:
                 raise ValueError(
@@ -1055,7 +1056,7 @@ class MagneticMACECalculator(Calculator):
                 "'model_path' argument is deprecated, please use 'model_paths'"
             )
             if model_paths is None:
-                logging.warning(f"{deprecation_message} in the future.")
+                warn("calc.param.model_path")
                 model_paths = kwargs["model_path"]
             else:
                 raise ValueError(

--- a/mace/cli/active_learning_md.py
+++ b/mace/cli/active_learning_md.py
@@ -11,6 +11,7 @@ from ase.md.langevin import Langevin
 from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
 
 from mace.calculators.mace import MACECalculator
+from mace.tools import deprecation
 
 
 def parse_args() -> argparse.Namespace:
@@ -141,6 +142,7 @@ def stop_error(dyn, threshold, reg=0.2):
 
 
 def main() -> None:
+    deprecation.warn("ep.mace_active_learning_md")
     args = parse_args()
     run(args)
 

--- a/mace/cli/convert_cueq_e3nn.py
+++ b/mace/cli/convert_cueq_e3nn.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 from e3nn import o3
 
+from mace.tools import deprecation
 from mace.tools.cg import O3_e3nn
 from mace.tools.cg_cueq_tools import symmetric_contraction_proj
 from mace.tools.scripts_utils import extract_config_mace_model
@@ -280,6 +281,7 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
 
 
 def main():
+    deprecation.warn("ep.mace_cueq_to_e3nn")
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input CuEq model")
     parser.add_argument(

--- a/mace/cli/convert_e3nn_cueq.py
+++ b/mace/cli/convert_e3nn_cueq.py
@@ -7,6 +7,7 @@ import torch
 from e3nn import o3
 
 from mace.modules.wrapper_ops import CuEquivarianceConfig
+from mace.tools import deprecation
 from mace.tools.cg import O3_e3nn
 from mace.tools.cg_cueq_tools import symmetric_contraction_proj
 from mace.tools.scripts_utils import extract_config_mace_model
@@ -278,6 +279,7 @@ def run(
 
 
 def main():
+    deprecation.warn("ep.mace_e3nn_cueq")
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input MACE model")
     parser.add_argument(

--- a/mace/cli/convert_e3nn_hybrid.py
+++ b/mace/cli/convert_e3nn_hybrid.py
@@ -7,6 +7,7 @@ import os
 import torch
 
 from mace.modules.wrapper_ops import CuEquivarianceConfig, OEQConfig
+from mace.tools import deprecation
 from mace.tools.scripts_utils import extract_config_mace_model
 from mace.tools.torch_tools import restores_default_dtype
 
@@ -139,6 +140,7 @@ def _shapes_match_up_to_unsqueeze(a, b):
 
 
 def main():
+    deprecation.warn("ep.convert_e3nn_hybrid")
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input MACE model")
     parser.add_argument(

--- a/mace/cli/convert_e3nn_oeq.py
+++ b/mace/cli/convert_e3nn_oeq.py
@@ -5,6 +5,7 @@ import os
 import torch
 
 from mace.modules.wrapper_ops import OEQConfig
+from mace.tools import deprecation
 from mace.tools.scripts_utils import extract_config_mace_model
 from mace.tools.torch_tools import restores_default_dtype
 
@@ -65,6 +66,7 @@ def run(
 
 
 def main():
+    deprecation.warn("ep.convert_e3nn_oeq")
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input MACE model")
     parser.add_argument(

--- a/mace/cli/convert_oeq_e3nn.py
+++ b/mace/cli/convert_oeq_e3nn.py
@@ -4,6 +4,7 @@ import os
 
 import torch
 
+from mace.tools import deprecation
 from mace.tools.scripts_utils import extract_config_mace_model
 from mace.tools.torch_tools import restores_default_dtype
 
@@ -54,6 +55,7 @@ def run(input_model, output_model="_e3nn.model", device="cpu", return_model=True
 
 
 def main():
+    deprecation.warn("ep.convert_oeq_e3nn")
     parser = argparse.ArgumentParser()
     parser.add_argument("input_model", help="Path to input oeq model")
     parser.add_argument(

--- a/mace/cli/create_lammps_model.py
+++ b/mace/cli/create_lammps_model.py
@@ -11,6 +11,7 @@ from e3nn.util import jit
 from mace.calculators import LAMMPS_MACE
 from mace.calculators.lammps_mliap_mace import LAMMPS_MLIAP_MACE
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
+from mace.tools import deprecation
 
 
 def parse_args():
@@ -42,7 +43,9 @@ def parse_args():
         help="Old libtorch format, or new mliap format",
         default="libtorch",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    deprecation.warn_args("cli.create_lammps_model", parser)
+    return args
 
 
 def select_head(model):
@@ -106,6 +109,7 @@ def main():
     if args.format == "mliap":
         torch.save(lammps_model, model_path + "-mliap_lammps.pt")
     else:
+        deprecation.warn("lammps.torchscript_wrapper")
         lammps_model_compiled = jit.compile(lammps_model)
         lammps_model_compiled.save(model_path + "-lammps.pt")
 

--- a/mace/cli/eval_configs.py
+++ b/mace/cli/eval_configs.py
@@ -19,7 +19,7 @@ from mace.calculators.mace import get_model_dtype
 from mace.cli.convert_e3nn_cueq import run as run_e3nn_to_cueq
 from mace.data import KeySpecification, update_keyspec_from_kwargs
 from mace.modules.utils import extract_invariant
-from mace.tools import torch_geometric, torch_tools, utils
+from mace.tools import deprecation, torch_geometric, torch_tools, utils
 from mace.tools.default_keys import DefaultKeys
 
 
@@ -125,7 +125,9 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    deprecation.warn_args("cli.eval_configs", parser)
+    return args
 
 
 def get_model_output(

--- a/mace/cli/fine_tuning_select.py
+++ b/mace/cli/fine_tuning_select.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from mace.calculators import MACECalculator, mace_mp
 from mace.calculators.foundations_models import mace_mp_names
+from mace.tools import deprecation
 
 try:
     import fpsample  # type: ignore
@@ -560,6 +561,7 @@ def select_samples(
 
 
 def main() -> None:
+    deprecation.warn("ep.mace_finetuning_select")
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)-8s %(message)s",

--- a/mace/cli/plot_train.py
+++ b/mace/cli/plot_train.py
@@ -8,6 +8,8 @@ import os
 import re
 from typing import List
 
+from mace.tools import deprecation
+
 # matplotlib/pandas are not mace-torch dependencies: guard the import so the
 # console entry point resolves (and --help works) in a clean install, and
 # main() can explain what to install instead of crashing with ImportError.
@@ -127,7 +129,9 @@ def parse_args() -> argparse.Namespace:
         required=False,
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    deprecation.warn_args("cli.plot_train", parser)
+    return args
 
 
 def _aggregate(data, keys: List[str]):

--- a/mace/cli/polar_density_cube.py
+++ b/mace/cli/polar_density_cube.py
@@ -22,6 +22,7 @@ import torch
 from ase.io.cube import write_cube
 
 from mace.calculators.foundations_models import mace_polar
+from mace.tools import deprecation
 
 try:
     from graph_longrange.features import (
@@ -582,7 +583,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="optional JSON path for cube quality metrics",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    deprecation.warn_args("cli.polar_density_cube", parser)
+    return args
 
 
 def run(args: argparse.Namespace) -> list[Path]:

--- a/mace/cli/preprocess_data.py
+++ b/mace/cli/preprocess_data.py
@@ -20,7 +20,7 @@ from mace import data, tools
 from mace.data import KeySpecification, update_keyspec_from_kwargs
 from mace.data.utils import save_configurations_as_HDF5
 from mace.modules import compute_statistics
-from mace.tools import torch_geometric
+from mace.tools import deprecation, torch_geometric
 from mace.tools.scripts_utils import get_atomic_energies, get_dataset_from_xyz
 from mace.tools.utils import AtomicNumberTable
 
@@ -135,7 +135,9 @@ def main() -> None:
     This script loads an xyz dataset and prepares
     new hdf5 file that is ready for training with on-the-fly dataloading
     """
-    args = tools.build_preprocess_arg_parser().parse_args()
+    parser = tools.build_preprocess_arg_parser()
+    args = parser.parse_args()
+    deprecation.warn_args("prep", parser)
     run(args)
 
 

--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -37,7 +37,7 @@ from mace.cli.convert_oeq_e3nn import run as run_oeq_to_e3nn
 from mace.cli.visualise_train import TrainingPlotter
 from mace.data import KeySpecification, update_keyspec_from_kwargs
 from mace.modules.lora import inject_LoRAs, merge_lora_weights
-from mace.tools import torch_geometric
+from mace.tools import deprecation, torch_geometric
 from mace.tools.distributed_tools import init_distributed, xpu_device_index
 from mace.tools.model_script_utils import configure_model
 from mace.tools.multihead_tools import (
@@ -82,8 +82,21 @@ def main() -> None:
     """
     This script runs the training/fine tuning for mace
     """
-    args = tools.build_default_arg_parser().parse_args()
+    parser = tools.build_default_arg_parser()
+    args = parser.parse_args()
+    _warn_about_v1_removals(parser, args)
     run(args)
+
+
+def _warn_about_v1_removals(parser, args) -> None:
+    """Say which of the options actually passed do not survive MACE v1.0."""
+    passed = deprecation.explicit_dests(parser)
+    deprecation.warn_args("train", parser)
+    if "model" in passed:
+        deprecation.warn_choice("choice", args.model)
+    for dest in ("interaction", "interaction_first"):
+        if dest in passed:
+            deprecation.warn_choice("reg", getattr(args, dest, None))
 
 
 def run(args) -> None:
@@ -1192,6 +1205,10 @@ def run(args) -> None:
                 torch.save(
                     model_to_save, Path(args.model_dir) / (args.name + "_stagetwo.model")
                 )
+                # Outside the try: under -W error this warning is an
+                # exception, and the handler below reports anything it catches
+                # as a compile failure, which would lose the artifact.
+                deprecation.warn("lammps.compiled_side_artifact")
                 try:
                     path_complied = Path(args.model_dir) / (
                         args.name + "_stagetwo_compiled.model"
@@ -1210,6 +1227,10 @@ def run(args) -> None:
                     )
             else:
                 torch.save(model_to_save, Path(args.model_dir) / (args.name + ".model"))
+                # Outside the try: under -W error this warning is an
+                # exception, and the handler below reports anything it catches
+                # as a compile failure, which would lose the artifact.
+                deprecation.warn("lammps.compiled_side_artifact")
                 try:
                     path_complied = Path(args.model_dir) / (
                         args.name + "_compiled.model"

--- a/mace/tools/cg.py
+++ b/mace/tools/cg.py
@@ -13,6 +13,8 @@ import numpy as np
 import torch
 from e3nn import o3
 
+from mace.tools.deprecation import warn_env
+
 try:
     import cuequivariance as cue
 
@@ -26,6 +28,8 @@ USE_CUEQ_CG = os.environ.get("MACE_USE_CUEQ_CG", "0").lower() in (
     "yes",
     "y",
 )
+
+warn_env("MACE_USE_CUEQ_CG")
 
 _TP = collections.namedtuple("_TP", "op, args")
 _INPUT = collections.namedtuple("_INPUT", "tensor, start, stop")

--- a/mace/tools/deprecation.py
+++ b/mace/tools/deprecation.py
@@ -1,0 +1,300 @@
+"""Advance notice for the surfaces MACE v1.0 removes or replaces.
+
+MACE v1.0 is a rewrite. Its feature inventory carries a KEEP / MERGE / DROP
+disposition for every enumerable surface of this package, and the non-KEEP rows
+of it are reproduced in :mod:`mace.tools.deprecation_table`. This module turns
+those rows into warnings, so that a 0.3.x user hears about a removal from the
+release that still has the feature rather than from the one that dropped it.
+
+Two things about the wording are deliberate.
+
+**No message names a v1 command.** The last 0.3.x release predates the v1 CLI,
+so telling a reader to "use ``mace train``" would point at a binary they cannot
+run. A message says what replaces the feature in kind, and leaves the new
+spelling to the v1.0 migration guide.
+
+**A warning fires only for something the caller chose.** A flag is warned about
+when it appears in ``argv``, not when it merely has a default; a command is
+warned about when it is run. Some rows have no such moment, and
+:data:`NEVER_WARNED` below says which and why. Those rows stay in the table and
+are printed by::
+
+    python -m mace.tools.deprecation
+
+which is the one place the whole disposition list is visible.
+
+Each warning goes out twice on purpose. :func:`warnings.warn` raises a
+``FutureWarning``, which is what ``-W error`` and library consumers can see and
+filter; ``logging.warning`` puts the same text in the run log, which is what a
+CLI user actually reads. Both are deduplicated per identifier per process, so a
+flag repeated across a resumed run does not repeat its warning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import warnings
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set
+
+from .deprecation_table import DISPOSITIONS, DROP, MERGE
+
+#: A named logger, deliberately not the root one. The module-level
+#: logging.warning() installs a StreamHandler on the root logger when root has
+#: no handlers yet, via basicConfig. These warnings fire while the CLI is still
+#: parsing, before setup_logger runs, so that handler would be installed at
+#: NOTSET and would then receive every record the run logs afterwards. The whole
+#: training log would be duplicated onto stderr. A named logger reaches the same
+#: reader through logging's lastResort handler without touching root.
+_log = logging.getLogger(__name__)
+
+#: The version that removes or replaces everything in the table.
+REMOVED_IN = "1.0"
+
+_GUIDE = "See the MACE v1.0 migration guide."
+
+#: Surfaces with no emission site, by decision rather than by oversight. MACE
+#: builds these itself on every ordinary run: a model class, an interaction
+#: block, a loss class, a symmetric-contraction helper, a data transform, a
+#: model or calculator output key, the foundation-model roster, and the
+#: unsafe-pickle escape hatch this package sets for itself. Warning on them
+#: would tell every user about a decision none of them made. What a user does
+#: choose is the option that selects them, and those options warn: --model,
+#: --interaction, --loss. tests/unit/test_deprecation.py holds this list to
+#: having no call site, so a warning added here has to be a deliberate change.
+NEVER_WARNED = frozenset(
+    {
+        "block",
+        "contraction",
+        "fm",
+        "loss",
+        "model",
+        "out",
+        "stdenv",
+        "transform",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Deprecation:
+    """One non-KEEP row of the v1 feature inventory."""
+
+    id: str
+    kind: str
+    what: str
+    why: str
+
+    def message(
+        self, context: Optional[str] = None, as_written: Optional[str] = None
+    ) -> str:
+        verb = "removes" if self.kind == DROP else "replaces"
+        where = f" ({context})" if context else ""
+        return (
+            f"MACE v{REMOVED_IN} {verb} {as_written or self.what}{where}: "
+            f"{self.why}. {_GUIDE}"
+        )
+
+
+DEPRECATIONS: Dict[str, Deprecation] = {
+    row[0]: Deprecation(*row) for row in DISPOSITIONS
+}
+
+_warned: Set[str] = set()
+
+
+def reset_warned() -> None:
+    """Forget what has already been warned about. For tests."""
+    _warned.clear()
+
+
+def warn(
+    dep_id: str,
+    context: Optional[str] = None,
+    as_written: Optional[str] = None,
+    stacklevel: int = 2,
+) -> bool:
+    """Warn once about ``dep_id``. Returns whether this call was the one to warn.
+
+    An unknown identifier is a programming error here rather than at import
+    time, because the emission sites are spread over the tree and a typo in one
+    of them must not be able to silence it.
+    """
+    try:
+        dep = DEPRECATIONS[dep_id]
+    except KeyError:
+        raise KeyError(
+            f"{dep_id!r} is not a row of the v1 disposition table; "
+            f"add it to mace/tools/deprecation_table.py or fix the call site"
+        ) from None
+    if dep_id in _warned:
+        return False
+    _warned.add(dep_id)
+    message = dep.message(context, as_written)
+    warnings.warn(message, FutureWarning, stacklevel=stacklevel + 1)
+    _log.warning(message)
+    return True
+
+
+def warn_env(*names: str) -> List[str]:
+    """Warn for each named environment variable that is actually set."""
+    fired = []
+    for name in names:
+        dep_id = f"env.{name}"
+        if os.environ.get(name) is not None and warn(dep_id, stacklevel=3):
+            fired.append(dep_id)
+    return fired
+
+
+def _option_dests(parser: argparse.ArgumentParser) -> Dict[str, str]:
+    """Map every option string of ``parser`` to the dest it writes."""
+    # argparse exposes no public accessor for this, and matching on the dest
+    # name alone would miss the aliases: --swa_lr and --stage_two_lr are one
+    # dest, and only one of the two spellings is deprecated.
+    mapping = {}
+    for action in parser._actions:  # pylint: disable=protected-access
+        for option in action.option_strings:
+            mapping[option] = action.dest
+    return mapping
+
+
+def _dests_from_config_file(parser: argparse.ArgumentParser) -> Dict[str, str]:
+    """The dests a config file or environment variable supplied, if any.
+
+    The training and preprocessing parsers are ``configargparse`` parsers with
+    ``is_config_file=True`` on ``--config``, so a YAML config sets values on
+    the namespace without putting anything in ``argv``. Reading ``argv`` alone
+    therefore misses every option supplied the way the README documents. This
+    asks configargparse where each setting came from, which is exact, rather
+    than guessing from values that differ from their default.
+
+    Returns an empty mapping under plain ``argparse``, where there is no config
+    file to read, and after a parse that recorded no provenance.
+    """
+    describe = getattr(parser, "get_source_to_settings_dict", None)
+    if describe is None:
+        return {}
+    try:
+        sources = describe().items()
+    except AttributeError:
+        # configargparse records provenance during parse_args and raises here
+        # if it has not run on this parser. A caller inspecting a parser it did
+        # not parse with should get "nothing from a config file", not a crash.
+        return {}
+    found: Dict[str, str] = {}
+    for source, settings in sources:
+        # command_line is handled from argv, where the spelling is visible;
+        # defaults are not something the caller chose.
+        if source == "command_line" or source.startswith("defaults"):
+            continue
+        for action, _value in settings.values():
+            if action is None or not action.option_strings:
+                continue
+            found.setdefault(action.dest, action.option_strings[0])
+    return found
+
+
+def explicit_options(
+    parser: argparse.ArgumentParser, argv: Optional[Sequence[str]] = None
+) -> Dict[str, str]:
+    """Map each dest the caller supplied to how it was spelled.
+
+    Defaults are not included: a flag nobody wrote is not a flag anybody chose,
+    and warning about it would fire on every run. The spelling matters because
+    deprecated aliases share a dest, and a message should quote the option the
+    reader actually used.
+
+    Both routes count. A flag on the command line is read from ``argv``, and one
+    supplied through ``--config`` is read from configargparse's own record of
+    where each setting came from.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    options = _option_dests(parser)
+    found: Dict[str, str] = {}
+    for token in argv:
+        if not token.startswith("-") or token in ("-", "--"):
+            continue
+        name = token.split("=", 1)[0]
+        dest = options.get(name)
+        if dest is None and name.startswith("--"):
+            # argparse accepts any unambiguous prefix of a long option.
+            matches = {d for opt, d in options.items() if opt.startswith(name)}
+            dest = matches.pop() if len(matches) == 1 else None
+        if dest is not None and dest not in found:
+            found[dest] = name
+    for dest, spelling in _dests_from_config_file(parser).items():
+        found.setdefault(dest, spelling)
+    return found
+
+
+def explicit_dests(
+    parser: argparse.ArgumentParser, argv: Optional[Sequence[str]] = None
+) -> List[str]:
+    """The dests the caller named on the command line, in the order given."""
+    return list(explicit_options(parser, argv))
+
+
+def warn_args(
+    prefix: str,
+    parser: argparse.ArgumentParser,
+    argv: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Warn for every deprecated option the caller passed to ``parser``.
+
+    ``prefix`` is the inventory namespace of the parser: ``"train"`` for the
+    training parser, ``"prep"`` for the preprocessing one, ``"cli.<module>"``
+    for a per-command parser.
+    """
+    fired = []
+    for dest, as_written in explicit_options(parser, argv).items():
+        dep_id = f"{prefix}.{dest}"
+        if dep_id in DEPRECATIONS and warn(dep_id, as_written=as_written, stacklevel=3):
+            fired.append(dep_id)
+    return fired
+
+
+def warn_choice(namespace: str, value: Optional[str]) -> Optional[str]:
+    """Warn for a deprecated value of a string-to-class choice.
+
+    ``--model ScaleShiftMACE`` and ``--interaction`` name a class through a
+    registry, so the deprecated thing is the value, not the option.
+    """
+    if value is None:
+        return None
+    dep_id = f"{namespace}.{value}"
+    if dep_id in DEPRECATIONS and warn(dep_id, stacklevel=3):
+        return dep_id
+    return None
+
+
+def rows(kind: Optional[str] = None) -> List[Deprecation]:
+    """The table, optionally narrowed to ``DROP`` or ``MERGE``, in file order."""
+    return [d for d in DEPRECATIONS.values() if kind is None or d.kind == kind]
+
+
+def report(stream=None) -> None:
+    """Print the whole disposition table, grouped by surface."""
+    out = stream if stream is not None else sys.stdout
+    groups: Dict[str, List[Deprecation]] = {}
+    for dep in DEPRECATIONS.values():
+        groups.setdefault(dep.id.split(".", 1)[0], []).append(dep)
+    dropped = len(rows(DROP))
+    print(
+        f"MACE v{REMOVED_IN} removes {dropped} surfaces and replaces "
+        f"{len(rows(MERGE))} more. {len(DEPRECATIONS)} rows.\n",
+        file=out,
+    )
+    for surface in sorted(groups):
+        print(f"[{surface}]", file=out)
+        for dep in groups[surface]:
+            print(f"  {dep.kind:5}  {dep.what}", file=out)
+            print(f"         {dep.why}.", file=out)
+        print(file=out)
+
+
+if __name__ == "__main__":
+    report()

--- a/mace/tools/deprecation_table.py
+++ b/mace/tools/deprecation_table.py
@@ -1,0 +1,1528 @@
+"""The MACE v1.0 disposition table: every surface v1 removes or replaces.
+
+Generated from the rewrite's feature inventory, which carries a KEEP / MERGE /
+DROP disposition and a reason for every enumerable surface of this package. Only
+the non-KEEP rows are reproduced here, because those are the ones a 0.3.x user has
+to hear about before the next major version takes them away.
+
+The inventory is tests/golden/feature_inventory.md, in this tree, and
+tests/unit/test_deprecation.py asserts the two agree row for row: same ids, same
+dispositions, in both directions. So a flag that gains a DROP row there and no
+row here fails the build rather than disappearing on a user without warning.
+Add the row in the same change, and keep the id, because the id is what makes
+the two comparable.
+
+Each row is (id, kind, what, why):
+
+* id    the inventory's stable identifier, namespaced by surface (train., cli.,
+        model., out.calc., ...). Emission sites cite it, and the ids are what
+        keeps this table checkable against the inventory it came from.
+* kind  DROP, the functionality goes; or MERGE, it survives under a more general
+        mechanism and only this spelling of it goes.
+* what  the option string, class or key as a user writes it.
+* why   what replaces it, or why it leaves.
+
+No entry names a v1 command. The last 0.3.x release predates the v1 CLI, so an
+imperative "use <new command>" would point at a binary the reader cannot run; the
+v1.0 migration guide is the signpost for the new spellings.
+"""
+
+from typing import Tuple
+
+DROP = "DROP"
+MERGE = "MERGE"
+
+#: (id, kind, what, why), one row per non-KEEP surface of the inventory.
+DISPOSITIONS: Tuple[Tuple[str, str, str, str], ...] = (
+    (
+        "ep.mace_finetuning_select",
+        MERGE,
+        "mace_finetuning_select",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command",
+    ),
+    (
+        "ep.mace_e3nn_cueq",
+        DROP,
+        "mace_e3nn_cueq",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "ep.mace_cueq_to_e3nn",
+        DROP,
+        "mace_cueq_to_e3nn",
+        "the reverse direction; v1 weights are canonical and backend dispatch is "
+        "automatic, so there is nothing left to convert between backends",
+    ),
+    (
+        "ep.mace_active_learning_md",
+        DROP,
+        "mace_active_learning_md",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. The committee variance it consumes stays in calculate; the release "
+        "notes document the recipe",
+    ),
+    (
+        "choice.BOTNet",
+        DROP,
+        "--model BOTNet",
+        "no BOTNet class exists anywhere in the tree; the choice reaches only a "
+        "deprecation raise. Use MACE instead",
+    ),
+    (
+        "choice.ScaleShiftBOTNet",
+        DROP,
+        "--model ScaleShiftBOTNet",
+        "no ScaleShiftBOTNet class exists anywhere in the tree; the choice reaches "
+        "only a deprecation raise. Use MACE instead",
+    ),
+    (
+        "choice.MACE",
+        MERGE,
+        "--model MACE",
+        "model composition is config-driven, not a class name",
+    ),
+    (
+        "choice.ScaleShiftMACE",
+        MERGE,
+        "--model ScaleShiftMACE",
+        "the default energy model becomes the default configuration; model "
+        "composition is config-driven, not a class name",
+    ),
+    (
+        "choice.PolarMACE",
+        MERGE,
+        "--model PolarMACE",
+        "selected by declaring the electrostatics observables; model composition is "
+        "config-driven, not a class name",
+    ),
+    (
+        "choice.MACELES",
+        MERGE,
+        "--model MACELES",
+        "selected by declaring the LES long-range term; model composition is "
+        "config-driven, not a class name",
+    ),
+    (
+        "choice.AtomicDipolesMACE",
+        MERGE,
+        "--model AtomicDipolesMACE",
+        "selected by declaring the dipole observable; model composition is "
+        "config-driven, not a class name",
+    ),
+    (
+        "choice.AtomicDielectricMACE",
+        MERGE,
+        "--model AtomicDielectricMACE",
+        "dipole + polarizability observables; model composition is config-driven, "
+        "not a class name",
+    ),
+    (
+        "choice.EnergyDipolesMACE",
+        MERGE,
+        "--model EnergyDipolesMACE",
+        "energy + dipole observables; model composition is config-driven, not a "
+        "class name",
+    ),
+    (
+        "choice.MagneticScaleShiftMACE",
+        MERGE,
+        "--model MagneticScaleShiftMACE",
+        "the only magnetic entry in the choices; model composition is "
+        "config-driven, not a class name",
+    ),
+    (
+        "train.config",
+        MERGE,
+        "--config",
+        "the v1 config system makes this first-class (TOML/YAML/JSON, always "
+        "available, resolved config saved as run metadata)",
+    ),
+    (
+        "train.log_dir",
+        MERGE,
+        "--log_dir",
+        "it becomes single work-dir layout convention",
+    ),
+    (
+        "train.model_dir",
+        MERGE,
+        "--model_dir",
+        "it becomes single work-dir layout convention",
+    ),
+    (
+        "train.checkpoints_dir",
+        MERGE,
+        "--checkpoints_dir",
+        "it becomes single work-dir layout convention",
+    ),
+    (
+        "train.results_dir",
+        MERGE,
+        "--results_dir",
+        "it becomes single work-dir layout convention",
+    ),
+    (
+        "train.downloads_dir",
+        MERGE,
+        "--downloads_dir",
+        "it becomes XDG cache-dir convention",
+    ),
+    (
+        "train.default_dtype",
+        MERGE,
+        "--default_dtype",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "train.plot_interaction_e",
+        DROP,
+        "--plot_interaction_e",
+        "niche diagnostic that drags model introspection into the plotting path",
+    ),
+    (
+        "train.model",
+        MERGE,
+        "--model",
+        "model composition is config-driven (BaseMACE + declared outputs), not a "
+        "class name",
+    ),
+    (
+        "train.use_last_readout_only",
+        MERGE,
+        "--use_last_readout_only",
+        "readout policy: once you declare which layers read out, reading only the "
+        "last one is configuration, not a boolean",
+    ),
+    (
+        "train.use_embedding_readout",
+        MERGE,
+        "--use_embedding_readout",
+        "readout policy: once you declare which layers read out, also reading the "
+        "embedding layer is configuration, not a boolean",
+    ),
+    (
+        "train.use_reduced_cg",
+        MERGE,
+        "--use_reduced_cg",
+        "a CG-representation choice the backend makes, not a modelling decision a "
+        "user can judge, and it changes numerics; convert_e3nn_hybrid.py defaults "
+        "it to True, so checkpoints carry it and the converter must read it rather "
+        "than assume",
+    ),
+    (
+        "train.use_so3",
+        DROP,
+        "--use_so3",
+        "a global parity-convention switch that doubles the irrep-handling surface "
+        "in exactly the layer v1 rewrites; no published model sets it",
+    ),
+    (
+        "train.return_electrostatic_potentials",
+        MERGE,
+        "--return_electrostatic_potentials",
+        "an observable declared in the output spec, not a model flag",
+    ),
+    (
+        "train.avg_num_neighbors",
+        MERGE,
+        "--avg_num_neighbors",
+        "it becomes dataset statistics recorded in the model metadata",
+    ),
+    (
+        "train.compute_avg_num_neighbors",
+        MERGE,
+        "--compute_avg_num_neighbors",
+        "it becomes dataset statistics recorded in the model metadata",
+    ),
+    (
+        "train.compute_stress",
+        MERGE,
+        "--compute_stress",
+        "the observable spec drives this: an observable that is declared is "
+        "computed, and one that is not is not",
+    ),
+    (
+        "train.compute_forces",
+        MERGE,
+        "--compute_forces",
+        "the observable spec drives this: an observable that is declared is "
+        "computed, and one that is not is not",
+    ),
+    (
+        "train.compute_polarizability",
+        MERGE,
+        "--compute_polarizability",
+        "the observable spec drives this: an observable that is declared is "
+        "computed, and one that is not is not",
+    ),
+    (
+        "train.compute_atomic_dipole",
+        MERGE,
+        "--compute_atomic_dipole",
+        "the observable spec drives this: an observable that is declared is "
+        "computed, and one that is not is not",
+    ),
+    (
+        "train.compute_magforces",
+        MERGE,
+        "--compute_magforces",
+        "the observable spec drives this: dE/dm is a declared derivative exactly "
+        "like forces and stress",
+    ),
+    (
+        "train.multi_processed_test",
+        MERGE,
+        "--multi_processed_test",
+        "the data layer infers sharding from the dataset; whether a test set is "
+        "split across files is not something the user should have to declare and "
+        "get wrong (today it is a bare if in run_train.py)",
+    ),
+    (
+        "train.atomic_numbers",
+        MERGE,
+        "--atomic_numbers",
+        "it becomes statistics / model metadata",
+    ),
+    (
+        "train.mean",
+        MERGE,
+        "--mean",
+        "it becomes statistics override",
+    ),
+    (
+        "train.std",
+        MERGE,
+        "--std",
+        "it becomes statistics override",
+    ),
+    (
+        "train.energy_key",
+        MERGE,
+        "--energy_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.forces_key",
+        MERGE,
+        "--forces_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.virials_key",
+        MERGE,
+        "--virials_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.stress_key",
+        MERGE,
+        "--stress_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.dipole_key",
+        MERGE,
+        "--dipole_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.polarizability_key",
+        MERGE,
+        "--polarizability_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.charges_key",
+        MERGE,
+        "--charges_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.head_key",
+        MERGE,
+        "--head_key",
+        "property-key convention of the observable spec",
+    ),
+    (
+        "train.force_mh_ft_lr",
+        DROP,
+        "--force_mh_ft_lr",
+        "replay-dependent defaults replace the override; the flag exists only to "
+        "defeat a heuristic v1 does not have",
+    ),
+    (
+        "train.loss",
+        MERGE,
+        "--loss",
+        "the 11 named schemes become loss-composition presets over the 10 loss "
+        "classes of",
+    ),
+    (
+        "train.swa_energy_weight",
+        MERGE,
+        "--swa_energy_weight / --stage_two_energy_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_forces_weight",
+        MERGE,
+        "--swa_forces_weight / --stage_two_forces_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_virials_weight",
+        MERGE,
+        "--swa_virials_weight / --stage_two_virials_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_stress_weight",
+        MERGE,
+        "--swa_stress_weight / --stage_two_stress_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_dipole_weight",
+        MERGE,
+        "--swa_dipole_weight / --stage_two_dipole_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_polarizability_weight",
+        MERGE,
+        "--swa_polarizability_weight / --stage_two_polarizability_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.swa_magforces_weight",
+        MERGE,
+        "--swa_magforces_weight / --stage_two_magforces_weight",
+        "per-stage schedules; arbitrary stages replace the two-stage special case, "
+        "and the swa spelling dies with the namespace",
+    ),
+    (
+        "train.lr_params_factors",
+        MERGE,
+        "--lr_params_factors",
+        "typed per-param-group fields of the per-stage optimizer config; the "
+        "capability stays (--freeze reuses it by zeroing factors), the hand-parsed "
+        "JSON-in-a-string dies",
+    ),
+    (
+        "train.swa",
+        MERGE,
+        "--swa / --stage_two",
+        "stage two becomes a preset second stage of an arbitrary-stage schedule",
+    ),
+    (
+        "train.start_swa",
+        MERGE,
+        "--start_swa / --start_stage_two",
+        "stage two becomes a preset second stage of an arbitrary-stage schedule",
+    ),
+    (
+        "train.swa_lr",
+        MERGE,
+        "--swa_lr / --stage_two_lr",
+        "stage two becomes a preset second stage of an arbitrary-stage schedule",
+    ),
+    (
+        "train.save_cpu",
+        DROP,
+        "--save_cpu",
+        "safetensors checkpoints are device-agnostic, so there is nothing to choose",
+    ),
+    (
+        "train.enable_cueq",
+        MERGE,
+        "--enable_cueq",
+        "it becomes backend dispatch config",
+    ),
+    (
+        "train.enable_oeq",
+        MERGE,
+        "--enable_oeq",
+        "it becomes backend dispatch config",
+    ),
+    (
+        "train.only_cueq",
+        MERGE,
+        "--only_cueq",
+        "'use cueq for every op, not just the ones that benefit' becomes a dispatch "
+        "policy, not a second boolean. Its own row precisely because a group-level "
+        "--enable_cueq/--only_cueq/--enable_oeq cell hides it; backend dispatch "
+        "config",
+    ),
+    (
+        "train.magmom_key",
+        MERGE,
+        "--magmom_key",
+        "property-key convention; the default REF_magmom extends the on-disk data "
+        "contract of",
+    ),
+    (
+        "train.magforces_key",
+        MERGE,
+        "--magforces_key",
+        "default REF_magforces; property-key convention; the default REF_magmom "
+        "extends the on-disk data contract of",
+    ),
+    (
+        "train.data_aug_magmom",
+        MERGE,
+        "--data_aug_magmom",
+        "a training-data transform (Random3DRotation), not a model flag",
+    ),
+    (
+        "train.data_aug_magmom_mode",
+        MERGE,
+        "--data_aug_magmom_mode",
+        "selects which spin symmetry the transform draws from (non-soc the full "
+        "O(3), soc the sign flip alone), so it travels with data_aug_magmom",
+    ),
+    (
+        "prep.config",
+        MERGE,
+        "--config",
+        "same mechanism and disposition as the training parser's config",
+    ),
+    (
+        "prep.train_file",
+        MERGE,
+        "--train_file",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.valid_file",
+        MERGE,
+        "--valid_file",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.test_file",
+        MERGE,
+        "--test_file",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.valid_fraction",
+        MERGE,
+        "--valid_fraction",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.work_dir",
+        MERGE,
+        "--work_dir",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.r_max",
+        MERGE,
+        "--r_max",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.config_type_weights",
+        MERGE,
+        "--config_type_weights",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.energy_key",
+        MERGE,
+        "--energy_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.forces_key",
+        MERGE,
+        "--forces_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.virials_key",
+        MERGE,
+        "--virials_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.stress_key",
+        MERGE,
+        "--stress_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.dipole_key",
+        MERGE,
+        "--dipole_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.polarizability_key",
+        MERGE,
+        "--polarizability_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.charges_key",
+        MERGE,
+        "--charges_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.head_key",
+        MERGE,
+        "--head_key",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.heads",
+        MERGE,
+        "--heads",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.atomic_numbers",
+        MERGE,
+        "--atomic_numbers",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.batch_size",
+        MERGE,
+        "--batch_size",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.scaling",
+        MERGE,
+        "--scaling",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.E0s",
+        MERGE,
+        "--E0s",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "prep.seed",
+        MERGE,
+        "--seed",
+        "the v1 config system declares this once for the whole run instead of "
+        "redeclaring it on the data-preparation command",
+    ),
+    (
+        "cli.eval_configs.default_dtype",
+        MERGE,
+        "--default_dtype",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "cli.eval_configs.compute_stress",
+        MERGE,
+        "--compute_stress",
+        "it becomes part of the observable spec: an observable that is declared is "
+        "computed",
+    ),
+    (
+        "cli.eval_configs.enable_cueq",
+        MERGE,
+        "--enable_cueq",
+        "it becomes backend dispatch config",
+    ),
+    (
+        "cli.eval_configs.magmom_key",
+        MERGE,
+        "--magmom_key",
+        "it becomes property-key convention",
+    ),
+    (
+        "cli.eval_configs.return_magforces",
+        MERGE,
+        "--return_magforces",
+        "observable spec (dE/dm declared like any other derivative)",
+    ),
+    (
+        "cli.fine_tuning_select.configs_pt",
+        MERGE,
+        "--configs_pt",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.configs_ft",
+        MERGE,
+        "--configs_ft",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.num_samples",
+        MERGE,
+        "--num_samples",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.subselect",
+        MERGE,
+        "--subselect",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.model",
+        MERGE,
+        "--model",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.output",
+        MERGE,
+        "--output",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.descriptors",
+        MERGE,
+        "--descriptors",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.device",
+        MERGE,
+        "--device",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.head_pt",
+        MERGE,
+        "--head_pt",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.head_ft",
+        MERGE,
+        "--head_ft",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.filtering_type",
+        MERGE,
+        "--filtering_type",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.weight_ft",
+        MERGE,
+        "--weight_ft",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.weight_pt",
+        MERGE,
+        "--weight_pt",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.filter_atomic_numbers_pt",
+        MERGE,
+        "--filter_atomic_numbers_pt",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.allow_random_padding",
+        MERGE,
+        "--disallow_random_padding",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.seed",
+        MERGE,
+        "--seed",
+        "absorbed into the integrated fine-tuning pipeline, driven by a fine-tuning "
+        "config rather than a separate selection command; selection stops being a "
+        "separate CLI over a separate model load",
+    ),
+    (
+        "cli.fine_tuning_select.default_dtype",
+        MERGE,
+        "--default_dtype",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "cli.fine_tuning_select.config",
+        MERGE,
+        "--config",
+        "it becomes the v1 config system",
+    ),
+    (
+        "cli.plot_train.start_swa",
+        MERGE,
+        "--start_stage_two / --start_swa",
+        "stage boundaries are read from the run's per-stage schedule metadata; once "
+        "stages are arbitrary a single 'stage two' marker no longer applies. "
+        "Carries both --start_stage_two and the legacy --start_swa spelling",
+    ),
+    (
+        "cli.active_learning_md.config",
+        DROP,
+        "--config",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.config_index",
+        DROP,
+        "--config_index",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.error_threshold",
+        DROP,
+        "--error_threshold",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.temperature_K",
+        DROP,
+        "--temperature_K",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.friction",
+        DROP,
+        "--friction",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.timestep",
+        DROP,
+        "--timestep",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.nsteps",
+        DROP,
+        "--nsteps",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.nprint",
+        DROP,
+        "--nprint",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.nsave",
+        DROP,
+        "--nsave",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.ncheckerror",
+        DROP,
+        "--ncheckerror",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.model",
+        DROP,
+        "--model",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.output",
+        DROP,
+        "--output",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.device",
+        DROP,
+        "--device",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.default_dtype",
+        DROP,
+        "--default_dtype",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.compute_stress",
+        DROP,
+        "--compute_stress",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.active_learning_md.info_prefix",
+        DROP,
+        "--info_prefix",
+        "out of v1.0 scope: an ASE MD loop a user writes in ~30 lines over the "
+        "calculator, at the cost of MACE owning thermostat, timestep and trajectory "
+        "I/O. What MACE must guarantee is the committee variance in calculate, "
+        "which stays",
+    ),
+    (
+        "cli.polar_density_cube.default_dtype",
+        MERGE,
+        "--default_dtype",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "cli.create_lammps_model.dtype",
+        MERGE,
+        "--dtype",
+        "it becomes PrecisionConfig of the export bundle",
+    ),
+    (
+        "cli.create_lammps_model.format",
+        MERGE,
+        "--format",
+        "v1 exports the MLIAP bundle only; the default TorchScript format is "
+        "dropped with jit.script, so the choice collapses to one and the flag with "
+        "it",
+    ),
+    (
+        "cli.convert_e3nn_cueq.input_model",
+        DROP,
+        "input_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (positional)",
+    ),
+    (
+        "cli.convert_e3nn_cueq.output_model",
+        DROP,
+        "--output_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_cueq.device",
+        DROP,
+        "--device",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_cueq.return_model",
+        DROP,
+        "--return_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (library flag: return the "
+        "converted model instead of writing it)",
+    ),
+    (
+        "cli.convert_cueq_e3nn.input_model",
+        DROP,
+        "input_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (positional)",
+    ),
+    (
+        "cli.convert_cueq_e3nn.output_model",
+        DROP,
+        "--output_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_cueq_e3nn.device",
+        DROP,
+        "--device",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_cueq_e3nn.return_model",
+        DROP,
+        "--return_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (library flag: return the "
+        "converted model instead of writing it)",
+    ),
+    (
+        "cli.convert_e3nn_oeq.input_model",
+        DROP,
+        "input_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (positional)",
+    ),
+    (
+        "cli.convert_e3nn_oeq.output_model",
+        DROP,
+        "--output_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_oeq.device",
+        DROP,
+        "--device",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_oeq.return_model",
+        DROP,
+        "--return_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (library flag: return the "
+        "converted model instead of writing it)",
+    ),
+    (
+        "cli.convert_oeq_e3nn.input_model",
+        DROP,
+        "input_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (positional)",
+    ),
+    (
+        "cli.convert_oeq_e3nn.output_model",
+        DROP,
+        "--output_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_oeq_e3nn.device",
+        DROP,
+        "--device",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_oeq_e3nn.return_model",
+        DROP,
+        "--return_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (library flag: return the "
+        "converted model instead of writing it)",
+    ),
+    (
+        "cli.convert_e3nn_hybrid.input_model",
+        DROP,
+        "input_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (positional)",
+    ),
+    (
+        "cli.convert_e3nn_hybrid.output_model",
+        DROP,
+        "--output_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_hybrid.device",
+        DROP,
+        "--device",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "cli.convert_e3nn_hybrid.return_model",
+        DROP,
+        "--return_model",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends (library flag: return the "
+        "converted model instead of writing it)",
+    ),
+    (
+        "model.MACE",
+        MERGE,
+        "MACE",
+        "BaseMACE + a declared energy output; the class as a class disappears",
+    ),
+    (
+        "model.ScaleShiftMACE",
+        MERGE,
+        "ScaleShiftMACE",
+        "the default energy model becomes the default configuration; BaseMACE + a "
+        "declared energy output; the class as a class disappears",
+    ),
+    (
+        "model.AtomicDipolesMACE",
+        MERGE,
+        "AtomicDipolesMACE",
+        "it becomes the dipole observable",
+    ),
+    (
+        "model.AtomicDielectricMACE",
+        MERGE,
+        "AtomicDielectricMACE",
+        "dipole + polarizability observables. Note this is the MACE-MDP foundation "
+        "architecture, so it needs a converter as well as a reimplementation",
+    ),
+    (
+        "model.EnergyDipolesMACE",
+        MERGE,
+        "EnergyDipolesMACE",
+        "it becomes energy + dipole observables",
+    ),
+    (
+        "reg.RealAgnosticAttResidualInteractionBlock",
+        DROP,
+        "RealAgnosticAttResidualInteractionBlock",
+        "unlike the Density blocks it appears in no finetuning_utils branch and no "
+        "converter, only in the registry and the parser choices: a research variant "
+        "with no published model, no test and no owner",
+    ),
+    (
+        "reg.LinearDipoleReadoutBlock",
+        MERGE,
+        "LinearDipoleReadoutBlock",
+        "an observable head declared in the output spec",
+    ),
+    (
+        "reg.NonLinearDipoleReadoutBlock",
+        MERGE,
+        "NonLinearDipoleReadoutBlock",
+        "an observable head declared in the output spec",
+    ),
+    (
+        "reg.rms_dipoles_scaling",
+        MERGE,
+        "rms_dipoles_scaling",
+        "it becomes observable normalization",
+    ),
+    (
+        "block.RealAgnosticInteractionBlock",
+        MERGE,
+        "RealAgnosticInteractionBlock",
+        "one of five interaction variants that collapse into a configured "
+        "convolution",
+    ),
+    (
+        "block.RealAgnosticDensityInteractionBlock",
+        MERGE,
+        "RealAgnosticDensityInteractionBlock",
+        "one of five interaction variants that collapse into a configured "
+        "convolution",
+    ),
+    (
+        "block.RealAgnosticDensityResidualInteractionBlock",
+        MERGE,
+        "RealAgnosticDensityResidualInteractionBlock",
+        "one of five interaction variants that collapse into a configured "
+        "convolution",
+    ),
+    (
+        "block.RealAgnosticAttResidualInteractionBlock",
+        MERGE,
+        "RealAgnosticAttResidualInteractionBlock",
+        "one of five interaction variants that collapse into a configured "
+        "convolution",
+    ),
+    (
+        "block.MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
+        MERGE,
+        "MagneticRealAgnosticResidueSpinOrbitCoupledDensityInteractionBlock",
+        "the residual spin-orbit-coupled variant collapses into a configured "
+        "convolution like the other interaction blocks",
+    ),
+    (
+        "contraction.EmptyParam",
+        MERGE,
+        "EmptyParam",
+        "weight bookkeeping for an unreachable order, not a feature",
+    ),
+    (
+        "transform.Random3DRotation",
+        MERGE,
+        "Random3DRotation",
+        "the --data_aug_magmom transform, which travels with the flag",
+    ),
+    (
+        "calc.class.MACELammpsConfig",
+        MERGE,
+        "MACELammpsConfig",
+        "the ML-IAP wrapper's own config object, an implementation detail",
+    ),
+    (
+        "loss.WeightedEnergyForcesLoss",
+        MERGE,
+        "WeightedEnergyForcesLoss",
+        "a composition preset (the ef/weighted schemes)",
+    ),
+    (
+        "loss.WeightedForcesLoss",
+        MERGE,
+        "WeightedForcesLoss",
+        "it becomes a composition preset (the forces_only scheme)",
+    ),
+    (
+        "loss.WeightedEnergyForcesStressLoss",
+        MERGE,
+        "WeightedEnergyForcesStressLoss",
+        "it becomes a composition preset (the stress scheme)",
+    ),
+    (
+        "loss.WeightedHuberEnergyForcesStressLoss",
+        MERGE,
+        "WeightedHuberEnergyForcesStressLoss",
+        "it becomes a composition preset (the huber scheme)",
+    ),
+    (
+        "loss.UniversalLoss",
+        MERGE,
+        "UniversalLoss",
+        "it becomes a composition preset (the universal scheme)",
+    ),
+    (
+        "loss.WeightedEnergyForcesVirialsLoss",
+        MERGE,
+        "WeightedEnergyForcesVirialsLoss",
+        "it becomes a composition preset (the virials scheme)",
+    ),
+    (
+        "loss.DipoleSingleLoss",
+        MERGE,
+        "DipoleSingleLoss",
+        "it becomes a composition preset (the dipole scheme)",
+    ),
+    (
+        "loss.DipolePolarLoss",
+        MERGE,
+        "DipolePolarLoss",
+        "a composition preset (the dipole_polar scheme)",
+    ),
+    (
+        "loss.WeightedEnergyForcesDipoleLoss",
+        MERGE,
+        "WeightedEnergyForcesDipoleLoss",
+        "a composition preset (the energy_forces_dipole scheme)",
+    ),
+    (
+        "loss.WeightedEnergyForcesL1L2Loss",
+        MERGE,
+        "WeightedEnergyForcesL1L2Loss",
+        "a composition preset (the l1l2energyforces scheme)",
+    ),
+    (
+        "calc.param.default_dtype",
+        MERGE,
+        "default_dtype",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "calc.param.model_type",
+        MERGE,
+        "model_type",
+        "auto-detected from model metadata; asking the user to name the model "
+        "family is asking them to get it wrong",
+    ),
+    (
+        "calc.param.enable_cueq",
+        MERGE,
+        "enable_cueq",
+        "it becomes backend dispatch config",
+    ),
+    (
+        "calc.param.enable_oeq",
+        MERGE,
+        "enable_oeq",
+        "it becomes backend dispatch config",
+    ),
+    (
+        "calc.param.model_path",
+        DROP,
+        "model_path",
+        "deprecated singular alias for model_paths; it warns and forwards, and "
+        "refuses when both are given",
+    ),
+    (
+        "calc.export.LAMMPS_MACE",
+        DROP,
+        "LAMMPS_MACE",
+        "the TorchScript wrapper dies with the TorchScript export format; the MLIAP "
+        "path replaces it",
+    ),
+    (
+        "calc.export.mace_anicc",
+        DROP,
+        "mace_anicc",
+        "a 2023 organic-chemistry model superseded by MACE-OFF, and the only loader "
+        "with a divergent signature (model_path instead of model): an API exception "
+        "for an obsolete artifact. Its tracked checkpoint "
+        "mace/calculators/foundations_models/ani500k_large_CC.model goes with it; "
+        'the release notes say "use MACE-OFF"',
+    ),
+    (
+        "out.model.displacement",
+        MERGE,
+        "displacement",
+        "the strain displacement is internal machinery of the derivative engine, "
+        "not a user-facing output; v1 does not return it",
+    ),
+    (
+        "out.model.charges_history",
+        MERGE,
+        "charges_history",
+        "the per-iteration trace of the fixed-point solve; a solver diagnostic, so "
+        "it belongs to the solver-dispatch layer rather than the model's outputs",
+    ),
+    (
+        "out.model.scf_steps",
+        MERGE,
+        "scf_steps",
+        "SCF solver diagnostics belong to the model-transform hook, not to the "
+        "model's output contract",
+    ),
+    (
+        "out.model.scf_energy_history",
+        MERGE,
+        "scf_energy_history",
+        "SCF solver diagnostics belong to the model-transform hook, not to the "
+        "model's output contract",
+    ),
+    (
+        "out.calc.LES_alphas",
+        MERGE,
+        "LES_alphas",
+        "the calculator renames the model's latent_alphas; v1 exposes one name for "
+        "one quantity, and a per-surface rename is exactly the kind of thing that "
+        "makes a key ungreppable",
+    ),
+    (
+        "out.calc.LES_kappas",
+        MERGE,
+        "LES_kappas",
+        "from latent_kappas; the calculator renames the model's latent_alphas; v1 "
+        "exposes one name for one quantity, and a per-surface rename is exactly the "
+        "kind of thing that makes a key ungreppable",
+    ),
+    (
+        "out.calc.MACE_magmoms",
+        MERGE,
+        "MACE_magmoms",
+        "the magnetic calculator's spelling of the magnetic-moment observable, also "
+        "written back into atoms.arrays; the calculator renames the model's "
+        "latent_alphas; v1 exposes one name for one quantity, and a per-surface "
+        "rename is exactly the kind of thing that makes a key ungreppable",
+    ),
+    (
+        "env.MACE_USE_CUEQ_CG",
+        DROP,
+        "MACE_USE_CUEQ_CG",
+        "the variable goes, not the capability: an environment variable that "
+        "silently changes model numerics is unreproducible and never lands in the "
+        "run metadata; it is what makes machine-to-machine differences "
+        "unexplainable. The CG source becomes a backend decision recorded in the "
+        "resolved config",
+    ),
+    (
+        "stdenv.TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD",
+        DROP,
+        "TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD",
+        "v1 checkpoints are neutral-format (safetensors + manifest), so nothing "
+        "needs the unsafe-pickle escape hatch; the legacy loader keeps it until the "
+        "converter is the only reader",
+    ),
+    (
+        "kwarg.default_dtype",
+        MERGE,
+        "default_dtype=",
+        "it becomes PrecisionConfig",
+    ),
+    (
+        "kwarg.model_path",
+        DROP,
+        "mace_anicc(model_path=…)",
+        "goes with mace_anicc itself; the signature exception is part of why",
+    ),
+    (
+        "lammps.torchscript_wrapper",
+        DROP,
+        "the LAMMPS_MACE TorchScript wrapper and the -lammps.pt artifact",
+        "v1 blocks are born without @compile_mode, so scripting can never apply to "
+        "them; the MLIAP bundle is the one supported artifact",
+    ),
+    (
+        "lammps.compiled_side_artifact",
+        DROP,
+        "the _compiled.model / _stagetwo_compiled.model side artifacts",
+        "a deliberate, recorded removal: v1 checkpoints are neutral-format only and "
+        "deployment artifacts come solely from the v1 export command",
+    ),
+    (
+        "pkg.vendored_torch_geometric",
+        DROP,
+        "the vendored mace.tools.torch_geometric copy",
+        "v1 collates without torch_geometric; the vendored copy is excluded from "
+        "lint and mypy today, which is the clearest sign it is not maintained code. "
+        "Complication: mace/data/augmentation.py imports the *real* package while "
+        "the rest of the tree imports the vendored one, and the [magnetic] extra "
+        "declares external torch-geometric, so both must go at once",
+    ),
+    (
+        "pkg.compile_utils",
+        MERGE,
+        "prepare / simplify_if_compile",
+        "v1 is compile-first, so the retrofit mechanism has nothing to retrofit",
+    ),
+    (
+        "pkg.public_import_surface",
+        DROP,
+        "the mace.* public import surface",
+        "a deliberate break: v1 defines a new public API, and the release notes "
+        "document the old to new equivalences rather than aliasing them",
+    ),
+    (
+        "pkg.anicc_checkpoint",
+        DROP,
+        "the bundled MACE-ANI-CC checkpoint",
+        "goes with mace_anicc; v1 fetches every artifact through the model registry "
+        "rather than bundling one",
+    ),
+    (
+        "pkg.lr_param_groups",
+        MERGE,
+        "the explicit optimizer parameter groups behind --lr_params_factors",
+        "typed per-param-group fields of the per-stage optimizer config",
+    ),
+    (
+        "pkg.augmentation",
+        MERGE,
+        "Random3DRotation",
+        "a registered training-data transform, not a model flag",
+    ),
+    (
+        "pkg.first_block_coercion",
+        DROP,
+        "the silent rewrite of an unsupported --interaction_first to RealAgnosticInteractionBlock",
+        "a config value the tool overwrites without a word is worse than a rejected "
+        "one: the run trains a different architecture than the user asked for and "
+        "nothing says so. v1 fails the combination in config validation",
+    ),
+    (
+        "fm.mace_anicc",
+        DROP,
+        "MACE-ANI-CC",
+        "superseded by MACE-OFF, and the only artifact bundled inside the wheel; "
+        'the release notes say "use MACE-OFF"',
+    ),
+    (
+        "ep.convert_e3nn_oeq",
+        DROP,
+        "the mace.cli.convert_e3nn_oeq command",
+        "v1 weights are canonical and backend dispatch is automatic, so there is "
+        "nothing left to convert between backends",
+    ),
+    (
+        "ep.convert_oeq_e3nn",
+        DROP,
+        "the mace.cli.convert_oeq_e3nn command",
+        "the reverse direction; v1 weights are canonical and backend dispatch is "
+        "automatic, so there is nothing left to convert between backends",
+    ),
+    (
+        "ep.convert_e3nn_hybrid",
+        DROP,
+        "the mace.cli.convert_e3nn_hybrid command",
+        "the mixed e3nn/cueq layout it produces has no counterpart once backend "
+        "dispatch is automatic and v1 weights are canonical",
+    ),
+)

--- a/mace/tools/model_script_utils.py
+++ b/mace/tools/model_script_utils.py
@@ -7,6 +7,7 @@ from e3nn import o3
 
 from mace import modules
 from mace.modules.wrapper_ops import CuEquivarianceConfig
+from mace.tools.deprecation import warn
 from mace.tools.finetuning_utils import load_foundations_elements, load_foundations_mdp
 from mace.tools.scripts_utils import extract_config_mace_model, resolve_m_max
 from mace.tools.torch_tools import dtype_dict
@@ -285,6 +286,11 @@ def _build_model(
             "RealAgnosticDensityInteractionBlock",
             "RealAgnosticResidualNonLinearInteractionBlock",
         ]:
+            warn(
+                "pkg.first_block_coercion",
+                context=f"--interaction_first {args.interaction_first} is being "
+                "replaced by RealAgnosticInteractionBlock for --model MACE",
+            )
             args.interaction_first = "RealAgnosticInteractionBlock"
         return modules.ScaleShiftMACE(
             **model_config,

--- a/tests/unit/test_deprecation.py
+++ b/tests/unit/test_deprecation.py
@@ -1,0 +1,516 @@
+"""The v1.0 deprecation table, and the guards that keep it honest.
+
+The table is advance notice: it says, from a release that still has the
+feature, which surfaces MACE v1.0 removes or replaces. Four things about it can
+rot silently, and each has a test here.
+
+* A row that has drifted from the inventory it came from. The inventory is in
+  this tree, at tests/golden/feature_inventory.md, so the table can be checked
+  against its source rather than trusted: same ids, same dispositions.
+* A message that names a v1 command. The last 0.3.x release predates the v1
+  CLI, so "use ``mace train``" points at a binary the reader cannot run.
+* An emission site citing an identifier the table does not have. The sites are
+  spread over the tree, so a typo in one of them silences that warning and
+  nothing else changes.
+* A row whose flag was renamed. The row still reads as coverage while the
+  warning can no longer fire, because the dest it keys on is gone.
+"""
+
+import argparse
+import ast
+import logging
+import re
+import warnings
+from pathlib import Path
+
+import pytest
+
+from mace.tools import deprecation
+from mace.tools.arg_parser import build_default_arg_parser, build_preprocess_arg_parser
+
+MACE_ROOT = Path(deprecation.__file__).resolve().parent.parent
+
+#: The rows that do not come from the rewrite's feature inventory. The inventory
+#: gives these three CLIs no entry-point row because nothing is registered to
+#: keep or drop, but python -m still reaches them.
+NOT_FROM_INVENTORY = {
+    "ep.convert_e3nn_oeq",
+    "ep.convert_oeq_e3nn",
+    "ep.convert_e3nn_hybrid",
+}
+
+#: The inventory the table is generated from, in this tree. Anchored on the
+#: package rather than the working directory, so the test does not depend on
+#: where pytest was invoked from.
+INVENTORY = MACE_ROOT.parent / "tests" / "golden" / "feature_inventory.md"
+
+
+@pytest.fixture(autouse=True)
+def _forget_warnings():
+    deprecation.reset_warned()
+    yield
+    deprecation.reset_warned()
+
+
+def test_the_table_is_well_formed():
+    assert deprecation.DEPRECATIONS, "the table is empty"
+    for dep_id, dep in deprecation.DEPRECATIONS.items():
+        assert dep.id == dep_id
+        assert dep.kind in (deprecation.DROP, deprecation.MERGE), dep_id
+        assert dep.what.strip(), dep_id
+        assert dep.why.strip(), dep_id
+        # A reason is prose that completes "MACE v1.0 removes X: ...", so it
+        # must not arrive already punctuated or still carrying markdown.
+        assert not dep.why.endswith("."), dep_id
+        assert "`" not in dep.why and "**" not in dep.why, dep_id
+
+
+def test_a_drop_removes_and_a_merge_replaces():
+    drops = deprecation.rows(deprecation.DROP)
+    merges = deprecation.rows(deprecation.MERGE)
+    assert drops and merges
+    for dep in drops:
+        assert "removes" in dep.message()
+    for dep in merges:
+        assert "replaces" in dep.message()
+
+
+def test_no_message_names_a_v1_command():
+    """The plan's rule: a 0.3.x warning may not point at the v1 CLI.
+
+    ``mace.cli.convert_e3nn_oeq`` is a module path and stays legal; ``mace
+    train`` is a command that will not exist until after the last 0.3.x
+    release, and naming it would send the reader to a binary they cannot run.
+    """
+    v1_command = re.compile(r"\bmace (train|eval|export|data|model|validate|fit)\b")
+    offenders = [
+        dep.id
+        for dep in deprecation.DEPRECATIONS.values()
+        if v1_command.search(dep.message())
+    ]
+    assert not offenders, f"these messages name a v1 command: {offenders}"
+
+
+def _inventory_dispositions():
+    """The non-KEEP rows of the inventory, as {id: DROP|MERGE}."""
+    text = INVENTORY.read_text(encoding="utf-8")
+    found = {}
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) != 5:
+            continue
+        row_id, _, _, disposition, _ = cells
+        kind = disposition.split("\u2014")[0].strip()
+        if kind in (deprecation.DROP, deprecation.MERGE):
+            found[row_id.strip("`")] = kind
+    return found
+
+
+def test_the_table_agrees_with_the_inventory_it_came_from():
+    """Same ids and same dispositions, both directions.
+
+    This is the test that makes the table trustworthy rather than merely
+    plausible. A flag added with a DROP row in the inventory and not added
+    here is a feature that will disappear without warning, which is the exact
+    failure the inventory exists to prevent; a disposition changed there and
+    not here makes the warning say the wrong thing.
+    """
+    inventory = _inventory_dispositions()
+    assert inventory, f"{INVENTORY} carries no DROP or MERGE rows"
+
+    table = {
+        dep_id: dep.kind
+        for dep_id, dep in deprecation.DEPRECATIONS.items()
+        if dep_id not in NOT_FROM_INVENTORY
+    }
+    missing = sorted(set(inventory) - set(table))
+    surplus = sorted(set(table) - set(inventory))
+    disagreeing = sorted(
+        f"{k}: inventory says {inventory[k]}, table says {table[k]}"
+        for k in set(inventory) & set(table)
+        if inventory[k] != table[k]
+    )
+    assert not missing, f"in the inventory and not in the table: {missing}"
+    assert not surplus, f"in the table and not in the inventory: {surplus}"
+    assert not disagreeing, f"dispositions disagree: {disagreeing}"
+
+
+def test_every_extra_row_is_a_declared_one():
+    """Only the three unregistered converter CLIs may be outside the inventory.
+
+    Without this, the exemption above could be widened to hide any drift.
+    """
+    entry_points = {
+        dep_id
+        for dep_id in deprecation.DEPRECATIONS
+        if dep_id.startswith("ep.") and not dep_id.startswith("ep.mace_")
+    }
+    assert entry_points == NOT_FROM_INVENTORY
+
+
+@pytest.mark.parametrize(
+    "prefix,parser",
+    [("train", build_default_arg_parser()), ("prep", build_preprocess_arg_parser())],
+)
+def test_every_flag_row_still_names_a_live_dest(prefix, parser):
+    """A renamed flag must break this test rather than stop warning quietly."""
+    dests = {action.dest for action in parser._actions}
+    rows = {
+        dep_id
+        for dep_id in deprecation.DEPRECATIONS
+        if dep_id.startswith(f"{prefix}.")
+    }
+    dead = {r for r in rows if r[len(prefix) + 1 :] not in dests}
+    assert not dead, f"{prefix} rows whose dest no longer exists: {sorted(dead)}"
+
+
+def test_every_emission_site_cites_a_row_that_exists():
+    """Scan the package for warn(...) calls and resolve every identifier.
+
+    This is the guard that a typo at a call site cannot pass: an unknown
+    identifier raises at the site, but only if the site is ever reached, and
+    most of these are on paths the unit suite does not run.
+    """
+    cited = set()
+    for path in MACE_ROOT.rglob("*.py"):
+        if "torch_geometric" in path.parts or path.name.startswith("deprecation"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "mace.tools.deprecation" not in text and "import deprecation" not in text:
+            continue
+        # warnings.warn is also spelled warn(...) in this tree, and its argument
+        # is prose. An identifier never contains whitespace.
+        cited.update(
+            arg
+            for arg in re.findall(r'\bwarn\(\s*"([^"]+)"', text)
+            if not re.search(r"\s", arg)
+        )
+        cited.update(f"env.{n}" for n in re.findall(r'\bwarn_env\(\s*"([^"]+)"', text))
+    assert cited, "found no emission sites at all, so this test proves nothing"
+    unknown = sorted(c for c in cited if c not in deprecation.DEPRECATIONS)
+    assert not unknown, f"emission sites cite rows that do not exist: {unknown}"
+
+
+def test_every_scanned_namespace_has_rows_to_find():
+    """A warn_args prefix that matches no row is a call that can never fire."""
+    prefixes = set()
+    for path in MACE_ROOT.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        prefixes.update(re.findall(r'warn_args\(\s*"([^"]+)"', text))
+        prefixes.update(re.findall(r'warn_choice\(\s*"([^"]+)"', text))
+    assert prefixes
+    for prefix in sorted(prefixes):
+        assert any(
+            dep_id.startswith(f"{prefix}.") for dep_id in deprecation.DEPRECATIONS
+        ), f"warn_args/warn_choice({prefix!r}) can never match a row"
+
+
+def test_a_warning_fires_once_and_on_both_channels(caplog):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert deprecation.warn("train.save_cpu") is True
+        assert deprecation.warn("train.save_cpu") is False
+    assert len(caught) == 1
+    assert caught[0].category is FutureWarning
+    assert "--save_cpu" in str(caught[0].message)
+    assert sum("--save_cpu" in r.message for r in caplog.records) == 1
+
+
+def test_an_unknown_identifier_is_an_error_at_the_call_site():
+    with pytest.raises(KeyError, match="disposition table"):
+        deprecation.warn("train.no_such_flag")
+
+
+def test_only_the_options_actually_passed_are_reported():
+    parser = build_default_arg_parser()
+    passed = deprecation.explicit_options(parser, ["--name", "x", "--save_cpu"])
+    assert set(passed) == {"name", "save_cpu"}
+    # --default_dtype has a default and a deprecation row, and must not appear.
+    assert "default_dtype" not in passed
+
+
+def test_the_spelling_the_caller_wrote_is_the_one_quoted():
+    """Deprecated aliases share a dest, so the dest cannot name the option."""
+    parser = build_default_arg_parser()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        deprecation.warn_args("train", parser, ["--stage_two_lr", "1e-3"])
+    assert len(caught) == 1
+    message = str(caught[0].message)
+    assert "--stage_two_lr" in message
+    assert "--swa_lr" not in message
+
+
+def test_an_equals_form_and_an_unambiguous_abbreviation_both_resolve():
+    parser = build_default_arg_parser()
+    assert "save_cpu" in deprecation.explicit_options(parser, ["--save_cpu=1"])
+    assert "use_so3" in deprecation.explicit_options(parser, ["--use_so"])
+
+
+def test_a_deprecated_model_choice_warns_and_a_kept_one_does_not():
+    assert deprecation.warn_choice("choice", "BOTNet") == "choice.BOTNet"
+    assert deprecation.warn_choice("choice", "NoSuchModel") is None
+    assert deprecation.warn_choice("choice", None) is None
+
+
+def test_an_environment_variable_warns_only_when_it_is_set(monkeypatch):
+    monkeypatch.delenv("MACE_USE_CUEQ_CG", raising=False)
+    assert deprecation.warn_env("MACE_USE_CUEQ_CG") == []
+    monkeypatch.setenv("MACE_USE_CUEQ_CG", "1")
+    assert deprecation.warn_env("MACE_USE_CUEQ_CG") == ["env.MACE_USE_CUEQ_CG"]
+
+
+def test_the_report_covers_every_row():
+    import io
+
+    buffer = io.StringIO()
+    deprecation.report(buffer)
+    printed = buffer.getvalue()
+    assert str(len(deprecation.DEPRECATIONS)) in printed
+    for dep in deprecation.DEPRECATIONS.values():
+        assert dep.what in printed, dep.id
+
+
+def test_a_parser_with_no_deprecated_options_stays_quiet():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--something")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert deprecation.warn_args("train", parser, ["--something", "1"]) == []
+    assert not caught
+
+
+def test_the_silencing_recipe_in_the_readme_works():
+    """The README tells users one filter silences the lot. Hold it to that.
+
+    ``module="mace"`` is the filter people reach for first and it does not
+    work, because the warning is attributed to the caller that passed the
+    option, not to a module inside the package. The message prefix is what
+    every entry shares, so that is what the README documents.
+    """
+    parser = build_default_arg_parser()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.filterwarnings("ignore", message="MACE v1.0", category=FutureWarning)
+        deprecation.warn_args("train", parser, ["--save_cpu", "--use_so3"])
+    assert not caught
+
+    deprecation.reset_warned()
+    with warnings.catch_warnings(record=True) as still_caught:
+        warnings.simplefilter("always")
+        deprecation.warn_args("train", parser, ["--save_cpu"])
+    assert len(still_caught) == 1
+
+
+def test_every_message_carries_the_prefix_the_readme_promises():
+    for dep in deprecation.DEPRECATIONS.values():
+        assert dep.message().startswith("MACE v1.0 "), dep.id
+
+
+def test_the_never_warned_surfaces_really_have_no_call_site():
+    """The policy in deprecation.NEVER_WARNED, held to what the tree does.
+
+    These rows exist for the record and for the report; MACE constructs them
+    itself on every run, so a warning would fire for every user. The option
+    that selects them is what warns instead. A call site appearing here is
+    either a mistake or a decision that belongs in that docstring.
+    """
+    cited = set()
+    for path in MACE_ROOT.rglob("*.py"):
+        if "torch_geometric" in path.parts or path.name.startswith("deprecation"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "mace.tools.deprecation" not in text and "import deprecation" not in text:
+            continue
+        cited.update(
+            arg
+            for arg in re.findall(r'\bwarn\(\s*"([^"]+)"', text)
+            if not re.search(r"\s", arg)
+        )
+    offenders = sorted(c for c in cited if c.split(".", 1)[0] in deprecation.NEVER_WARNED)
+    assert not offenders, f"these are documented as never warned: {offenders}"
+
+
+def test_the_never_warned_surfaces_are_all_real_namespaces():
+    """A stale entry would make the test above vacuously true."""
+    namespaces = {dep_id.split(".", 1)[0] for dep_id in deprecation.DEPRECATIONS}
+    assert deprecation.NEVER_WARNED <= namespaces, (
+        f"stale entries: {sorted(deprecation.NEVER_WARNED - namespaces)}"
+    )
+
+
+def test_no_message_uses_a_dash_as_a_connector():
+    """House style: a dash never stands between two halves of a thought.
+
+    The inventory these rows come from writes that way freely, so the
+    generation step rewrites it and this holds the result.
+    """
+    offenders = [
+        dep.id
+        for dep in deprecation.DEPRECATIONS.values()
+        if "—" in dep.message() or "–" in dep.message()
+    ]
+    assert not offenders, f"these messages contain a dash connector: {offenders}"
+
+
+def test_warning_does_not_install_a_handler_on_the_root_logger():
+    """The module-level logging.warning() would, and that breaks every run.
+
+    ``logging.warning`` calls ``basicConfig`` when the root logger has no
+    handlers, installing a ``StreamHandler`` at ``NOTSET``. These warnings fire
+    while the CLI is still parsing, before ``setup_logger``, so that handler
+    would then receive every record the run logs afterwards and duplicate the
+    whole training log onto stderr. It cost a real failure in
+    ``tests/workflows/test_foundation_kwargs.py``, where a run's stderr
+    suddenly carried the parsed argument namespace.
+    """
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    for handler in saved:
+        root.removeHandler(handler)
+    try:
+        deprecation.warn("train.save_cpu")
+        assert not root.handlers, (
+            "warning installed a root handler; use a named logger, "
+            f"not logging.warning: {root.handlers}"
+        )
+    finally:
+        for handler in saved:
+            root.addHandler(handler)
+
+
+def test_the_message_still_reaches_the_log():
+    """The named logger must not have made the log half of it silent."""
+    logger = logging.getLogger("mace.tools.deprecation")
+    records = []
+
+    class Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = Capture()
+    logger.addHandler(handler)
+    try:
+        deprecation.warn("train.use_so3")
+    finally:
+        logger.removeHandler(handler)
+    assert any("--use_so3" in message for message in records), records
+
+
+def test_options_supplied_through_a_config_file_warn(tmp_path):
+    """A YAML config sets values without putting anything in argv.
+
+    The training and preprocessing parsers are configargparse parsers with
+    ``is_config_file=True`` on ``--config``, and the README documents the YAML
+    workflow, so reading argv alone would leave every config-file user with no
+    advance notice at all. This is the route most training runs actually use to
+    set ``--model``, ``--loss`` and the rest.
+    """
+    config = tmp_path / "run.yaml"
+    config.write_text(
+        "name: cfg\ntrain_file: fit.xyz\nsave_cpu: true\nuse_so3: true\n",
+        encoding="utf-8",
+    )
+    parser = build_default_arg_parser()
+    argv = ["--config", str(config)]
+    parser.parse_args(argv)
+
+    seen = deprecation.explicit_options(parser, argv)
+    assert {"save_cpu", "use_so3"} <= set(seen), seen
+
+    fired = deprecation.warn_args("train", parser, argv)
+    assert "train.save_cpu" in fired
+    assert "train.use_so3" in fired
+
+
+def test_a_config_file_default_is_not_reported_as_chosen(tmp_path):
+    """Only what the config actually sets, not everything it leaves alone."""
+    config = tmp_path / "run.yaml"
+    config.write_text("name: cfg\ntrain_file: fit.xyz\n", encoding="utf-8")
+    parser = build_default_arg_parser()
+    argv = ["--config", str(config)]
+    parser.parse_args(argv)
+
+    seen = deprecation.explicit_options(parser, argv)
+    assert "save_cpu" not in seen
+    assert "default_dtype" not in seen
+    assert deprecation.warn_args("train", parser, argv) == ["train.config"]
+
+
+def test_a_plain_argparse_parser_is_still_handled():
+    """explicit_options must not require configargparse to be in play."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save_cpu", action="store_true")
+    assert not hasattr(parser, "get_source_to_settings_dict")
+    assert deprecation.explicit_options(parser, ["--save_cpu"]) == {
+        "save_cpu": "--save_cpu"
+    }
+
+
+def test_inspecting_a_parser_that_was_never_parsed_does_not_raise():
+    """configargparse raises AttributeError until parse_args has run.
+
+    ``warn_args`` is called on parsers in several CLIs, and one of them
+    inspecting a parser it did not parse with must get "nothing from a config
+    file" rather than a crash inside argument handling.
+    """
+    parser = build_default_arg_parser()
+    with pytest.raises(AttributeError):
+        parser.get_source_to_settings_dict()
+    assert deprecation.explicit_options(parser, ["--save_cpu"]) == {
+        "save_cpu": "--save_cpu"
+    }
+
+
+def test_no_warning_sits_inside_a_try_that_swallows_exceptions():
+    """Under ``-W error`` these warnings are exceptions.
+
+    A call inside a ``try`` whose handler catches ``Exception`` turns the
+    warning into that handler's failure path. It happened once: the warning for
+    the compiled side artifact sat inside the ``try`` guarding
+    ``jit.compile``, so ``-W error`` reported a compile failure and the
+    artifact was never written. ``-W error`` is a documented way to surface
+    these, so it must not be able to corrupt a run.
+    """
+    helpers = {"warn", "warn_args", "warn_choice", "warn_env"}
+
+    def called_helpers(node):
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            func = inner.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name in helpers:
+                yield name, inner.lineno
+
+    def swallows_broadly(handlers):
+        for handler in handlers:
+            if handler.type is None:
+                return True
+            names = [
+                n.id for n in ast.walk(handler.type) if isinstance(n, ast.Name)
+            ]
+            if "Exception" in names or "BaseException" in names:
+                return True
+        return False
+
+    offenders = []
+    for path in MACE_ROOT.rglob("*.py"):
+        if "torch_geometric" in path.parts or path.name.startswith("deprecation"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "mace.tools.deprecation" not in text and "import deprecation" not in text:
+            continue
+        for node in ast.walk(ast.parse(text)):
+            if not isinstance(node, ast.Try) or not swallows_broadly(node.handlers):
+                continue
+            for statement in node.body:
+                for name, lineno in called_helpers(statement):
+                    rel = path.relative_to(MACE_ROOT.parent)
+                    offenders.append(f"{rel}:{lineno} calls {name}")
+    assert not offenders, (
+        "these deprecation warnings would become the handler's failure "
+        f"under -W error: {offenders}"
+    )


### PR DESCRIPTION
## What this does

MACE v1.0 is a rewrite, and it does not carry every surface of the 0.3.x line. Until now the only record of which ones was the rewrite's feature inventory, which lives on `mace-reforge`. A user of this line had no way to learn that a flag they depend on is going away, and would first hear about it from the release that had already dropped it.

`mace/tools/deprecation_table.py` holds the 208 non-KEEP rows of that inventory, 62 `DROP` and 149 `MERGE` once the three unregistered converter CLIs are included. `mace/tools/deprecation.py` turns each row into a `FutureWarning` plus the same text in the run log, deduplicated per identifier per process.

Nothing changes about what any of these options do in 0.3.x.

## Two constraints on the wording

**No message names a v1 command.** The last 0.3.x release ships before the v1 CLI exists, so "use `mace train`" would point at a binary the reader cannot run. 39 of the inventory reasons named one. They now name the replacement mechanism instead and leave the new spelling to the v1.0 migration guide (#1603). A test enforces this.

**A warning fires only for something the caller chose.** A flag warns when it appears in `argv`, not when it merely has a default. A command warns when it is run. Where a whole command goes away, its own warning fires once instead of one line per flag.

Of the 211 rows, 111 fire directly on use and 54 more are flags of a command whose own warning already covers them. The remaining 46 are the model, block, loss and registry classes and the model output keys: MACE constructs those itself on every ordinary run, so warning on them would tell every user about a decision none of them made. They are listed in `NEVER_WARNED`, the option that selects them warns instead, and the whole table is visible at once with:

    python -m mace.tools.deprecation

## One site gains a message it never had

For `--model MACE`, an `--interaction_first` outside the supported set was silently rewritten to `RealAgnosticInteractionBlock`. The run trained a different architecture than the one asked for and nothing said so. It now says so, and it is the only behavioural change in this PR.

## Silencing

Every message starts with `MACE v1.0`, so one filter covers all of them:

```python
warnings.filterwarnings("ignore", message="MACE v1.0", category=FutureWarning)
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive warnings and docs; the wide CLI/calculator touch surface and `-W error` treating warnings as exceptions are the main integration risks, with one explicit new warning on interaction_first coercion.
> 
> **Overview**
> Adds a **central v1.0 deprecation layer** so 0.3.x users get `FutureWarning`s (and matching log lines) when they use flags, commands, or APIs that v1 removes or folds into config-driven mechanisms—without changing 0.3.x behavior otherwise.
> 
> **`mace/tools/deprecation_table.py`** holds the inventory of DROP/MERGE surfaces; **`mace/tools/deprecation.py`** turns rows into deduplicated warnings, supports CLI/config-aware detection (`warn_args`, `warn_choice`, `warn_env`), and exposes `python -m mace.tools.deprecation` for the full list. The README documents the policy (warn only what you chose), silencing via `message="MACE v1.0"`, and migration-guide wording (no v1 CLI names).
> 
> **Call sites** are wired through training (`run_train`), preprocess/eval/plot/LAMMPS/polar CLIs, converter and active-learning entry points, calculators (`model_path`, `mace_anicc`, `LAMMPS_MACE`), `MACE_USE_CUEQ_CG`, and training-time LAMMPS compiled side artifacts (warnings moved **outside** compile `try` blocks so `-W error` does not masquerade as compile failure).
> 
> **Only functional change:** unsupported `--interaction_first` with `--model MACE` still coerces to `RealAgnosticInteractionBlock` but now emits **`pkg.first_block_coercion`** instead of rewriting silently.
> 
> **`tests/unit/test_deprecation.py`** locks table shape, inventory parity, emission-site IDs, config-file argv handling, and logging/warning safety guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae92832d12162d309213399c0ee29e2f36d79ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->