### PR TITLE
Keep AI tools out of the contributor list

### DIFF
--- a/.github/scripts/check_ai_attribution.py
+++ b/.github/scripts/check_ai_attribution.py
@@ -38,13 +38,17 @@ VENDOR_EMAIL = re.compile(
     re.IGNORECASE,
 )
 
-#: Bot accounts, which GitHub renders with a `[bot]` suffix.
+#: Bot accounts, which GitHub renders with a `[bot]` suffix. Anything is
+#: allowed between the vendor token and the suffix, because apps name
+#: themselves freely: `gemini-code-assist[bot]`, `copilot-swe-agent[bot]`.
+#: Being liberal here costs nothing, since `[bot]` is already proof that the
+#: identity is not a person.
 BOT_ACCOUNT = re.compile(
     r"\b(?:claude|copilot|chatgpt|codex|chatgpt-codex-connector|cursor|devin"
     r"|devin-ai-integration|gemini|jules|google-labs-jules|openhands|sweep"
     r"|codegen|cody|continue|augment|qodo|codiumai|coderabbitai|greptile"
     r"|ellipsis|korbit|sourcery|bito|tembo|factory-droid|charlie"
-    r"|blackboxai)(?:-ai)?\[bot\]",
+    r"|blackboxai)[\w-]*\[bot\]",
     re.IGNORECASE,
 )
 
