### PR TITLE
Give the cuEquivariance fusion flag its deprecation row

### DIFF
--- a/mace/tools/deprecation_table.py
+++ b/mace/tools/deprecation_table.py
@@ -463,6 +463,15 @@ DISPOSITIONS: Tuple[Tuple[str, str, str, str], ...] = (
         "config",
     ),
     (
+        "train.cueq_conv_fusion",
+        MERGE,
+        "--cueq_conv_fusion",
+        "the fusion policy becomes part of backend dispatch config, chosen per op "
+        "rather than set by a flag. Note it is the one acceleration setting whose "
+        "0.3.x default differs between training (unfused) and inference (fused), so "
+        "a run that sets it explicitly is not asking for the default either way",
+    ),
+    (
         "train.magmom_key",
         MERGE,
         "--magmom_key",


### PR DESCRIPTION
Every `unit` job on `develop` has been failing since yesterday, along with `coverage`, and they all fail on the same test:

```
FAILED tests/unit/test_deprecation.py::test_the_table_agrees_with_the_inventory_it_came_from
AssertionError: in the inventory and not in the table: ['train.cueq_conv_fusion']
```

Two changes collided. #1702 gave `--cueq_conv_fusion` a MERGE row in `tests/golden/feature_inventory.md`. #1715 added `mace/tools/deprecation_table.py` together with the test that holds the table and the inventory to the same ids and the same dispositions. Neither pull request was ever red. #1715 had last run its checks the previous day, when the inventory row did not exist yet, and GitHub does not re-run a pull request when its base branch moves underneath it, so the first build that could see the combination was the push build on the merge commit.

This patch adds the missing entry, next to the `train.only_cueq` row it belongs with, and the flag now warns the way its siblings do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only change to the deprecation table; no runtime training or inference behavior is modified.
> 
> **Overview**
> Adds the missing **MERGE** deprecation row for `train.cueq_conv_fusion` / `--cueq_conv_fusion` in `mace/tools/deprecation_table.py`, placed next to the other cuEquivariance training flags (`train.only_cueq`).
> 
> This brings the v1 disposition table back in sync with `tests/golden/feature_inventory.md`, which fixes `test_the_table_agrees_with_the_inventory_it_came_from` and restores deprecation warnings for users who set the fusion flag explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 466f2898bcadab3f7b3e5e3e7b221a17dfe289e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->