### PR TITLE
[codex] Fix gated block TorchScript export

### DIFF
--- a/mace/modules/gate.py
+++ b/mace/modules/gate.py
@@ -52,6 +52,9 @@ class GatedEquivariantBlock(torch.nn.Module):
     the ``layout`` keyword.
     """
 
+    __constants__ = ["_has_act_scalar", "_has_act_gate"]
+    _gated_info: List[Tuple[int, int, int, int, int]]
+
     def __init__(
         self,
         irreps_scalars: o3.Irreps,
@@ -176,6 +179,15 @@ class GatedEquivariantBlock(torch.nn.Module):
             self._act_gate = act_gates[0]
             self._gate_cst = _normalize2mom_cst(act_gates[0])
 
+        self._has_act_scalar = self._act_scalar is not None
+        self._has_act_gate = self._act_gate is not None
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        # Full-module checkpoints predating TorchScript support lack these flags.
+        self._has_act_scalar = self._act_scalar is not None
+        self._has_act_gate = self._act_gate is not None
+
     @staticmethod
     def _compute_scalar_output_irreps(
         irreps_scalars: o3.Irreps, act_scalars: Sequence[Optional[Callable]]
@@ -202,23 +214,25 @@ class GatedEquivariantBlock(torch.nn.Module):
         return o3.Irreps(out)
 
     @property
+    @torch.jit.unused
     def irreps_in(self) -> o3.Irreps:
         return self._irreps_in
 
     @property
+    @torch.jit.unused
     def irreps_out(self) -> o3.Irreps:
         return self._irreps_out
 
     def forward(self, features: torch.Tensor) -> torch.Tensor:
         scalars = features.narrow(-1, self._s_start, self._s_len)
-        if self._act_scalar is not None:
+        if self._has_act_scalar:
             scalars = self._act_scalar(scalars) * self._scalar_cst
 
         if not self._gated_info:
             return scalars
 
         gates = features.narrow(-1, self._g_start, self._g_len)
-        if self._act_gate is not None:
+        if self._has_act_gate:
             gates = self._act_gate(gates) * self._gate_cst
 
         ir_mul = self._layout_is_ir_mul
@@ -227,17 +241,17 @@ class GatedEquivariantBlock(torch.nn.Module):
             gated_chunk = features.narrow(-1, gd_start, gd_len)
             gate_chunk = gates.narrow(-1, g_off, mul)
 
-            batch_shape = features.shape[:-1]
+            batch_shape = list(features.shape[:-1])
             if ir_mul:
                 # ir_mul: data is [c1_m1, c1_m2, ..., c2_m1, ...] → (ir_dim, mul)
-                gated_3d = gated_chunk.reshape(*batch_shape, ir_dim, mul)
+                gated_3d = gated_chunk.reshape(batch_shape + [ir_dim, mul])
                 gate_3d = gate_chunk.unsqueeze(-2)
-                result = (gated_3d * gate_3d).reshape(*batch_shape, ir_dim * mul)
+                result = (gated_3d * gate_3d).reshape(batch_shape + [ir_dim * mul])
             else:
                 # mul_ir: data is [m1_c1, m1_c2, ..., m2_c1, ...] → (mul, ir_dim)
-                gated_3d = gated_chunk.reshape(*batch_shape, mul, ir_dim)
+                gated_3d = gated_chunk.reshape(batch_shape + [mul, ir_dim])
                 gate_3d = gate_chunk.unsqueeze(-1)
-                result = (gated_3d * gate_3d).reshape(*batch_shape, mul * ir_dim)
+                result = (gated_3d * gate_3d).reshape(batch_shape + [mul * ir_dim])
             gated_parts.append(result)
 
         return torch.cat([scalars] + gated_parts, dim=-1)

--- a/tests/integrations/lammps/test_gate_export.py
+++ b/tests/integrations/lammps/test_gate_export.py
@@ -1,0 +1,71 @@
+"""Exercise the real LAMMPS export CLI with a small untrained nonlinear model."""
+
+import copy
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+
+with torch.serialization.safe_globals([slice]):
+    from e3nn import o3
+
+from mace import modules
+from mace.calculators import LAMMPS_MACE
+from mace.modules.gate import GatedEquivariantBlock
+from tests.integrations.lammps._harness import model_batch
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_lammps_cli_preserves_energy_forces_virial(tmp_path, legacy):
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(1713)
+        model = modules.ScaleShiftMACE(
+            r_max=3.0,
+            num_bessel=4,
+            num_polynomial_cutoff=5,
+            max_ell=2,
+            interaction_cls=modules.RealAgnosticResidualNonLinearInteractionBlock,
+            interaction_cls_first=modules.RealAgnosticInteractionBlock,
+            num_interactions=2,
+            num_elements=2,
+            hidden_irreps=o3.Irreps("8x0e + 8x1o"),
+            MLP_irreps=o3.Irreps("4x0e"),
+            gate=torch.nn.functional.silu,
+            atomic_energies=np.array([-1.0, -5.0]),
+            avg_num_neighbors=3.0,
+            atomic_numbers=[1, 6],
+            correlation=2,
+            atomic_inter_scale=1.0,
+            atomic_inter_shift=0.0,
+        ).double()
+    gates = [m for m in model.modules() if isinstance(m, GatedEquivariantBlock)]
+    assert gates, "The model must actually exercise the affected nonlinear gate"
+    reference = LAMMPS_MACE(copy.deepcopy(model))
+    atoms = Atoms(
+        numbers=[6, 1, 1], positions=[[0, 0, 0], [0.8, 0.3, 0], [-0.3, 0.9, 0.2]]
+    )
+    batch = model_batch(model, atoms)
+    mask = torch.ones(len(atoms), dtype=torch.float64)
+    expected = reference(copy.deepcopy(batch), mask, True)
+    if legacy:
+        for gate in gates:
+            del gate._has_act_scalar
+            del gate._has_act_gate
+    checkpoint = tmp_path / "tiny.model"
+    torch.save(model, checkpoint)
+    process = subprocess.run(
+        [sys.executable, "-m", "mace.cli.create_lammps_model", str(checkpoint)],
+        text=True,
+        capture_output=True,
+        timeout=90,
+    )
+    assert process.returncode == 0, process.stdout + process.stderr
+    exported = torch.jit.load(str(checkpoint) + "-lammps.pt")
+    actual = exported(copy.deepcopy(batch), mask, True)
+    for key in ("total_energy_local", "node_energy", "forces", "virials"):
+        assert expected[key] is not None and actual[key] is not None
+        assert torch.isfinite(actual[key]).all()
+        torch.testing.assert_close(actual[key], expected[key], rtol=1e-9, atol=1e-10)

--- a/tests/unit/test_gate_torchscript.py
+++ b/tests/unit/test_gate_torchscript.py
@@ -1,0 +1,67 @@
+"""Standalone #1713 reproduction; no foundation checkpoint or GPU required."""
+
+import io
+import math
+
+import pytest
+import torch
+
+from mace.modules.gate import GatedEquivariantBlock
+
+
+@pytest.mark.parametrize("layout", ["mul_ir", "ir_mul"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("batch_shape", [(), (3,), (2, 3)])
+@pytest.mark.parametrize("kind", ["gated", "scalars_only", "no_activation"])
+def test_gate_script_roundtrip_preserves_values_and_gradients(
+    layout, dtype, batch_shape, kind
+):
+    scalar_only = kind == "scalars_only"
+    active = kind != "no_activation"
+    gate = GatedEquivariantBlock(
+        "2x0e",
+        [torch.nn.functional.silu if active else None],
+        "" if scalar_only else "2x0e",
+        [] if scalar_only else [torch.sigmoid if active else None],
+        "" if scalar_only else "2x1o",
+        layout=layout,
+    ).to(dtype=dtype)
+    shape = batch_shape + (gate.irreps_in.dim,)
+    x = torch.linspace(-1.0, 1.0, math.prod(shape), dtype=dtype).reshape(shape)
+    x.requires_grad_(True)
+    expected = gate(x)
+    expected_grad = torch.autograd.grad(expected.square().sum(), x)[0]
+    assert torch.isfinite(expected).all()
+    assert torch.isfinite(expected_grad).all()
+
+    scripted = torch.jit.script(gate)
+    archive = io.BytesIO()
+    torch.jit.save(scripted, archive)
+    archive.seek(0)
+    restored = torch.jit.load(archive)
+    restored_x = x.detach().clone().requires_grad_(True)
+    actual = restored(restored_x)
+    actual_grad = torch.autograd.grad(actual.square().sum(), restored_x)[0]
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_grad, expected_grad)
+
+
+def test_legacy_gate_checkpoint_without_activation_flags():
+    gate = GatedEquivariantBlock(
+        "2x0e",
+        [torch.nn.functional.silu],
+        "2x0e",
+        [torch.sigmoid],
+        "2x1o",
+    )
+    x = torch.linspace(-1.0, 1.0, 10)
+    expected = gate(x)
+    # Simulate the actual attribute set of older full-module checkpoints.
+    del gate._has_act_scalar
+    del gate._has_act_gate
+    archive = io.BytesIO()
+    torch.save(gate, archive)
+    archive.seek(0)
+    restored = torch.load(archive, weights_only=False)
+    torch.testing.assert_close(restored(x), expected)
+    torch.testing.assert_close(torch.jit.script(restored)(x), expected)


### PR DESCRIPTION
## Summary

Addresses #1713: make `GatedEquivariantBlock` scriptable without changing its eager numerical operations or Python Irreps properties.

- Exclude Python-only Irreps properties from TorchScript.
- Use constant activation-presence flags, restoring them when loading older full-module checkpoints.
- Declare the gated-slice list type for empty/scalar-only cases and express dynamic reshape sizes as lists.
- Add component script/save/load value/gradient tests and a real `create_lammps_model` CLI regression using a deterministic tiny nonlinear ScaleShiftMACE model.

## Verification

Environment: Python3.12, PyTorch2.11.0+cpu, e3nn0.4.4. No foundation-model download or GPU required.

- Original gate: reproduces the reported `Unknown type name 'o3.Irreps'` error both directly and through the actual LAMMPS export CLI.
- 37 new component cases pass: both layouts, float32/float64, multiple batch ranks, scalar-only and absent activations, and simulated legacy checkpoint loading.
- 2 new CLI cases pass: current/legacy tiny model export, reload, and energy/node-energy/force/virial parity with the eager LAMMPS wrapper (rtol1e-9, atol1e-10).
- Packaged new tests: 39 passed. Existing gate tests: 94 passed, including e3nn first/second derivative parity and no-graph-break checks.
- Configured pre-commit hooks pass; Black/isort explicitly checked the new tests because repository hook exclusions omit tests. No reference numbers or existing tolerances were modified.

AI-assisted implementation and validation. The actual reporter's mh-1 fine-tuned artifact and Torch2.7.1/CUDA environment have not been tested. These are small-model export contract tests, not a LAMMPS binary trajectory or foundation-model accuracy certification. Existing dependency TorchScript deprecation warnings remain. No claim of human review is being made.