@@ -67,7 +71,7 @@ ASSISTANT_PRODUCT = re.compile(
     r"|claude[\s_-]+\d"
     r"|gemini[\s_-]*(?:pro|flash)"
     r"|gemini[\s_-]+\d"
-    r"|gpt-?\d"
+    r"|gpt-?\d\w*"
     r"|o[1-4]-(?:mini|preview)"
     r"|devin[\s_-]*ai"
     r"|chatgpt|copilot|codex|codewhisperer|windsurf|openhands"

--- a/.github/scripts/check_ai_attribution.py
+++ b/.github/scripts/check_ai_attribution.py
@@ -50,13 +50,30 @@ BOT_ACCOUNT = re.compile(
 #: An assistant's product name. `Claude Dupont` is a person; `Claude Opus 4.7`,
 #: `Claude Code` and `GPT-4` are not. Requiring this form is what lets an
 #: identity naming a real human through without a vendor address.
+#:
+#: Both boundaries are anchored, or a token matches any longer word starting
+#: with it and the surname Devine reads as Devin. A version digit needs a
+#: separator in front of it for the same reason: `Claude 3` is a model,
+#: `claude3` is the start of somebody's email address.
 ASSISTANT_PRODUCT = re.compile(
-    r"\b(?:claude\s*(?:code|opus|sonnet|haiku|instant|\d)"
-    r"|gpt-?\d|o[1-4]-(?:mini|preview)|chatgpt|copilot|codex"
-    r"|gemini\s*(?:pro|flash|\d)|devin|cursor\s*agent|codewhisperer"
-    r"|amazon\s+q|windsurf|openhands|swe-?agent|replit\s+agent)",
+    r"\b(?:"
+    r"claude[\s_-]*(?:code|opus|sonnet|haiku|instant)"
+    r"|claude[\s_-]+\d"
+    r"|gemini[\s_-]*(?:pro|flash)"
+    r"|gemini[\s_-]+\d"
+    r"|gpt-?\d"
+    r"|o[1-4]-(?:mini|preview)"
+    r"|chatgpt|copilot|codex|devin|codewhisperer|windsurf|openhands"
+    r"|cursor[\s_-]*agent"
+    r"|swe-?agent"
+    r"|amazon\s+q"
+    r"|replit\s+agent"
+    r")\b",
     re.IGNORECASE,
 )
+
+#: `Name <email>`, so a product name can be matched against the name alone.
+_IDENTITY = re.compile(r"^(?P<name>.*?)\s*<[^>]*>$")
 
 #: The trailer GitHub reads to add a co-author. Attribution trailers that do
 #: not claim authorship are deliberately not listed: `Made-with:` discloses a
@@ -93,13 +110,23 @@ class Report:
         return not self.findings
 
 
+def display_name(identity: str) -> str:
+    """The name half of `Name <email>`, or all of it when there is no address."""
+    identity = identity.strip()
+    match = _IDENTITY.match(identity)
+    return match.group("name") if match else identity
+
+
 def assistant_reason(identity: str) -> str:
     """Why `identity` names an assistant rather than a person, or ""."""
     if VENDOR_EMAIL.search(identity):
         return "an AI vendor email address"
     if BOT_ACCOUNT.search(identity):
         return "an AI bot account"
-    if ASSISTANT_PRODUCT.search(identity):
+    # Against the display name only. An email's local part is not a name:
+    # reading `claude1@` as `Claude 1` would block the very people the vendor
+    # address and product name rules are shaped to leave alone.
+    if ASSISTANT_PRODUCT.search(display_name(identity)):
         return "an assistant's product name"
     return ""
 

--- a/.github/scripts/check_ai_attribution.py
+++ b/.github/scripts/check_ai_attribution.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Require that a commit's authors are people.
+
+Using an assistant is fine and needs no disclosure rules here. Claiming one as
+an author is the problem: GitHub builds the contributor list from the author
+and committer identities and from `Co-authored-by:` trailers, so any of the
+three can put an assistant on MACE's contributor list. A squash merge then
+copies the branch's trailers into the permanent history, where removing them
+means rewriting it. Two commits on develop carry nineteen such lines between
+them.
+
+Scope is authorship and nothing else. Disclosing a tool is left alone: a
+`Made-with: Cursor` trailer, a generated-with footer and any mention in the
+message body all pass, because none of them claims authorship.
+
+A contributor whose own name is Claude is unaffected. Only an AI vendor
+address, a bot account, or an assistant's product name counts, never a bare
+first name.
+
+Usage:
+    check_ai_attribution.py <base-ref> <head-ref>   # inspect a commit range
+    check_ai_attribution.py --stdin                 # read `git log` output
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+#: Vendor addresses. An email is the one unambiguous signal: nobody receives
+#: mail at anthropic.com by being called Claude.
+VENDOR_EMAIL = re.compile(
+    r"@(?:anthropic\.com|openai\.com|cursor\.(?:com|sh)|cognition(?:-?labs)?\.ai"
+    r"|codeium\.com|sourcegraph\.com|tabnine\.com|aider\.chat)\b",
+    re.IGNORECASE,
+)
+
+#: Bot accounts, which GitHub renders with a `[bot]` suffix.
+BOT_ACCOUNT = re.compile(
+    r"\b(?:claude|copilot|chatgpt|codex|chatgpt-codex-connector|cursor|devin"
+    r"|devin-ai-integration|gemini|jules|google-labs-jules|openhands|sweep"
+    r"|codegen|cody|continue|augment|qodo|codiumai|coderabbitai|greptile"
+    r"|ellipsis|korbit|sourcery|bito|tembo|factory-droid|charlie"
+    r"|blackboxai)(?:-ai)?\[bot\]",
+    re.IGNORECASE,
+)
+
+#: An assistant's product name. `Claude Dupont` is a person; `Claude Opus 4.7`,
+#: `Claude Code` and `GPT-4` are not. Requiring this form is what lets an
+#: identity naming a real human through without a vendor address.
+ASSISTANT_PRODUCT = re.compile(
+    r"\b(?:claude\s*(?:code|opus|sonnet|haiku|instant|\d)"
+    r"|gpt-?\d|o[1-4]-(?:mini|preview)|chatgpt|copilot|codex"
+    r"|gemini\s*(?:pro|flash|\d)|devin|cursor\s*agent|codewhisperer"
+    r"|amazon\s+q|windsurf|openhands|swe-?agent|replit\s+agent)",
+    re.IGNORECASE,
+)
+
+#: The trailer GitHub reads to add a co-author. Attribution trailers that do
+#: not claim authorship are deliberately not listed: `Made-with:` discloses a
+#: tool, and disclosure is allowed.
+COAUTHOR_TRAILERS = ("co-authored-by", "coauthored-by")
+
+_TRAILER = re.compile(r"^\s*([A-Za-z][A-Za-z0-9-]*)\s*:\s*(.+?)\s*$")
+
+
+@dataclass
+class Commit:
+    """A commit reduced to the fields that can carry authorship."""
+
+    sha: str
+    author: str = ""
+    committer: str = ""
+    message: str = ""
+
+
+@dataclass
+class Finding:
+    sha: str
+    where: str
+    text: str
+    why: str
+
+
+@dataclass
+class Report:
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+
+def assistant_reason(identity: str) -> str:
+    """Why `identity` names an assistant rather than a person, or ""."""
+    if VENDOR_EMAIL.search(identity):
+        return "an AI vendor email address"
+    if BOT_ACCOUNT.search(identity):
+        return "an AI bot account"
+    if ASSISTANT_PRODUCT.search(identity):
+        return "an assistant's product name"
+    return ""
+
+
+def inspect(commits: list[Commit]) -> Report:
+    """Findings for every commit that names an assistant as an author.
+
+    Pure: takes commit records, returns findings. The git plumbing lives in
+    `commits_in_range`, so the rules are testable without a repository.
+    """
+    report = Report()
+    for commit in commits:
+        for label, identity in (("author", commit.author),
+                                ("committer", commit.committer)):
+            why = assistant_reason(identity)
+            if why:
+                report.findings.append(
+                    Finding(commit.sha, label, identity, why))
+
+        for line in commit.message.splitlines():
+            match = _TRAILER.match(line)
+            if match is None or match.group(1).lower() not in COAUTHOR_TRAILERS:
+                continue
+            why = assistant_reason(match.group(2))
+            if why:
+                report.findings.append(
+                    Finding(commit.sha, f"{match.group(1)} trailer",
+                            match.group(2), why))
+    return report
+
+
+def commits_in_range(base: str, head: str) -> list[Commit]:
+    """The commits `head` adds to `base`, newest last."""
+    sep, rec = "\x1f", "\x1e"
+    out = subprocess.run(
+        ["git", "log", f"--format=%H{sep}%an <%ae>{sep}%cn <%ce>{sep}%B{rec}",
+         f"{base}..{head}"],
+        capture_output=True, text=True, check=True).stdout
+    return _parse(out)
+
+
+def _parse(raw: str) -> list[Commit]:
+    sep, rec = "\x1f", "\x1e"
+    commits = []
+    for chunk in raw.split(rec):
+        if not chunk.strip():
+            continue
+        sha, author, committer, message = chunk.lstrip("\n").split(sep, 3)
+        commits.append(Commit(sha, author, committer, message))
+    return commits
+
+
+def main(argv: list[str]) -> int:
+    if argv[:1] == ["--stdin"]:
+        commits = _parse(sys.stdin.read())
+    elif len(argv) == 2:
+        commits = commits_in_range(argv[0], argv[1])
+    else:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    report = inspect(commits)
+    if report.ok:
+        print(f"[ok] every author is a person in {len(commits)} commit(s)")
+        return 0
+
+    print(f"FAIL an assistant is named as an author in "
+          f"{len(report.findings)} place(s) across {len(commits)} commit(s):\n")
+    for f in report.findings:
+        print(f"  {f.sha[:12]}  {f.where}: {f.text}")
+        print(f"                {f.why}")
+    print(
+        "\nUse whatever tools you like. The authors have to be people.\n"
+        "Drop these lines and amend:\n"
+        "  git commit --amend              # for the tip commit\n"
+        "  git rebase -i <base>            # reword, further back\n"
+        "Claude Code stops adding the trailer with "
+        "`includeCoAuthoredBy: false`.\n"
+        "Saying a tool helped is fine: `Made-with:` and a generated-with "
+        "footer both pass."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/check_ai_attribution.py
+++ b/.github/scripts/check_ai_attribution.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 #: mail at anthropic.com by being called Claude.
 VENDOR_EMAIL = re.compile(
     r"@(?:anthropic\.com|openai\.com|cursor\.(?:com|sh)|cognition(?:-?labs)?\.ai"
+    r"|devin\.ai"
     r"|codeium\.com|sourcegraph\.com|tabnine\.com|aider\.chat)\b",
     re.IGNORECASE,
 )
@@ -55,6 +56,11 @@ BOT_ACCOUNT = re.compile(
 #: with it and the surname Devine reads as Devin. A version digit needs a
 #: separator in front of it for the same reason: `Claude 3` is a model,
 #: `claude3` is the start of somebody's email address.
+#:
+#: A token stands alone only when nobody is called it. `Copilot`, `Codex` and
+#: `CodeWhisperer` are safe on their own; `Claude`, `Gemini` and `Devin` are
+#: people's names, so each needs a product word, a version number or a vendor
+#: address before it counts. Apply that test to anything added here.
 ASSISTANT_PRODUCT = re.compile(
     r"\b(?:"
     r"claude[\s_-]*(?:code|opus|sonnet|haiku|instant)"
@@ -63,7 +69,8 @@ ASSISTANT_PRODUCT = re.compile(
     r"|gemini[\s_-]+\d"
     r"|gpt-?\d"
     r"|o[1-4]-(?:mini|preview)"
-    r"|chatgpt|copilot|codex|devin|codewhisperer|windsurf|openhands"
+    r"|devin[\s_-]*ai"
+    r"|chatgpt|copilot|codex|codewhisperer|windsurf|openhands"
     r"|cursor[\s_-]*agent"
     r"|swe-?agent"
     r"|amazon\s+q"

--- a/.github/workflows/ci-core.yaml
+++ b/.github/workflows/ci-core.yaml
@@ -33,6 +33,37 @@ jobs:
           pip-packages: wandb
       - run: pre-commit run --all-files --show-diff-on-failure
 
+  attribution:
+    # A commit's authors have to be people. GitHub builds the contributor list
+    # from the author, the committer and `Co-authored-by:`, so an assistant in
+    # any of the three lands on MACE's contributor list, and a squash merge
+    # copies the branch's trailers into the permanent history: two commits on
+    # develop carry nineteen such lines between them. Using a tool is fine and
+    # disclosing it is fine; only the authorship claim fails.
+    #
+    # Only the commits the PR adds are inspected, so what is already merged
+    # cannot fail an unrelated branch.
+    #
+    # `pull_request` only. On a push the offending commit is already in, and
+    # there is nothing the run could ask anyone to do about it.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Both sides of the range have to be present, and the default
+          # checkout is a depth-1 merge commit.
+          fetch-depth: 0
+      - name: Reject AI attribution in the commits this PR adds
+        # The SHAs go through the environment rather than into the script
+        # body: nothing from the event should be expanded into a shell.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Stdlib only, so the runner's interpreter is enough.
+        run: python3 .github/scripts/check_ai_attribution.py "$BASE_SHA" "$HEAD_SHA"
+
   cueq-wheel-extras:
     # The `cueq*` extras name wheels no PR job installs: the GPU pipeline pulls
     # cueq-cuda-13 and nothing anywhere touches cu11 or cu12. The only failure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,36 @@ change makes one fail, the first assumption is that the change is wrong.
 Regenerating a reference, or widening a tolerance, is a separate PR with a
 physics justification. It is never part of a feature.
 
+## Commit authorship
+
+Use whatever tools help you. The authors of a commit have to be people.
+
+GitHub builds the contributor list from three fields: the commit author, the
+committer, and any `Co-authored-by:` trailer. An assistant in any of them
+becomes a contributor to MACE, and a squash merge copies the branch's trailers
+into the permanent history, where removing them means rewriting it. The
+trailer is the one that catches people out, because a tool can add it while
+the author field stays correctly your own.
+
+Saying that a tool helped is fine and is not what this is about. A
+`Made-with:` trailer, a generated-with footer, a sentence in the message body:
+all allowed. The line is authorship, not disclosure.
+
+The `attribution` check enforces this on the commits your PR adds. To see what
+it sees:
+
+```bash
+python3 .github/scripts/check_ai_attribution.py origin/develop HEAD
+```
+
+If it catches something, drop the line and amend (`git commit --amend` for the
+tip, `git rebase -i` further back). Claude Code stops adding the trailer with
+`includeCoAuthoredBy: false`; other tools have an equivalent setting.
+
+A contributor whose own name is Claude is unaffected. The check keys on vendor
+addresses, bot accounts and product names such as `Claude Opus`, never on a
+bare first name.
+
 ## Where the rewrite's decisions live
 
 - **[The ticket board](https://github.com/orgs/ACEsuit/projects/2)** is the

--- a/tests/unit/test_ai_attribution.py
+++ b/tests/unit/test_ai_attribution.py
@@ -139,6 +139,11 @@ PEOPLE = [
     "Ann Codexis <ann@example.org>",
     "Joe Windsurfer <joe@example.org>",
     "Tom Copilots <tom@example.org>",
+    # Devin is a product and a common given name, so the bare token cannot
+    # stand on its own any more than Claude can.
+    "Devin Smith <devin@example.org>",
+    "Devin Booker <dbooker@example.org>",
+    "Devin <devin.smith@univ-lyon1.fr>",
 ]
 
 
@@ -198,3 +203,33 @@ def test_trailers_survive_crlf_and_indentation():
 def test_a_commit_with_no_body_passes():
     assert checker.inspect([_commit(message="Fix it")]).ok
     assert checker.inspect([_commit(message="")]).ok
+
+
+REJECTED_ASSISTANTS = [
+    # Devin still has to be caught, by a product form, a bot account or the
+    # vendor's own domain.
+    "Devin AI <x@gmail.com>",
+    "devin-ai <x@gmail.com>",
+    "devin-ai-integration[bot] <devin@example.com>",
+    "Devin <noreply@cognition.ai>",
+    "Devin <noreply@devin.ai>",
+]
+
+
+@pytest.mark.parametrize("identity", REJECTED_ASSISTANTS)
+def test_devin_is_still_caught_by_product_bot_or_domain(identity):
+    assert not checker.inspect([_commit(author=identity)]).ok, identity
+
+
+def test_a_bare_token_is_only_used_where_nobody_is_called_it():
+    """The rule the patterns follow, so an addition cannot quietly break it.
+
+    A name that people actually have needs a product word, a version number
+    or a vendor address. A name nobody has may stand alone.
+    """
+    for human_name in ("Claude", "Gemini", "Devin"):
+        identity = f"{human_name} Smith <smith@example.org>"
+        assert checker.inspect([_commit(author=identity)]).ok, human_name
+    for product_only in ("Copilot", "Codex", "CodeWhisperer", "ChatGPT"):
+        identity = f"{product_only} <bot@example.org>"
+        assert not checker.inspect([_commit(author=identity)]).ok, product_only

--- a/tests/unit/test_ai_attribution.py
+++ b/tests/unit/test_ai_attribution.py
@@ -122,15 +122,47 @@ def test_people_and_prose_are_accepted(line):
     assert report.ok, f"false positive on: {line} -> {report.findings}"
 
 
-@pytest.mark.parametrize(
-    "identity",
-    [
-        "Claude Dupont <claude.dupont@univ-lyon1.fr>",
-        "Claude <claude@univ-lyon1.fr>",
-    ],
-)
-def test_a_person_named_claude_can_author_a_commit(identity):
-    assert checker.inspect([_commit(author=identity)]).ok
+#: People the gate must leave alone. Every one of these was a real false
+#: positive on the first cut of the patterns, found in review of #1716.
+PEOPLE = [
+    "Claude Dupont <claude.dupont@univ-lyon1.fr>",
+    "Claude <claude@univ-lyon1.fr>",
+    # A digit right after the name is an email local part, not a model
+    # version. These read as "Claude 1" and "Gemini 1" without the separator.
+    "Claude <claude1@example.org>",
+    "Claude Bernard <claude2024@gmail.com>",
+    "Gemini Rossi <gemini1@example.org>",
+    # A token has to be a whole word, or every longer word starting with it
+    # matches. Devine is a real surname.
+    "Mary Devine <mdevine@example.org>",
+    "Raj Devinder <raj@example.org>",
+    "Ann Codexis <ann@example.org>",
+    "Joe Windsurfer <joe@example.org>",
+    "Tom Copilots <tom@example.org>",
+]
+
+
+@pytest.mark.parametrize("identity", PEOPLE)
+def test_a_person_can_author_a_commit(identity):
+    assert checker.inspect([_commit(author=identity)]).ok, identity
+
+
+@pytest.mark.parametrize("identity", PEOPLE)
+def test_a_person_can_be_credited_as_coauthor(identity):
+    report = checker.inspect([_commit(message=f"x\n\nCo-authored-by: {identity}\n")])
+    assert report.ok, f"{identity} -> {report.findings}"
+
+
+def test_a_product_name_is_read_from_the_name_not_the_address():
+    """The split is the fix for the email-local-part false positives.
+
+    An assistant is still caught when the address is innocent, which is what
+    stops the narrowing from becoming a hole.
+    """
+    assert checker.display_name("Claude Opus 5 <x@gmail.com>") == "Claude Opus 5"
+    assert checker.display_name("plain@example.org") == "plain@example.org"
+    assert not checker.inspect([_commit(author="Claude Opus 4.7 <someone@gmail.com>")]).ok
+    assert not checker.inspect([_commit(author="Claude 3.5 Sonnet <x@gmail.com>")]).ok
 
 
 def test_a_clean_commit_passes():

--- a/tests/unit/test_ai_attribution.py
+++ b/tests/unit/test_ai_attribution.py
@@ -1,0 +1,168 @@
+"""The authorship gate's rules, pinned against what the tools really emit.
+
+The policy is narrow on purpose: an assistant may be used, it may not be
+credited as an author. So the rejected cases are all authorship claims, and
+the accepted ones include every way of saying a tool helped.
+
+Samples marked "seen on this repo" are copied from real commits, so a regex
+edit that stops catching them fails here rather than on the next pull request.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "scripts"
+    / "check_ai_attribution.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_ai_attribution", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves annotations through sys.modules, so the module has
+    # to be registered before it executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load()
+
+HUMAN = "Ada Lovelace <ada@example.org>"
+
+
+def _commit(message="Do a thing", author=HUMAN, committer=None):
+    return checker.Commit(
+        sha="0" * 40,
+        author=author,
+        committer=committer if committer is not None else author,
+        message=message,
+    )
+
+
+REJECTED_COAUTHORS = [
+    # Claude Code's default trailer. Seen on this repo in #1244 and #1711, and
+    # on #1711 it is the *only* thing crediting an assistant: the author field
+    # there is already the contributor's own.
+    "Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>",
+    "Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>",
+    "Co-authored-by: Claude Code <noreply@anthropic.com>",
+    # Other assistants.
+    "Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>",
+    "Co-authored-by: Cursor Agent <cursoragent@cursor.com>",
+    "Co-authored-by: devin-ai-integration[bot] <devin@example.com>",
+    "Co-authored-by: claude[bot] <claude@example.com>",
+    "Co-authored-by: ChatGPT <noreply@openai.com>",
+]
+
+
+@pytest.mark.parametrize("line", REJECTED_COAUTHORS)
+def test_an_assistant_credited_as_coauthor_is_rejected(line):
+    report = checker.inspect([_commit(message=f"Add a block\n\n{line}\n")])
+    assert not report.ok, f"missed: {line}"
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "Claude <noreply@anthropic.com>",
+        "Claude Code <noreply@anthropic.com>",
+        "claude[bot] <bot@users.noreply.github.com>",
+        "Copilot <copilot@example.com>",
+    ],
+)
+def test_an_assistant_as_author_or_committer_is_rejected(identity):
+    assert not checker.inspect([_commit(author=identity)]).ok
+    assert not checker.inspect([_commit(author=HUMAN, committer=identity)]).ok
+
+
+ALLOWED_TOOL_DISCLOSURE = [
+    # Cursor's trailer, seen on this repo in #1391. It discloses a tool rather
+    # than claiming authorship, so it passes.
+    "Made-with: Cursor",
+    "Generated-by: Devin",
+    "Assisted-by: Gemini",
+    # Claude Code's footer.
+    "🤖 Generated with [Claude Code](https://claude.ai/code)",
+    "Generated with Claude Code",
+    # Saying so in prose is fine too.
+    "Wrote the first draft of this block with Claude, then rewrote the loop",
+    "Reviewed-by: Copilot",
+]
+
+
+@pytest.mark.parametrize("line", ALLOWED_TOOL_DISCLOSURE)
+def test_disclosing_a_tool_is_allowed(line):
+    report = checker.inspect([_commit(message=f"Add a block\n\n{line}\n")])
+    assert report.ok, f"tool disclosure must pass: {line} -> {report.findings}"
+
+
+ACCEPTED_PEOPLE = [
+    # A contributor whose given name is Claude. The gate keys on the vendor
+    # address or a product name, never on a bare first name.
+    "Co-authored-by: Claude Dupont <claude.dupont@univ-lyon1.fr>",
+    "Co-authored-by: Claude Bernard <cbernard@example.org>",
+    "Co-authored-by: Claude <claude@univ-lyon1.fr>",
+    "Co-authored-by: Ilyes Batatia <ilyes@example.org>",
+    # Prose that happens to contain the words.
+    "Move the cursor to the next atom in the readout loop",
+    "Fix: cursor position drifts when the basis is truncated",
+]
+
+
+@pytest.mark.parametrize("line", ACCEPTED_PEOPLE)
+def test_people_and_prose_are_accepted(line):
+    report = checker.inspect([_commit(message=f"Add a block\n\n{line}\n")])
+    assert report.ok, f"false positive on: {line} -> {report.findings}"
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "Claude Dupont <claude.dupont@univ-lyon1.fr>",
+        "Claude <claude@univ-lyon1.fr>",
+    ],
+)
+def test_a_person_named_claude_can_author_a_commit(identity):
+    assert checker.inspect([_commit(author=identity)]).ok
+
+
+def test_a_clean_commit_passes():
+    assert checker.inspect([_commit()]).ok
+
+
+def test_it_reports_every_offending_line_not_just_the_first():
+    message = (
+        "Add a block\n\n"
+        "Co-authored-by: Claude Opus 5 <noreply@anthropic.com>\n"
+        "Co-authored-by: Copilot <1+Copilot@users.noreply.github.com>\n"
+    )
+    assert len(checker.inspect([_commit(message=message)]).findings) == 2
+
+
+def test_findings_name_the_commit_and_the_reason():
+    report = checker.inspect(
+        [_commit(message="x\n\nCo-authored-by: Claude Code <noreply@anthropic.com>\n")]
+    )
+    finding = report.findings[0]
+    assert finding.sha == "0" * 40
+    assert "trailer" in finding.where
+    assert finding.why
+
+
+def test_trailers_survive_crlf_and_indentation():
+    crlf = "x\r\n\r\nCo-authored-by: Claude Opus 5 <noreply@anthropic.com>\r\n"
+    indented = "x\n\n  Co-authored-by: Claude Opus 5 <noreply@anthropic.com>\n"
+    assert not checker.inspect([_commit(message=crlf)]).ok
+    assert not checker.inspect([_commit(message=indented)]).ok
+
+
+def test_a_commit_with_no_body_passes():
+    assert checker.inspect([_commit(message="Fix it")]).ok
+    assert checker.inspect([_commit(message="")]).ok

--- a/tests/unit/test_ai_attribution.py
+++ b/tests/unit/test_ai_attribution.py
@@ -233,3 +233,48 @@ def test_a_bare_token_is_only_used_where_nobody_is_called_it():
     for product_only in ("Copilot", "Codex", "CodeWhisperer", "ChatGPT"):
         identity = f"{product_only} <bot@example.org>"
         assert not checker.inspect([_commit(author=identity)]).ok, product_only
+
+
+#: Real GitHub app identities. An app names itself freely, so the suffix
+#: between the vendor token and `[bot]` cannot be enumerated: reserving
+#: `gemini` for people let `gemini-code-assist[bot]` through until this list
+#: existed. Found in review of #1716.
+BOT_IDENTITIES = [
+    "gemini-code-assist[bot] <x@users.noreply.github.com>",
+    "claude[bot] <x@users.noreply.github.com>",
+    "claude-code[bot] <x@users.noreply.github.com>",
+    "copilot-swe-agent[bot] <x@users.noreply.github.com>",
+    "chatgpt-codex-connector[bot] <x@users.noreply.github.com>",
+    "devin-ai-integration[bot] <x@users.noreply.github.com>",
+    "cursor[bot] <x@users.noreply.github.com>",
+    "coderabbitai[bot] <x@users.noreply.github.com>",
+    "sourcery-ai[bot] <x@users.noreply.github.com>",
+    "google-labs-jules[bot] <x@users.noreply.github.com>",
+]
+
+
+@pytest.mark.parametrize("identity", BOT_IDENTITIES)
+def test_an_app_identity_is_caught_whatever_it_calls_itself(identity):
+    assert not checker.inspect([_commit(author=identity)]).ok, identity
+
+
+#: Model names, with an innocent address so the name is what has to carry it.
+#: `GPT-4o` ends in a letter, so a boundary straight after the version digit
+#: never arrives.
+MODEL_NAMES = [
+    "GPT-4o", "GPT-4o-mini", "GPT-4", "GPT-5", "GPT-4.1", "o3-mini",
+    "Claude 3.5 Sonnet", "Gemini 2.5 Pro", "Claude Opus 4.7", "Claude Code",
+]
+
+
+@pytest.mark.parametrize("name", MODEL_NAMES)
+def test_a_model_name_is_caught_on_an_innocent_address(name):
+    identity = f"{name} <someone@gmail.com>"
+    assert not checker.inspect([_commit(author=identity)]).ok, name
+
+
+def test_a_person_is_not_a_bot_just_because_a_bot_shares_their_name():
+    """The `[bot]` suffix is what makes the liberal bot matching safe."""
+    assert checker.inspect([_commit(author="Gemini Rossi <gemini@example.org>")]).ok
+    assert checker.inspect([_commit(author="Jules Verne <jverne@example.org>")]).ok
+    assert checker.inspect([_commit(author="Cody Banks <cbanks@example.org>")]).ok


### PR DESCRIPTION
## Why

Using an AI tool is fine. Listing it as an author is not.

GitHub builds the contributor list from three things: the commit author, the committer, and `Co-authored-by:`. An AI in any of them becomes a MACE contributor, and a squash merge writes it into the history for good.

## What fails

Only authorship: the author, the committer, and `Co-authored-by:`.

## What passes

Saying a tool helped, because that credits nobody. `Made-with: Cursor`, a generated-with footer, or any mention in the commit body.

Someone whose name really is Claude also passes. A finding needs a vendor email, a bot account, or a product name like `Claude Opus`.

## Notes

It reads only the commits a PR adds, so the old ones cannot fail someone else's branch.

Run it yourself:

```bash
python3 .github/scripts/check_ai_attribution.py origin/develop HEAD
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI policy, contributor docs, and unit tests; no runtime or application code paths are modified.
> 
> **Overview**
> Adds a **pull-request gate** so only people appear as commit authors, committers, or `Co-authored-by:` entries—preventing assistants from landing on GitHub’s contributor list after squash merges.
> 
> A new stdlib script **`.github/scripts/check_ai_attribution.py`** scans the commit range `base..head` and flags vendor emails, `[bot]` identities, and product-style names (e.g. `Claude Opus`, `GPT-4`) on author, committer, and co-author trailers. **`Made-with:`**, generated-with footers, and prose about tool use are intentionally ignored.
> 
> **`ci-core.yaml`** gains an **`attribution`** job (PR-only, full `fetch-depth`, SHAs via env) that runs the script on commits the PR adds. **`CONTRIBUTING.md`** documents the policy and local command. **`tests/unit/test_ai_attribution.py`** pins accept/reject cases, including real-repo samples and false-positive guards for human names like Claude or Devin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c9d05614edcb081c63b9fb59fe5205059b28dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->