### PR TITLE
Add typed model outputs and a declarative observable specification

### DIFF
--- a/docs/reforge/output_surface.md
+++ b/docs/reforge/output_surface.md
@@ -1,0 +1,66 @@
+# The user-observable output surface
+
+"v1 has the same functionality as develop" is a claim about the names a user
+can read out, not about the names one function happens to return. A key that
+reaches the user only through the ase calculator, or only through
+`mace_eval_configs`, is functionality just the same, and a completeness gate
+keyed on the model `forward` alone cannot see it.
+
+The surface is therefore the union of three layers.
+
+| layer | read from | owner | keys | new at this layer |
+|---|---|---|---|---|
+| (a) model forward | `mace/modules/models.py`, `mace/modules/extensions.py` | CORE-1 (#1555) | 43 | 43 |
+| (b) ase calculator `results` | `mace/calculators/mace.py` | DEP-1 (#1583) for the energy family, DEP-1a (#1634) for dipole / dielectric / polar / LES / magnetic | 31 | 15 |
+| (c) `mace_eval_configs` | `mace/cli/eval_configs.py` | CLI-1 (#1579) | 13 | 3 |
+| **union** | | | | **61** |
+
+61, not 43, is the number "the output surface survived the rewrite" is measured
+against.
+
+## Deriving it, rather than trusting this table
+
+Every number above is extracted from the frozen tree by
+`tests/golden/surface_scan.py`, the same mechanical scan run at three sites,
+and `tests/architecture/test_observable_completeness.py` re-derives all four
+and fails if this table disagrees. Each owning ticket runs the extraction over
+its own layer rather than copying a number from here: a hand-kept list that
+looks complete and silently is not is the defect this whole exercise exists to
+remove.
+
+Two traps the scan already accounts for, both of which shrink the surface
+quietly when missed:
+
+- Layer (a) must follow keys **assigned onto the returned object**, not only
+  dict literals. The self-consistent magnetic model assigns three diagnostics
+  after building its output, so an extraction that stops at return literals
+  stops at 40.
+- Layer (b)'s committee keys must be read off the code, not off
+  `implemented_properties`. The loop emits both a `_comm` and a `_var` suffix
+  for all four members of the ensemble store, while `implemented_properties`
+  advertises four of those eight: `forces_var`, `stress_comm` and
+  `dipole_comm` are produced and never declared.
+
+## What is new at each layer
+
+**(b) exists only at the calculator**, 15 names: `free_energy` and `energies`
+(the aliases and the E0-inclusive per-atom energy), `stresses` (the Voigt
+per-atom rename of the model's `atomic_stresses`), `LES_alphas`, `LES_kappas`,
+`bec` (the lower-cased mean of the model's `BEC`), `MACE_magmoms`, and the
+eight committee keys `{energy,forces,stress,dipole}_{comm,var}`.
+
+**(c) exists only at the evaluation CLI**, 3 names, and each is a *rename* of a
+model key, which is exactly why they are easy to lose: `BO_contributions` (model
+`contributions`), `descriptors` (model `node_feats`, after invariant extraction
+and layer truncation), `node_energies` (model `node_energy`). Only `energy`,
+`forces` and `stress` are shared with the calculator; the other ten names that
+layer writes reach the user through this CLI alone.
+
+## Layer (a), key by key
+
+CORE-1 owns layer (a) and classifies all 43 in
+`tests/architecture/observable_coverage.py`: each key becomes a declared
+`ObservableSpec`, a derivative of one under the `d_<q>_d_<x>` rule, or a row
+saying explicitly that it is not an observable and naming the mechanism that
+owns it instead. The test beside that file fails on a key with no row, so a key
+added to a legacy forward cannot pass unclassified.

--- a/docs/reforge/target_layout.md
+++ b/docs/reforge/target_layout.md
@@ -30,7 +30,8 @@ packages/mace-core/
 │   ├── __init__.py                     # re-exports public types/config/registries; does NOT import heavy submodules
 │   ├── _version.py                     # contract version (semver of the weights format/spec)
 │   │
-│   ├── types.py                        # MACEOutputs (typed dataclass, replaces the get_outputs dict); GRAPH_SCHEMA + GraphInfo/GraphView (rfc-03 flat-dict contract)
+│   ├── outputs.py                      # MACEOutput (typed dataclass generic over the tensor type, replaces the get_outputs dict)
+│   ├── types.py                        # GRAPH_SCHEMA + GraphInfo/GraphView (rfc-03 flat-dict contract)
 │   ├── graph.py                        # flat-dict contract {node_attrs,edge_index,positions,batch,cell,shifts,...} + shape/dtype validation
 │   │
 │   ├── config/
@@ -46,15 +47,14 @@ packages/mace-core/
 │   │   ├── number_table.py             # AtomicNumberTable (reimplemented; mirror of tools/utils.py, without dragging in train.py)
 │   │   └── default_keys.py             # DefaultKeys (reimplemented; mirror of tools/default_keys.py)
 │   │
-│   ├── observables/
-│   │   ├── __init__.py                 # OBSERVABLE_REGISTRY (declarative: name → spec)
-│   │   ├── base.py                     # Observable protocol: output irreps, how it's derived (readout | autograd | grad-strain)
-│   │   ├── energy.py                   # Energy, SiteEnergy (readout+scatter_sum)
-│   │   ├── forces.py                   # Forces (=-dE/dx via autograd) — spec only, the physics is executed by mace_torch/mace_jax
-│   │   ├── stress.py                   # Stress, Virials (grad w.r.t. strain; sign convention PINNED here)
-│   │   ├── dipole.py                   # Dipole, AtomicDipole
-│   │   ├── polarizability.py           # Polarizability (dielectric/polar)
-│   │   └── hessian.py                  # Hessian (second derivative)
+│   ├── observables/                    # a property is a row in a declarations file, not a module per property
+│   │   ├── __init__.py                 # the public surface of the package
+│   │   ├── spec.py                     # InputSpec, ObservableSpec, DerivativeSpec, ObservableCatalogue (pydantic)
+│   │   ├── grammar.py                  # the irreps string grammar: parse + validate + dimension (no algebra)
+│   │   ├── derivatives.py              # d_<q>_d_<x> naming, and the three special cases with their signs
+│   │   └── defaults.py                 # loader for a declarations file
+│   ├── defaults/
+│   │   └── observables.yaml            # energy + its position and cell derivatives: the row every observable copies
 │   │
 │   ├── kernels/
 │   │   ├── protocol.py                 # KernelBackend Protocol, generic over TensorT: make_* factories + capabilities (§3.1)
@@ -493,10 +493,10 @@ silently wrong forces); it stays usable for inference (`supports_double_backward
 
 ### 3.2 A new observable (config only)
 
-- **Extender touches:** a `mace_core/observables/myobs.py` file with an `Observable` (declares output irreps and derivation mode: `readout` | `autograd(energy, wrt=positions)` | `grad_strain`) + `@register_observable("myobs")`.
-- **Core touched:** zero existing files (only the new module is added). The model exposes it automatically because `BaseMACE` iterates over `config.observables`; `MACEOutputs` is a dataclass with optional fields populated by name.
-- **Enabling it:** `ModelConfig(observables=["energy","forces","myobs"])`.
-- **Test:** `mace_core/tests/test_observable_registry.py` validates irreps/derivation consistency (pure); if it is autograd-derived, `tests/parity` verifies finite-diff.
+- **Extender touches:** a declarations file: one `ObservableSpec` row giving `name`, `irreps`, `per_atom`, `units`, `normalization`, `default_loss_weight`, and the declared inputs to differentiate against. No module, no decorator. A derivative is named by the rule `d_<q>_d_<x>`, with `forces`, `stress` and `magforces` as the three special cases, so asking for a derivative against a newly declared input needs no code either.
+- **Core touched:** zero files. The model exposes the row automatically because `BaseMACE` iterates over the declared observables; `MACEOutput` carries the six core fields and everything else by name in `extras`.
+- **Enabling it:** list it in the model config's observables, or point the config at a declarations file that extends `defaults/observables.yaml`.
+- **Test:** `packages/mace-core/tests/test_observables.py` validates the grammar and the derivative naming (pure); if it is autograd-derived, `tests/parity` verifies finite-diff.
 
 ### 3.3 A new loss / transform (plugin registry)
 

--- a/packages/mace-core/pyproject.toml
+++ b/packages/mace-core/pyproject.toml
@@ -17,7 +17,11 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
-dependencies = []
+dependencies = [
+    "numpy>=1.23",
+    "pydantic>=2.7",
+    "pyyaml>=6.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/ACEsuit/mace"

--- a/packages/mace-core/src/mace_core/__init__.py
+++ b/packages/mace-core/src/mace_core/__init__.py
@@ -1,11 +1,30 @@
 """Framework-agnostic contract and pure math for MACE v1.
 
-Scaffold only. The public surface arrives with the tickets that build it.
+This package imports no framework. Everything here is expressed over plain
+Python, numpy and pydantic, so the same types carry ``torch.Tensor`` in
+``mace_torch`` and ``jax.Array`` in ``mace_jax``.
 """
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
+from mace_core.observables import (
+    DerivativeSpec,
+    InputSpec,
+    ObservableCatalogue,
+    ObservableSpec,
+    load_default_catalogue,
+)
+from mace_core.outputs import MACEOutput
+
+__all__ = [
+    "DerivativeSpec",
+    "InputSpec",
+    "MACEOutput",
+    "ObservableCatalogue",
+    "ObservableSpec",
+    "__version__",
+    "load_default_catalogue",
+]
 
 #: Version of the installed `mace-core` distribution. Read from installed metadata
 #: rather than hardcoded, so it cannot drift from what pip resolved.

--- a/packages/mace-core/src/mace_core/defaults/observables.yaml
+++ b/packages/mace-core/src/mace_core/defaults/observables.yaml
@@ -1,0 +1,49 @@
+# The canonical observable declarations: energy, and its derivatives with
+# respect to the two inputs every model has.
+#
+# This file is the example every other observable copies. A new property is a
+# row here (or in a project's own file) and needs no code: the spec drives the
+# head, the loss term, the derivative names and the per-atom/per-graph padding.
+#
+# Units follow the project convention: eV and Å. The strain is dimensionless,
+# so the cell input carries "1".
+
+inputs:
+  # Atomic positions. A polar vector: it changes sign under inversion, which is
+  # what makes the energy gradient taken against it a 1o quantity as well.
+  - name: pos
+    irreps: "1o"
+    per_atom: true
+    units: "Å"
+
+  # The symmetric strain the cell derivative is actually taken against, not the
+  # nine cell entries. A symmetric rank-2 tensor is a scalar plus an l=2 part.
+  - name: cell
+    irreps: "0e+2e"
+    per_atom: false
+    units: "1"
+
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    # The std of the target, the successor of the legacy `std_scaling` entry.
+    # The legacy default was `rms_forces_scaling`, which scales the energy
+    # readout by the RMS of the *force* targets; that couples two observables
+    # through one number and cannot be written as a per-observable field. Which
+    # of the two v1 defaults to is a decision for the head, not for this file.
+    normalization: "std"
+    default_loss_weight: 1.0
+    derivatives:
+      # Named `forces`, reported as -dE/dpos.
+      - wrt: pos
+        units: "eV/Å"
+        normalization: "rms"
+        default_loss_weight: 100.0
+      # Named `stress`, reported as +dE/dstrain, divided by the cell volume by
+      # whatever computes it. The division is not part of the sign.
+      - wrt: cell
+        units: "eV/Å^3"
+        normalization: "none"
+        default_loss_weight: 1.0

--- a/packages/mace-core/src/mace_core/observables/__init__.py
+++ b/packages/mace-core/src/mace_core/observables/__init__.py
@@ -1,0 +1,49 @@
+"""Declarative observables: what a model computes, declared rather than coded."""
+
+from mace_core.observables.defaults import (
+    DEFAULTS_RESOURCE,
+    load_catalogue,
+    load_default_catalogue,
+)
+from mace_core.observables.derivatives import (
+    SPECIAL_CASES,
+    derivative_name,
+    derivative_sign,
+)
+from mace_core.observables.grammar import (
+    IRREPS_GRAMMAR,
+    IrrepsGrammarError,
+    IrrepTerm,
+    irreps_dimension,
+    parse_irreps,
+)
+from mace_core.observables.spec import (
+    NORMALIZATIONS,
+    DerivativeRequest,
+    DerivativeSpec,
+    InputSpec,
+    Normalization,
+    ObservableCatalogue,
+    ObservableSpec,
+)
+
+__all__ = [
+    "DEFAULTS_RESOURCE",
+    "IRREPS_GRAMMAR",
+    "NORMALIZATIONS",
+    "SPECIAL_CASES",
+    "DerivativeRequest",
+    "DerivativeSpec",
+    "InputSpec",
+    "IrrepTerm",
+    "IrrepsGrammarError",
+    "Normalization",
+    "ObservableCatalogue",
+    "ObservableSpec",
+    "derivative_name",
+    "derivative_sign",
+    "irreps_dimension",
+    "load_catalogue",
+    "load_default_catalogue",
+    "parse_irreps",
+]

--- a/packages/mace-core/src/mace_core/observables/defaults.py
+++ b/packages/mace-core/src/mace_core/observables/defaults.py
@@ -1,0 +1,50 @@
+"""Loading a catalogue from a declarations file.
+
+The shipped file is packaged data rather than a Python literal, because the
+whole point of the declarative spec is that a property can be added without
+touching code -- including the code that holds the defaults.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mace_core.observables.spec import ObservableCatalogue
+
+__all__ = [
+    "DEFAULTS_RESOURCE",
+    "load_catalogue",
+    "load_default_catalogue",
+]
+
+#: Where the shipped declarations live, relative to the package root.
+DEFAULTS_RESOURCE = "defaults/observables.yaml"
+
+
+def _catalogue_from_text(text: str, source: str) -> ObservableCatalogue:
+    document: Any = yaml.safe_load(text)
+    if document is None:
+        document = {}
+    if not isinstance(document, dict):
+        raise ValueError(
+            f"{source}: an observable declarations file must be a mapping with "
+            f"`inputs` and `observables` keys, not a "
+            f"{type(document).__name__}."
+        )
+    return ObservableCatalogue.model_validate(document)
+
+
+def load_catalogue(path: str | Path) -> ObservableCatalogue:
+    """Load and validate a declarations file from disk."""
+    path = Path(path)
+    return _catalogue_from_text(path.read_text(encoding="utf-8"), str(path))
+
+
+def load_default_catalogue() -> ObservableCatalogue:
+    """The shipped declarations: energy plus its position and cell derivatives."""
+    resource = files("mace_core").joinpath(DEFAULTS_RESOURCE)
+    return _catalogue_from_text(resource.read_text(encoding="utf-8"), DEFAULTS_RESOURCE)

--- a/packages/mace-core/src/mace_core/observables/derivatives.py
+++ b/packages/mace-core/src/mace_core/observables/derivatives.py
@@ -1,0 +1,65 @@
+"""How a derivative of a declared quantity is named and signed.
+
+The rule is one line: the derivative of a declared quantity ``q`` with respect
+to a declared input ``x`` is called ``d_<q>_d_<x>``. Three pairs have a name of
+their own, and they are data in the table below rather than branches spread
+through the consumers that need them.
+
+The third special case is the reason this grammar is written over declared
+inputs rather than over positions and the cell. ``magforces`` is
+``-dE/d(magmom)``, computed in the same autograd call as the forces, trained
+with its own loss term, and used by the magnetic self-consistent model to drive
+its fixed point. A grammar that knew only ``d_<q>_d_pos`` and ``d_<q>_d_cell``
+could not express it, and the magnetic work would have had to go around the
+abstraction that exists to prevent exactly that.
+
+The sign is the one the reported quantity carries, so that
+``reported = sign * d(quantity)/d(input)``. The volume division that turns the
+strain derivative into a stress is not a sign and is not here: it belongs to
+whatever computes the stress.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "SPECIAL_CASES",
+    "derivative_name",
+    "derivative_sign",
+]
+
+#: ``(quantity, input) -> (name, sign)`` for the three pairs whose name is not
+#: the ``d_<q>_d_<x>`` default. Everything else follows the rule.
+SPECIAL_CASES: dict[tuple[str, str], tuple[str, int]] = {
+    ("energy", "pos"): ("forces", -1),
+    ("energy", "cell"): ("stress", +1),
+    ("energy", "magmom"): ("magforces", -1),
+}
+
+
+def derivative_name(quantity: str, wrt: str) -> str:
+    """The canonical name of ``d(quantity)/d(wrt)``.
+
+    Args:
+        quantity: The name of the differentiated observable.
+        wrt: The name of the declared input it is differentiated against.
+
+    Returns:
+        The special-cased name if the pair has one, otherwise
+        ``f"d_{quantity}_d_{wrt}"``.
+    """
+    special = SPECIAL_CASES.get((quantity, wrt))
+    if special is not None:
+        return special[0]
+    return f"d_{quantity}_d_{wrt}"
+
+
+def derivative_sign(quantity: str, wrt: str) -> int:
+    """The sign the reported derivative carries: ``reported = sign * dq/dx``.
+
+    ``+1`` unless the pair is one of the two negated special cases, forces and
+    magnetic forces, which are both the negative gradient of the energy.
+    """
+    special = SPECIAL_CASES.get((quantity, wrt))
+    if special is not None:
+        return special[1]
+    return 1

--- a/packages/mace-core/src/mace_core/observables/grammar.py
+++ b/packages/mace-core/src/mace_core/observables/grammar.py
@@ -1,0 +1,117 @@
+"""The irreps string grammar, and nothing beyond it.
+
+An observable declares the spherical-tensor shape of its values as a string:
+``"0e"`` for a scalar, ``"1o"`` for a polar vector, ``"1e"`` for an axial one,
+``"0e+2e"`` for a symmetric rank-2 tensor, ``"128x0e+128x1o+128x2e"`` for a
+block of hidden features. This module parses and validates that string.
+
+It is grammar only. No tensor products, no Clebsch-Gordan coefficients, no
+simplification or sorting of terms: the algebra lands in its own module with
+the reduced basis, and a half-implementation here would be the version every
+later caller had to work around. What a caller gets from this module is the
+guarantee that a declaration is well formed, the terms it names, and the
+dimension they add up to.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "IRREPS_GRAMMAR",
+    "IrrepTerm",
+    "IrrepsGrammarError",
+    "irreps_dimension",
+    "parse_irreps",
+]
+
+#: Stated in every error this module raises, because an error that says only
+#: "invalid" leaves the reader to guess between four plausible spellings.
+IRREPS_GRAMMAR = (
+    "a '+'-separated sum of terms, each written '<l><parity>' or "
+    "'<multiplicity>x<l><parity>', where <l> is a non-negative integer and "
+    "<parity> is 'e' (even) or 'o' (odd). Examples: '0e' (a scalar), '1o' (a "
+    "polar vector), '1e' (an axial vector), '0e+2e' (a symmetric rank-2 "
+    "tensor), '128x0e+128x1o+128x2e'."
+)
+
+_TERM = re.compile(r"^(?:(\d+)x)?(\d+)([eo])$")
+
+
+class IrrepsGrammarError(ValueError):
+    """A declaration that is not a well-formed irreps string."""
+
+
+@dataclass(frozen=True)
+class IrrepTerm:
+    """One ``<multiplicity>x<l><parity>`` term of a declaration.
+
+    Attributes:
+        multiplicity: How many copies of the irrep the term declares.
+        degree: The rotation order ``l``. A value of ``l`` spans ``2l + 1``
+            components.
+        parity: ``"e"`` or ``"o"``, the behaviour under inversion. The
+            distinction is load-bearing rather than decorative: a force is
+            ``1o`` and a magnetic moment is ``1e``, and a model that confuses
+            them is wrong under inversion while looking right under rotation.
+    """
+
+    multiplicity: int
+    degree: int
+    parity: str
+
+    @property
+    def dimension(self) -> int:
+        """The number of components this term contributes."""
+        return self.multiplicity * (2 * self.degree + 1)
+
+    def __str__(self) -> str:
+        return f"{self.multiplicity}x{self.degree}{self.parity}"
+
+
+def parse_irreps(text: str, *, observable: str | None = None) -> tuple[IrrepTerm, ...]:
+    """Parse an irreps declaration into its terms.
+
+    Args:
+        text: The declaration, for example ``"128x0e+128x1o"``.
+        observable: The observable the declaration belongs to. Named in the
+            error message, because a validation failure reported without it
+            tells the reader which grammar was violated and not which of their
+            declarations violated it.
+
+    Returns:
+        The terms, in the order they were written. The order is preserved
+        rather than sorted: it is the layout of the values themselves.
+
+    Raises:
+        IrrepsGrammarError: If the declaration is empty or any term is
+            malformed.
+    """
+    where = f"observable {observable!r}: " if observable else ""
+    if not text or not text.strip():
+        raise IrrepsGrammarError(
+            f"{where}the irreps declaration is empty. Expected {IRREPS_GRAMMAR}"
+        )
+    terms = []
+    for piece in text.split("+"):
+        match = _TERM.match(piece.strip())
+        if match is None:
+            raise IrrepsGrammarError(
+                f"{where}{piece.strip()!r} is not a valid irreps term in "
+                f"{text!r}. Expected {IRREPS_GRAMMAR}"
+            )
+        multiplicity, degree, parity = match.groups()
+        terms.append(
+            IrrepTerm(
+                multiplicity=1 if multiplicity is None else int(multiplicity),
+                degree=int(degree),
+                parity=parity,
+            )
+        )
+    return tuple(terms)
+
+
+def irreps_dimension(text: str, *, observable: str | None = None) -> int:
+    """The total number of components a declaration spans."""
+    return sum(term.dimension for term in parse_irreps(text, observable=observable))

--- a/packages/mace-core/src/mace_core/observables/spec.py
+++ b/packages/mace-core/src/mace_core/observables/spec.py
@@ -1,0 +1,320 @@
+"""Declaring an observable, an input, and the derivatives between them.
+
+Which quantities a legacy model computes is decided by a ladder of string
+comparisons on the model class name that sets six boolean flags, plus ten more
+``compute_*`` arguments on the forward signatures. Adding one property means
+editing several files. Here a property is a row: name it, say what shape it
+has, say whether there is one per atom or one per structure, and it is declared.
+
+Three objects, and they do different jobs:
+
+``InputSpec``
+    something the model is given -- positions, the cell, a magnetic moment, an
+    electronic temperature. Declared so that a derivative can be taken with
+    respect to it without new code.
+
+``ObservableSpec``
+    something the model produces and a loss can be written against.
+
+``DerivativeSpec``
+    derived, never declared: the result of asking an observable for its
+    derivative with respect to an input. Its name and sign come from
+    :mod:`mace_core.observables.derivatives`.
+
+``ObservableCatalogue`` holds a set of them and is what the defaults file loads
+into. Validation lives there rather than in the individual specs because the
+interesting errors are between rows: a derivative asked against an input nobody
+declared, or two rows whose derived names collide.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from mace_core.observables.derivatives import derivative_name, derivative_sign
+from mace_core.observables.grammar import (
+    IrrepTerm,
+    irreps_dimension,
+    parse_irreps,
+)
+
+__all__ = [
+    "NORMALIZATIONS",
+    "DerivativeRequest",
+    "DerivativeSpec",
+    "InputSpec",
+    "Normalization",
+    "ObservableCatalogue",
+    "ObservableSpec",
+]
+
+#: How a target is scaled before it reaches a head and a loss term. The
+#: per-observable successor of the legacy scaling registry, whose three entries
+#: were a global choice for the whole model. This package stores and validates
+#: the value; the head applies it in the output layer and the loss applies the
+#: matching term, both reading this one field, so there is never a second
+#: scaling mechanism to keep in step with it.
+Normalization = Literal["none", "std", "rms"]
+
+#: The accepted values, for error messages and for callers that enumerate them.
+NORMALIZATIONS: tuple[str, ...] = ("none", "std", "rms")
+
+_SCALAR = (IrrepTerm(multiplicity=1, degree=0, parity="e"),)
+
+
+def _check_name(value: str, kind: str) -> str:
+    if not value.isidentifier():
+        raise ValueError(
+            f"{kind} name {value!r} is not usable: a name must be a valid "
+            f"Python identifier, because it is also the key the value is "
+            f"stored under and part of any derivative name derived from it."
+        )
+    return value
+
+
+class InputSpec(BaseModel):
+    """Something the model is given, and can be differentiated against.
+
+    ``pos`` and ``cell`` are the two every model has. Anything else is declared
+    the same way, which is what makes ``d_energy_d_<feature>`` reachable for a
+    new feature without touching code.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    irreps: str
+    #: ``True`` for one value per atom (positions, magnetic moments), ``False``
+    #: for one per structure (the cell, a total charge). This is what decides
+    #: whether a derivative taken against the input is padded per node or per
+    #: graph.
+    per_atom: bool
+    units: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate(self) -> InputSpec:
+        _check_name(self.name, "input")
+        parse_irreps(self.irreps, observable=self.name)
+        return self
+
+
+class DerivativeRequest(BaseModel):
+    """A derivative an observable asks for, and the loss settings it carries.
+
+    The name and the sign are not here: they are derived, and letting a
+    declaration override them would reintroduce the per-consumer naming this
+    abstraction removes. What a declaration does own is what a loss needs --
+    its weight, its normalization, and the unit string to report.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    #: The name of the declared input to differentiate against.
+    wrt: str
+    default_loss_weight: float = Field(default=1.0, ge=0.0)
+    normalization: Normalization = "none"
+    #: Left to the declaration. Deriving it would mean unit algebra over the
+    #: quantity and the input, which this ticket does not own.
+    units: str | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_bare_name(cls, value: object) -> object:
+        """``derivatives: [pos, cell]`` is the same as spelling out ``wrt``."""
+        if isinstance(value, str):
+            return {"wrt": value}
+        return value
+
+
+class DerivativeSpec(BaseModel):
+    """A derivative, as resolved by the catalogue. Never declared directly."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    #: The observable being differentiated.
+    of: str
+    #: The input it is differentiated against.
+    wrt: str
+    #: ``reported = sign * d(of)/d(wrt)``.
+    sign: int
+    #: Inherited from the input: a derivative against a per-atom input has one
+    #: value per atom, whatever the differentiated quantity is.
+    per_atom: bool
+    #: Known when the differentiated quantity is a single scalar, in which case
+    #: the gradient carries the input's irreps. ``None`` otherwise, because the
+    #: general case is a tensor product and the algebra is not this module's.
+    irreps: str | None
+    units: str | None
+    normalization: Normalization
+    default_loss_weight: float
+
+
+class ObservableSpec(BaseModel):
+    """One declared property: what it is, what shape it has, how it is scaled.
+
+    Any atomic or total spherical-tensor property declared here becomes
+    trainable with no new code: the spec drives the head, the loss term and the
+    padding classification.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str
+    #: The spherical-tensor shape, in the grammar of
+    #: :mod:`mace_core.observables.grammar`.
+    irreps: str
+    #: ``True`` for one value per atom, ``False`` for one per structure. Every
+    #: output carries this, which is what lets padding be added and removed
+    #: without a consumer keeping its own list of which names are which.
+    per_atom: bool
+    #: Project convention: eV, Å.
+    units: str = Field(min_length=1)
+    normalization: Normalization
+    default_loss_weight: float = Field(default=1.0, ge=0.0)
+    #: The derivatives this observable asks for. Naming works for any declared
+    #: input whether or not it is listed here; listing it is what says the
+    #: model should compute it.
+    derivatives: tuple[DerivativeRequest, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate(self) -> ObservableSpec:
+        _check_name(self.name, "observable")
+        parse_irreps(self.irreps, observable=self.name)
+        seen: set[str] = set()
+        for request in self.derivatives:
+            if request.wrt in seen:
+                raise ValueError(
+                    f"observable {self.name!r} asks for the derivative with "
+                    f"respect to {request.wrt!r} twice. Declare it once."
+                )
+            seen.add(request.wrt)
+        return self
+
+    @property
+    def dimension(self) -> int:
+        """The number of components one value of this observable spans."""
+        return irreps_dimension(self.irreps, observable=self.name)
+
+    @property
+    def is_scalar(self) -> bool:
+        """Whether the declaration is a single ``0e``."""
+        return parse_irreps(self.irreps, observable=self.name) == _SCALAR
+
+    def derivative_name(self, wrt: str) -> str:
+        """The canonical name of this observable's derivative against ``wrt``."""
+        return derivative_name(self.name, wrt)
+
+    def derivative_sign(self, wrt: str) -> int:
+        """The sign that derivative is reported with."""
+        return derivative_sign(self.name, wrt)
+
+    def requested_derivatives(self) -> tuple[str, ...]:
+        """The inputs this observable asked to be differentiated against."""
+        return tuple(request.wrt for request in self.derivatives)
+
+
+class ObservableCatalogue(BaseModel):
+    """A set of declared inputs and observables, validated against each other."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    inputs: tuple[InputSpec, ...] = ()
+    observables: tuple[ObservableSpec, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate(self) -> ObservableCatalogue:
+        self._reject_duplicates([spec.name for spec in self.inputs], "input")
+        self._reject_duplicates([spec.name for spec in self.observables], "observable")
+        declared = {spec.name for spec in self.inputs}
+        taken = {spec.name for spec in self.observables}
+        for observable in self.observables:
+            for request in observable.derivatives:
+                if request.wrt not in declared:
+                    raise ValueError(
+                        f"observable {observable.name!r} asks for its "
+                        f"derivative with respect to {request.wrt!r}, which is "
+                        f"not a declared input. Declare it under `inputs`, or "
+                        f"use one of {sorted(declared)}."
+                    )
+                name = observable.derivative_name(request.wrt)
+                if name in taken:
+                    raise ValueError(
+                        f"the derivative of {observable.name!r} with respect "
+                        f"to {request.wrt!r} is named {name!r}, which is "
+                        f"already taken. Rename the observable that holds it, "
+                        f"or drop the derivative."
+                    )
+                taken.add(name)
+        return self
+
+    @staticmethod
+    def _reject_duplicates(names: list[str], kind: str) -> None:
+        seen: set[str] = set()
+        for name in names:
+            if name in seen:
+                raise ValueError(
+                    f"{kind} {name!r} is declared twice. Every {kind} name is "
+                    f"a key, so it has to be unique."
+                )
+            seen.add(name)
+
+    def input(self, name: str) -> InputSpec:
+        """The declared input called ``name``."""
+        for spec in self.inputs:
+            if spec.name == name:
+                return spec
+        raise KeyError(
+            f"{name!r} is not a declared input. The declared inputs are "
+            f"{sorted(spec.name for spec in self.inputs)}."
+        )
+
+    def observable(self, name: str) -> ObservableSpec:
+        """The declared observable called ``name``."""
+        for spec in self.observables:
+            if spec.name == name:
+                return spec
+        raise KeyError(
+            f"{name!r} is not a declared observable. The declared observables "
+            f"are {sorted(spec.name for spec in self.observables)}."
+        )
+
+    def derivative(self, observable: str, wrt: str) -> DerivativeSpec:
+        """Resolve one derivative, whether or not the observable asked for it.
+
+        Naming and signing are properties of the pair, not of the request, so a
+        consumer can ask what a derivative *would* be called without the
+        declaration having listed it.
+        """
+        spec = self.observable(observable)
+        input_spec = self.input(wrt)
+        request = next(
+            (r for r in spec.derivatives if r.wrt == wrt), DerivativeRequest(wrt=wrt)
+        )
+        return DerivativeSpec(
+            name=spec.derivative_name(wrt),
+            of=spec.name,
+            wrt=wrt,
+            sign=spec.derivative_sign(wrt),
+            per_atom=input_spec.per_atom,
+            irreps=input_spec.irreps if spec.is_scalar else None,
+            units=request.units,
+            normalization=request.normalization,
+            default_loss_weight=request.default_loss_weight,
+        )
+
+    def requested_derivatives(self) -> tuple[DerivativeSpec, ...]:
+        """Every derivative the declarations actually asked for."""
+        return tuple(
+            self.derivative(spec.name, request.wrt)
+            for spec in self.observables
+            for request in spec.derivatives
+        )
+
+    def names(self) -> tuple[str, ...]:
+        """Every name this catalogue puts on a model output."""
+        return tuple(spec.name for spec in self.observables) + tuple(
+            spec.name for spec in self.requested_derivatives()
+        )

--- a/packages/mace-core/src/mace_core/outputs.py
+++ b/packages/mace-core/src/mace_core/outputs.py
@@ -1,0 +1,141 @@
+"""The typed object a model returns instead of a dictionary of tensors.
+
+Every legacy model ``forward`` returns ``Dict[str, Optional[torch.Tensor]]``,
+and between the eleven of them they emit 43 distinct string keys. Nothing
+checks a key against anything, so each consumer keeps its own hand-written
+list of the names it knows: the ase calculator classifies 22 of the 43 and
+returns the other 21 with their padding rows still in them. This module
+replaces the dictionary with a typed object whose core fields are named once.
+
+Six fields are core and everything else goes through :attr:`MACEOutput.extras`.
+That split is deliberate rather than a compromise: the electrostatic, magnetic
+and dielectric families are large, model-specific and still moving, so pinning
+them as attributes would mean a core type that changes shape every time a new
+model lands. What classifies an entry of ``extras`` as per-atom or per-graph is
+its :class:`~mace_core.observables.ObservableSpec`, not a second key list kept
+somewhere else.
+
+The class is generic over the tensor type. ``mace_core`` imports no framework,
+so ``TensorT`` is bound to ``torch.Tensor`` in ``mace_torch``, to ``jax.Array``
+in ``mace_jax``, and to ``numpy.ndarray`` in this package's own tests. The same
+pattern carries the kernel Protocol, so it has to work with no framework
+installed at all.
+
+Units follow the project convention: eV, Å, and eV/Å for a force.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Generic, TypeVar
+
+__all__ = [
+    "CORE_FIELD_NAMES",
+    "FIELD_BY_OBSERVABLE",
+    "MACEOutput",
+    "TensorT",
+]
+
+#: The array type a framework binds. Deliberately unbound: a bound of, say,
+#: "something with a .shape" would be a structural claim about torch and jax
+#: that this package cannot check and does not need.
+TensorT = TypeVar("TensorT")
+
+
+@dataclass
+class MACEOutput(Generic[TensorT]):
+    """What a model computed, in one typed object.
+
+    A field left at ``None`` was not computed. That is different from an entry
+    of ``extras`` that is missing: a core field is part of the type whether or
+    not this model produces it, while ``extras`` carries only what was asked
+    for.
+
+    Attributes:
+        total_energy: Total energy per graph, in eV. Shape ``(n_graphs,)``.
+            The observable is named ``energy``; see :data:`FIELD_BY_OBSERVABLE`.
+        node_energies: Per-atom energy, in eV, shape ``(n_atoms,)``. Whether
+            the isolated-atom reference is included is the model's business
+            and is stated by the model, not here.
+        forces: ``-d(energy)/d(positions)``, in eV/Å, shape ``(n_atoms, 3)``.
+        stress: ``+d(energy)/d(strain) / volume``, in eV/Å³, shape
+            ``(n_graphs, 3, 3)``.
+        virials: The same derivative before the volume division, in eV, shape
+            ``(n_graphs, 3, 3)``.
+        dipole: Total dipole per graph, shape ``(n_graphs, 3)``.
+        extras: Every other declared observable, keyed by its
+            :class:`~mace_core.observables.ObservableSpec` name.
+
+    The object is mutable on purpose. Forces and stress are computed by a
+    derivative engine *around* the model call rather than inside a module's
+    forward, so something has to fill those fields in after the model returned,
+    and a frozen object would mean copying the whole thing to do it.
+    """
+
+    total_energy: TensorT | None = None
+    node_energies: TensorT | None = None
+    forces: TensorT | None = None
+    stress: TensorT | None = None
+    virials: TensorT | None = None
+    dipole: TensorT | None = None
+    extras: dict[str, TensorT] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Reject an ``extras`` key that a core field already owns.
+
+        Writing ``extras["forces"]`` is otherwise silent: the value is stored,
+        ``output.forces`` stays ``None``, and every consumer that reads the
+        field sees nothing. That is the shape of bug this class exists to
+        remove, so it is an error at construction instead.
+        """
+        shadowed = sorted(
+            name
+            for name in self.extras
+            if FIELD_BY_OBSERVABLE.get(name, name) in CORE_FIELD_NAMES
+        )
+        if shadowed:
+            raise ValueError(
+                f"{shadowed} are core fields of MACEOutput and cannot also be "
+                f"keys of `extras`: a consumer reading the field would see "
+                f"nothing. Assign them as fields instead."
+            )
+
+    def get(self, name: str) -> TensorT | None:
+        """The value stored under ``name``, or ``None`` if there is none.
+
+        ``name`` is an observable name or a core field name. Without this, a
+        consumer that iterates over declared observables has to branch on
+        which of them happen to be core fields, and that branch is the
+        hand-kept key list this class exists to remove.
+        """
+        field_name = FIELD_BY_OBSERVABLE.get(name, name)
+        if field_name in CORE_FIELD_NAMES:
+            return getattr(self, field_name)
+        return self.extras.get(name)
+
+    def names(self) -> tuple[str, ...]:
+        """Every name that carries a value, core fields first, then ``extras``.
+
+        A core field holding ``None`` was not computed and is left out, so this
+        is what the model actually produced rather than what it could produce.
+        """
+        present = [name for name in CORE_FIELD_NAMES if getattr(self, name) is not None]
+        present.extend(self.extras)
+        return tuple(present)
+
+    def __contains__(self, name: str) -> bool:
+        return self.get(name) is not None
+
+
+#: The six fields that are part of the type. Derived from the dataclass rather
+#: than written out again, so the two cannot disagree.
+CORE_FIELD_NAMES: tuple[str, ...] = tuple(
+    f.name for f in fields(MACEOutput) if f.name != "extras"
+)
+
+#: The one place an observable's name and its storage field differ. The field
+#: says "total" because the type also carries per-atom energies, while the
+#: observable is named ``energy`` because that is the name the derivative
+#: grammar's special cases are keyed on (``energy`` + positions -> ``forces``).
+#: Written down as one entry rather than left to each consumer to remember.
+FIELD_BY_OBSERVABLE: dict[str, str] = {"energy": "total_energy"}

--- a/packages/mace-core/tests/test_observables.py
+++ b/packages/mace-core/tests/test_observables.py
@@ -1,0 +1,410 @@
+"""The declarative observable specification.
+
+The acceptance bar is "zero new code", so most of these tests declare something
+in YAML text and assert what comes out. If any of them needed a new branch in
+``mace_core`` to pass, the abstraction would not be doing its job.
+"""
+
+import pytest
+from mace_core.observables import (
+    DerivativeRequest,
+    InputSpec,
+    IrrepsGrammarError,
+    ObservableCatalogue,
+    ObservableSpec,
+    derivative_name,
+    derivative_sign,
+    irreps_dimension,
+    load_catalogue,
+    load_default_catalogue,
+    parse_irreps,
+)
+from pydantic import ValidationError
+
+# A catalogue with the two inputs every model has, written out so that the
+# tests below can add one row at a time to it.
+BASE_INPUTS = """
+inputs:
+  - name: pos
+    irreps: "1o"
+    per_atom: true
+    units: "Å"
+  - name: cell
+    irreps: "0e+2e"
+    per_atom: false
+    units: "1"
+"""
+
+
+def catalogue_from(text, tmp_path):
+    path = tmp_path / "observables.yaml"
+    path.write_text(BASE_INPUTS + text, encoding="utf-8")
+    return load_catalogue(path)
+
+
+# ---------------------------------------------------------------------------
+# The irreps grammar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "dimension"),
+    [
+        ("0e", 1),
+        ("1o", 3),
+        ("1e", 3),
+        ("0e+2e", 6),
+        ("128x0e+128x1o+128x2e", 128 * (1 + 3 + 5)),
+        (" 0e + 1o ", 4),
+    ],
+)
+def test_the_grammar_accepts_a_sum_of_multiplied_irreps(text, dimension):
+    assert irreps_dimension(text) == dimension
+
+
+def test_a_term_keeps_its_written_order_and_its_parity():
+    terms = parse_irreps("2x1o+0e")
+    assert [(t.multiplicity, t.degree, t.parity) for t in terms] == [
+        (2, 1, "o"),
+        (1, 0, "e"),
+    ]
+
+
+@pytest.mark.parametrize("text", ["", "   ", "1", "1x", "x0e", "0e+", "1u", "-1o"])
+def test_a_malformed_declaration_is_rejected(text):
+    with pytest.raises(IrrepsGrammarError):
+        parse_irreps(text)
+
+
+def test_a_grammar_error_names_the_observable_and_the_grammar():
+    with pytest.raises(IrrepsGrammarError) as caught:
+        parse_irreps("1u", observable="quadrupole")
+    message = str(caught.value)
+    assert "quadrupole" in message
+    assert "'1u'" in message
+    assert "multiplicity" in message and "parity" in message
+
+
+def test_a_malformed_spec_names_the_observable_and_the_grammar():
+    """The same contract through pydantic, which is how a user meets it."""
+    with pytest.raises(ValidationError) as caught:
+        ObservableSpec(
+            name="quadrupole",
+            irreps="rank2",
+            per_atom=True,
+            units="e*Å^2",
+            normalization="none",
+        )
+    message = str(caught.value)
+    assert "quadrupole" in message
+    assert "'rank2'" in message
+    assert "Examples: '0e'" in message
+
+
+# ---------------------------------------------------------------------------
+# Spec validation
+# ---------------------------------------------------------------------------
+
+
+def test_normalization_is_required_and_closed():
+    # Both calls are rejected by the type checker as well, which is the point:
+    # the field is a closed Literal, so a wrong value is caught statically and
+    # at runtime. The ignores are what let the runtime half be tested.
+    with pytest.raises(ValidationError):
+        ObservableSpec(name="q", irreps="0e", per_atom=False, units="eV")  # ty: ignore[missing-argument]
+    with pytest.raises(ValidationError):
+        ObservableSpec(
+            name="q",
+            irreps="0e",
+            per_atom=False,
+            units="eV",
+            normalization="minmax",  # ty: ignore[invalid-argument-type]
+        )
+
+
+def test_an_unknown_field_is_an_error_rather_than_ignored():
+    with pytest.raises(ValidationError):
+        ObservableSpec(
+            name="q",
+            irreps="0e",
+            per_atom=False,
+            units="eV",
+            normalization="none",
+            weight=3.0,  # ty: ignore[unknown-argument]
+        )
+
+
+def test_a_name_that_is_not_an_identifier_is_rejected():
+    with pytest.raises(ValidationError) as caught:
+        ObservableSpec(
+            name="latent charges",
+            irreps="0e",
+            per_atom=True,
+            units="e",
+            normalization="none",
+        )
+    assert "identifier" in str(caught.value)
+
+
+def test_units_may_not_be_empty():
+    with pytest.raises(ValidationError):
+        ObservableSpec(
+            name="q", irreps="0e", per_atom=False, units="", normalization="none"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Derivative naming and signs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("quantity", "wrt", "name", "sign"),
+    [
+        ("energy", "pos", "forces", -1),
+        ("energy", "cell", "stress", +1),
+        ("energy", "magmom", "magforces", -1),
+    ],
+)
+def test_the_three_special_cases_keep_their_names_and_signs(quantity, wrt, name, sign):
+    assert derivative_name(quantity, wrt) == name
+    assert derivative_sign(quantity, wrt) == sign
+
+
+@pytest.mark.parametrize(
+    ("quantity", "wrt", "name"),
+    [
+        ("dipole", "pos", "d_dipole_d_pos"),
+        ("dipole", "cell", "d_dipole_d_cell"),
+        ("polarizability", "pos", "d_polarizability_d_pos"),
+        ("energy", "elec_temp", "d_energy_d_elec_temp"),
+        ("quadrupole", "magmom", "d_quadrupole_d_magmom"),
+    ],
+)
+def test_everything_else_follows_the_rule(quantity, wrt, name):
+    assert derivative_name(quantity, wrt) == name
+    assert derivative_sign(quantity, wrt) == +1
+
+
+# ---------------------------------------------------------------------------
+# The shipped defaults
+# ---------------------------------------------------------------------------
+
+
+def test_the_defaults_declare_energy_and_its_two_derivatives():
+    catalogue = load_default_catalogue()
+    assert catalogue.names() == ("energy", "forces", "stress")
+    assert [spec.name for spec in catalogue.inputs] == ["pos", "cell"]
+
+
+def test_the_default_forces_row_is_the_negative_position_gradient():
+    forces = load_default_catalogue().derivative("energy", "pos")
+    assert forces.name == "forces"
+    assert forces.sign == -1
+    assert forces.per_atom is True
+    assert forces.irreps == "1o"
+    assert forces.units == "eV/Å"
+    assert forces.default_loss_weight == 100.0
+
+
+def test_the_default_stress_row_is_the_positive_strain_gradient():
+    stress = load_default_catalogue().derivative("energy", "cell")
+    assert stress.name == "stress"
+    assert stress.sign == +1
+    assert stress.per_atom is False
+    assert stress.irreps == "0e+2e"
+
+
+# ---------------------------------------------------------------------------
+# The two "zero new code" acceptance cases
+# ---------------------------------------------------------------------------
+
+
+def test_a_new_rank_two_per_atom_observable_is_a_row_in_yaml(tmp_path):
+    catalogue = catalogue_from(
+        """
+observables:
+  - name: quadrupole
+    irreps: "0e+2e"
+    per_atom: true
+    units: "e*Å^2"
+    normalization: "rms"
+    default_loss_weight: 2.5
+    derivatives: [pos, cell]
+""",
+        tmp_path,
+    )
+    quadrupole = catalogue.observable("quadrupole")
+    assert quadrupole.per_atom is True
+    assert quadrupole.dimension == 6
+    assert quadrupole.default_loss_weight == 2.5
+    assert catalogue.names() == (
+        "quadrupole",
+        "d_quadrupole_d_pos",
+        "d_quadrupole_d_cell",
+    )
+
+
+def test_a_new_input_feature_makes_its_derivative_declarable(tmp_path):
+    """`magmom` is the case that pays for the grammar being written over
+    declared inputs rather than over positions and the cell."""
+    catalogue = catalogue_from(
+        """
+  - name: magmom
+    irreps: "1e"
+    per_atom: true
+    units: "muB"
+
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+    derivatives:
+      - wrt: magmom
+        units: "eV/muB"
+        default_loss_weight: 10.0
+""",
+        tmp_path,
+    )
+    magforces = catalogue.derivative("energy", "magmom")
+    assert magforces.name == "magforces"
+    assert magforces.sign == -1
+    assert magforces.per_atom is True
+    # A magnetic moment is an axial vector, so its conjugate force is too.
+    assert magforces.irreps == "1e"
+    assert magforces.default_loss_weight == 10.0
+    assert catalogue.names() == ("energy", "magforces")
+
+
+def test_the_bare_string_form_and_the_mapping_form_agree(tmp_path):
+    shorthand = catalogue_from(
+        """
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+    derivatives: [pos]
+""",
+        tmp_path,
+    )
+    assert shorthand.observable("energy").derivatives == (DerivativeRequest(wrt="pos"),)
+
+
+# ---------------------------------------------------------------------------
+# Catalogue-level validation: the errors that live between rows
+# ---------------------------------------------------------------------------
+
+
+def test_a_derivative_against_an_undeclared_input_is_an_error(tmp_path):
+    with pytest.raises(ValidationError) as caught:
+        catalogue_from(
+            """
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+    derivatives: [elec_temp]
+""",
+            tmp_path,
+        )
+    message = str(caught.value)
+    assert "energy" in message
+    assert "elec_temp" in message
+    assert "['cell', 'pos']" in message
+
+
+def test_a_derived_name_may_not_collide_with_a_declared_observable(tmp_path):
+    with pytest.raises(ValidationError) as caught:
+        catalogue_from(
+            """
+observables:
+  - name: forces
+    irreps: "1o"
+    per_atom: true
+    units: "eV/Å"
+    normalization: "rms"
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+    derivatives: [pos]
+""",
+            tmp_path,
+        )
+    assert "'forces'" in str(caught.value)
+
+
+def test_a_name_declared_twice_is_an_error(tmp_path):
+    with pytest.raises(ValidationError) as caught:
+        catalogue_from(
+            """
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "none"
+""",
+            tmp_path,
+        )
+    assert "declared twice" in str(caught.value)
+
+
+def test_asking_for_the_same_derivative_twice_is_an_error(tmp_path):
+    with pytest.raises(ValidationError):
+        catalogue_from(
+            """
+observables:
+  - name: energy
+    irreps: "0e"
+    per_atom: false
+    units: "eV"
+    normalization: "std"
+    derivatives: [pos, pos]
+""",
+            tmp_path,
+        )
+
+
+def test_an_unknown_observable_or_input_says_what_is_declared():
+    catalogue = load_default_catalogue()
+    with pytest.raises(KeyError) as caught:
+        catalogue.observable("dipole")
+    assert "['energy']" in str(caught.value)
+    with pytest.raises(KeyError) as caught:
+        catalogue.input("magmom")
+    assert "['cell', 'pos']" in str(caught.value)
+
+
+def test_a_derivative_can_be_named_without_having_been_requested():
+    """Naming is a property of the pair; requesting is what says "compute it"."""
+    catalogue = ObservableCatalogue(
+        inputs=[InputSpec(name="pos", irreps="1o", per_atom=True, units="Å")],
+        observables=[
+            ObservableSpec(
+                name="dipole",
+                irreps="1o",
+                per_atom=False,
+                units="Debye",
+                normalization="rms",
+            )
+        ],
+    )
+    assert catalogue.names() == ("dipole",)
+    derived = catalogue.derivative("dipole", "pos")
+    assert derived.name == "d_dipole_d_pos"
+    # The differentiated quantity is not a scalar, so the gradient's irreps are
+    # a tensor product this package deliberately does not compute.
+    assert derived.irreps is None

--- a/packages/mace-core/tests/test_outputs.py
+++ b/packages/mace-core/tests/test_outputs.py
@@ -1,0 +1,113 @@
+"""MACEOutput: the typed replacement for the forward's dictionary of tensors.
+
+The tests run on numpy arrays throughout. That is the point rather than a
+convenience: ``MACEOutput`` is generic over the tensor type so that one class
+serves torch, jax and neither, and a test suite that only ever exercised it
+with torch would not notice the day it stopped being framework-free.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+from mace_core.outputs import CORE_FIELD_NAMES, FIELD_BY_OBSERVABLE, MACEOutput
+
+
+def test_the_six_core_fields_are_the_declared_ones():
+    """The type's shape, pinned. `extras` is not one of them."""
+    assert CORE_FIELD_NAMES == (
+        "total_energy",
+        "node_energies",
+        "forces",
+        "stress",
+        "virials",
+        "dipole",
+    )
+
+
+def test_an_empty_output_holds_nothing():
+    output = MACEOutput[np.ndarray]()
+    assert output.names() == ()
+    assert output.get("forces") is None
+    assert "forces" not in output
+
+
+def test_core_fields_round_trip_numpy_arrays():
+    forces = np.zeros((4, 3))
+    output = MACEOutput(total_energy=np.array([-1.5]), forces=forces)
+    assert output.get("total_energy") is output.total_energy
+    assert output.get("forces") is forces
+    assert output.names() == ("total_energy", "forces")
+
+
+def test_energy_reaches_the_total_energy_field_under_either_name():
+    """The one place an observable name and a field name differ."""
+    assert FIELD_BY_OBSERVABLE == {"energy": "total_energy"}
+    output = MACEOutput(total_energy=np.array([2.0]))
+    assert output.get("energy") is output.get("total_energy")
+    assert "energy" in output
+
+
+def test_extras_carries_what_the_core_fields_do_not():
+    """The escape hatch is load-bearing: 43 legacy keys, six core fields."""
+    output = MACEOutput(extras={"latent_charges": np.zeros(4)})
+    assert "latent_charges" in output
+    latent_charges = output.get("latent_charges")
+    assert latent_charges is not None
+    assert latent_charges.shape == (4,)
+    assert output.names() == ("latent_charges",)
+
+
+def test_a_name_nobody_wrote_is_absent_rather_than_an_error():
+    """A consumer iterating declared observables asks for names that a given
+    model did not compute; that is not an error, it is a `None`."""
+    output = MACEOutput(extras={"charges": np.zeros(2)})
+    assert output.get("magforces") is None
+    assert "magforces" not in output
+
+
+def test_a_core_field_left_none_is_not_reported_as_present():
+    output = MACEOutput(forces=None, extras={})
+    assert output.names() == ()
+
+
+def test_two_outputs_do_not_share_an_extras_dictionary():
+    """`extras` has a default factory; a shared mutable default would make one
+    model's outputs appear in another's."""
+    first = MACEOutput[np.ndarray]()
+    second = MACEOutput[np.ndarray]()
+    first.extras["dipole_moment"] = np.zeros(3)
+    assert second.extras == {}
+
+
+def test_the_class_is_generic_over_the_tensor_type():
+    """Subscripting has to work with no framework installed at all: the kernel
+    Protocol reuses this pattern, so it cannot depend on torch being there."""
+    assert MACEOutput[np.ndarray] is not None
+    assert isinstance(MACEOutput[np.ndarray](), MACEOutput)
+
+
+@pytest.mark.parametrize("framework", ["torch", "jax", "e3nn"])
+def test_importing_mace_core_imports_no_framework(framework):
+    """Run in a fresh interpreter on purpose. Asserting this in-process would
+    pass whenever some earlier test in the session had already imported torch,
+    which is the case the assertion exists for."""
+    probe = (
+        "import sys, mace_core, mace_core.observables, mace_core.outputs\n"
+        f"assert {framework!r} not in sys.modules, "
+        f"'importing mace_core pulled in {framework}'\n"
+    )
+    subprocess.run([sys.executable, "-c", probe], check=True)
+
+
+@pytest.mark.parametrize("key", ["forces", "energy", "total_energy", "dipole"])
+def test_extras_may_not_shadow_a_core_field(key):
+    """A value written into `extras` under a core field's name would be stored
+    and never read: the field it shadows stays `None`."""
+    with pytest.raises(ValueError, match="cannot also be"):
+        MACEOutput(extras={key: np.zeros(3)})
+
+
+def test_a_name_that_is_not_a_core_field_is_fine_in_extras():
+    assert MACEOutput(extras={"node_energy": np.zeros(3)}).names() == ("node_energy",)

--- a/tests/architecture/observable_coverage.py
+++ b/tests/architecture/observable_coverage.py
@@ -1,0 +1,483 @@
+"""Where every legacy model output goes in the declarative specification.
+
+The frozen models emit 43 distinct keys from their ``forward`` methods. This
+module says, for each one, what it becomes: a declared observable, a derivative
+of one, or a row saying explicitly that it is not an observable and naming the
+mechanism that owns it instead. A key with no row fails the test beside this
+file, so a key added to a legacy forward cannot slip through unclassified.
+
+The 43 are **not listed here**. They are read out of ``mace/modules/models.py``
+and ``mace/modules/extensions.py`` by ``tests/golden/surface_scan.py``, which
+follows keys assigned onto the returned object as well as dict literals -- the
+self-consistent model assigns its three diagnostics after the fact, so an
+extraction that stopped at return literals would stop at 40 and lose them
+silently.
+
+Two pieces of metadata are likewise derived rather than retyped. The golden
+harness already declares a kind and a unit for every one of these keys, so the
+per-atom/per-graph classification and the unit string come from there and the
+rows below carry only what a schema cannot know: the spherical-tensor shape,
+and the decision.
+
+One convention worth stating once. A rank-2 Cartesian quantity -- a stress, a
+virial, a polarizability -- is stored by the legacy models as a full 3x3, nine
+numbers, while its irreps declaration ``0e+2e`` spans six. That is not a
+contradiction: the declaration says what the quantity *is* under rotation, and
+the 3x3 is a layout with three redundant entries. Reconciling the two is the
+head's job, and it is written down here because the mismatch otherwise looks
+like an error in these rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+from tests.golden import harness, surface_scan
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The two files the ticket's count is defined over. The scanner discovers
+#: forwards across the whole package -- the LAMMPS and torchsim wrappers define
+#: one too -- and those are deployment layers with their own tickets, so this
+#: surface is named rather than discovered.
+LEGACY_MODEL_SOURCES = (
+    REPO_ROOT / "mace" / "modules" / "models.py",
+    REPO_ROOT / "mace" / "modules" / "extensions.py",
+)
+
+#: The ase calculator, layer (b) of the three-layer surface.
+LEGACY_CALCULATOR_SOURCES = (REPO_ROOT / "mace" / "calculators" / "mace.py",)
+
+PER_ATOM_KINDS = frozenset(
+    {
+        harness.PER_ATOM_SCALAR,
+        harness.PER_ATOM_VECTOR,
+        harness.PER_ATOM_TENSOR,
+        harness.PER_ATOM_MATRIX,
+    }
+)
+PER_GRAPH_KINDS = frozenset(
+    {
+        harness.GRAPH_SCALAR,
+        harness.GRAPH_VECTOR,
+        harness.GRAPH_TENSOR,
+        harness.GRAPH_ARRAY,
+    }
+)
+
+#: The inputs a derivative row may be taken against. ``pos`` and ``cell`` are
+#: the two every model has and are declared in the shipped defaults; ``magmom``
+#: is the third the frozen tree actually differentiates against, and is
+#: declared by whichever configuration turns the magnetic model on.
+DECLARED_INPUTS = frozenset({"pos", "cell", "magmom"})
+
+
+@dataclass(frozen=True)
+class Spec:
+    """The key becomes a declared observable.
+
+    An irreps declaration is two independent facts, and lumping them together
+    is what made a third of these rows look unanswerable. What the quantity is
+    under rotation is a property of the quantity. How wide it is can be a
+    property of the *model*: the number of readout layers, the maximum multipole
+    order, whether an anisotropic readout was declared. A row that names both is
+    complete even when it cannot write a single literal, because the model fills
+    the rest in when it is declared, exactly as the ticket's own
+    ``128x0e+128x1o+128x2e`` example does.
+
+    So a row states either ``irreps`` or ``irreps_pattern`` plus ``set_by``, and
+    there is no third state. Nothing here is deferred to another ticket: every
+    one of the 43 was worked out, and a future row that cannot be fails the test
+    rather than acquiring a TODO.
+
+    Attributes:
+        irreps: The declaration, when the quantity fixes it outright.
+        irreps_pattern: The declaration with the model-dependent part named.
+            Prose, not the grammar: it is read by people, and the grammar would
+            have to grow placeholders to hold it.
+        set_by: What the model supplies. Required with ``irreps_pattern``,
+            because "it depends on the model" is not an answer until it says on
+            what.
+        note: Anything about the row a reader would otherwise have to rederive.
+    """
+
+    irreps: str | None = None
+    irreps_pattern: str | None = None
+    set_by: str = ""
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Derivative:
+    """The key is a derivative of another quantity, and is renamed by the rule.
+
+    Attributes:
+        of: The differentiated quantity.
+        wrt: The declared input it is differentiated against.
+        sign: The sign the frozen tree reports, so that
+            ``legacy value = sign * d(of)/d(wrt)``. Read off the source and,
+            where the note says so, measured. It is stated per row rather than
+            taken from the rule because a row that silently agreed with the
+            rule and a row nobody checked look identical. The test asserts the
+            two agree, with no way to annotate a disagreement: a pair the rule
+            gets wrong is either a misclassified row or a real gap in the
+            grammar, and both have to be resolved rather than recorded.
+        note: Why the row is worth a second look, where it is.
+    """
+
+    of: str
+    wrt: str
+    sign: int
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class Drop:
+    """The key is not an observable. ``reason`` names what owns it instead."""
+
+    reason: str
+
+
+Disposition = Union[Spec, Derivative, Drop]
+
+
+#: Every key the two frozen model modules emit, and what it becomes.
+DISPOSITIONS: dict[str, Disposition] = {
+    # --- energies ----------------------------------------------------------
+    "energy": Spec(irreps="0e"),
+    "node_energy": Spec(irreps="0e"),
+    "interaction_energy": Spec(irreps="0e"),
+    "les_energy": Spec(irreps="0e"),
+    "electrostatic_energy": Spec(irreps="0e"),
+    "electron_energy": Spec(irreps="0e"),
+    "fermi_level": Spec(irreps="0e"),
+    "contributions": Spec(
+        irreps_pattern="<2 + num_interactions>x0e",
+        set_by="the number of energy terms the model sums",
+        note=(
+            "the energy decomposed into its terms. `energies = [e0, "
+            "pair_energy]` and one entry is appended per interaction layer "
+            "(mace/modules/models.py:361, :398), so the extent is the "
+            "isolated-atom reference plus the ZBL pair term plus one per "
+            "layer. Measured on the tiny_mace anchor, which has two layers: "
+            "shape (1, 4)."
+        ),
+    ),
+    # --- charges and potentials -------------------------------------------
+    "charges": Spec(irreps="0e"),
+    "latent_charges": Spec(irreps="0e"),
+    "spins": Spec(
+        irreps="0e",
+        note=(
+            "the per-atom spin population, a scalar. Not to be confused with a "
+            "magnetic moment, which is an axial vector ('1e')."
+        ),
+    ),
+    "electrostatic_potentials": Spec(irreps="0e"),
+    # --- dipoles -----------------------------------------------------------
+    "dipole": Spec(irreps="1o"),
+    "atomic_dipoles": Spec(irreps="1o"),
+    "latent_dipoles": Spec(irreps="1o"),
+    # --- rank-2 quantities -------------------------------------------------
+    "polarizability": Spec(irreps="0e+2e"),
+    "polarizability_sh": Spec(
+        irreps="0e+2e",
+        note=(
+            "already the spherical form, six components. The Cartesian "
+            "`polarizability` above is the same quantity in the 3x3 layout, "
+            "which is what makes the pair a useful check on the head."
+        ),
+    ),
+    "virials": Spec(
+        irreps="0e+2e",
+        note=(
+            "the NEGATED cell derivative, and the sign is not a detail: "
+            "`compute_forces_virials` computes the stress from the raw "
+            "gradient and negates the virial only in its return statement "
+            "(mace/modules/utils.py:107-115), so the frozen tree reports "
+            "`virials = -dE/dstrain` and `stress = +dE/dstrain / V`. Measured "
+            "on the tiny_scaleshift anchor over an fcc cell: "
+            "max|stress * V + virials| = 1.2e-35, exactly zero, while "
+            "max|stress * V - virials| = 6.5e-3. The two therefore differ by a "
+            "sign as well as by the volume. `stress` is the row that carries "
+            "the derivative naming; `virials` stays an observable of its own "
+            "because the spec has no way to say 'the same derivative in "
+            "another normalization and the opposite sign', which is a question "
+            "for the head that produces them."
+        ),
+    ),
+    "atomic_virials": Spec(irreps="0e+2e"),
+    "atomic_stresses": Spec(irreps="0e+2e"),
+    # --- families whose shape is a model hyperparameter ---------------------
+    "density_coefficients": Spec(
+        irreps_pattern="two concatenated ladders 0e+1o+2e+...+<atomic_multipoles_max_l>",
+        set_by="atomic_multipoles_max_l",
+        note=(
+            "the spin-summed electron density in the model's multipole basis. "
+            "`self.charges_irreps = 2 * o3.Irreps.spherical_harmonics("
+            "atomic_multipoles_max_l)` (mace/modules/extensions.py:789), and "
+            "in e3nn that product concatenates the ladder twice rather than "
+            "doubling each multiplicity, so the layout is two ladders end to "
+            "end even though the content simplifies to 2x0e+2x1o+2x2e+... "
+            "Dimension 8, 18, 32 for max_l 1, 2, 3."
+        ),
+    ),
+    "spin_density": Spec(
+        irreps_pattern="two concatenated ladders 0e+1o+2e+...+<atomic_multipoles_max_l>",
+        set_by="atomic_multipoles_max_l",
+        note=(
+            "the alpha minus beta difference of the same basis as "
+            "`density_coefficients` (mace/modules/extensions.py:1250), so it "
+            "carries identical irreps."
+        ),
+    ),
+    "spin_charge_density": Spec(
+        irreps_pattern=(
+            "<2 spin channels> x two concatenated ladders "
+            "0e+1o+2e+...+<atomic_multipoles_max_l>"
+        ),
+        set_by="atomic_multipoles_max_l, and the fixed pair of spin channels",
+        note=(
+            "the density before the spin channels are summed or subtracted: "
+            "`spin_charge_density.view(shape[0], 2, -1)` "
+            "(mace/modules/extensions.py:1094). `density_coefficients` is its "
+            "sum over that axis and `spin_density` its difference."
+        ),
+    ),
+    "fukui_functions": Spec(
+        irreps="2x0e",
+        note=(
+            "two scalars per atom, one per spin channel, and not model "
+            "dependent at all: `self.fukui_source_map` is a readout whose "
+            "output irreps are the literal `o3.Irreps(\"2x0e\")` "
+            "(mace/modules/extensions.py:838-842). They are added to the l=0 "
+            "component of each spin channel of the density."
+        ),
+    ),
+    "BEC": Spec(
+        irreps_pattern="<1 or 2>x(0e+1e+2e)",
+        set_by=(
+            "whether the model passes latent dipoles to LES alongside the "
+            "latent charges, which adds a second channel"
+        ),
+        note=(
+            "NOT the same quantity as `dmu_dr`, which is the tempting reading "
+            "and the wrong one. LES builds a polarization from its own latent "
+            "charges with the mean removed and an epsilon^(1/2) factor, takes "
+            "it through a Berry phase under periodic boundary conditions, and "
+            "differentiates *that* against the positions, dephasing and "
+            "projecting the result by the cell "
+            "(les/module/bec.py:56-93). `dmu_dr` differentiates the "
+            "dielectric model's `dipole` readout, a different quantity in a "
+            "different gauge and a different unit (e against Debye/Ang). "
+            "Measured on the tiny_maceles anchor, the shape is "
+            "(n_atoms, 2, 3, 3), not (n_atoms, 3, 3): the leading pair is the "
+            "charge-derived tensor and the latent-dipole-derived one, and "
+            "whether that axis is there at all depends on whether the model "
+            "passes latent dipoles. Each 3x3 block is a general rank-2 tensor "
+            "rather than a symmetric one (max|B - B^T| = 0.20 on that anchor), "
+            "so a block is 0e+1e+2e and the channel axis is the multiplicity "
+            "DEP-1a has to fix."
+        ),
+    ),
+    "latent_kappas": Spec(
+        irreps="0e",
+        note=(
+            "one scalar per atom. The LES signature documents it as "
+            "[n_atoms, ] (les/les.py:89) and `les_kappa_readouts` is a scalar "
+            "readout; measured (3,) on the tiny_maceles anchor."
+        ),
+    ),
+    "latent_alphas": Spec(
+        irreps_pattern="0e, or 0e+2e",
+        set_by="whether the model declares the anisotropic alpha readouts",
+        note=(
+            "an atomic polarizability, isotropic by default and anisotropic "
+            "when `use_induced_dipoles` brings in `les_alpha_2e_readouts`. "
+            "That branch reads out a spherical 0e+2e and expands it through "
+            "`spherical_to_cartesian` (mace/modules/extensions.py:485-494), "
+            "then squares it as A A^T, which is symmetric, so the anisotropic "
+            "form is 0e+2e and not the general 0e+1e+2e. LES accepts both "
+            "shapes explicitly (les/les.py:133-136). Measured (3,) on the "
+            "tiny_maceles anchor, which is the isotropic path."
+        ),
+    ),
+    "latent_quads": Spec(
+        irreps="2e",
+        note=(
+            "an atomic quadrupole. Stored as a Cartesian 3x3 "
+            "(les/les.py:88), but the model subtracts the trace explicitly "
+            "(mace/modules/extensions.py:549-552), so it is symmetric and "
+            "traceless, which is exactly 2e and five numbers rather than nine. "
+            "Measured on the tiny_maceles anchor: max|A - A^T| = 2.7e-20 and "
+            "|trace| = 5.4e-20."
+        ),
+    ),
+    # --- derivatives -------------------------------------------------------
+    "forces": Derivative(
+        of="energy",
+        wrt="pos",
+        sign=-1,
+        note="mace/modules/utils.py:115 returns `-1 * forces`.",
+    ),
+    "stress": Derivative(
+        of="energy",
+        wrt="cell",
+        sign=+1,
+        note=(
+            "positive, and only because the stress is built from the raw "
+            "gradient before the virial is negated. See the `virials` row: the "
+            "two are not the same sign."
+        ),
+    ),
+    "magforces": Derivative(
+        of="energy",
+        wrt="magmom",
+        sign=-1,
+        note=(
+            "mace/modules/utils.py returns `-mag_forces` from both "
+            "`compute_forces_virials_magforces` and `compute_forces_magforces`."
+        ),
+    ),
+    "dmu_dr": Derivative(
+        of="dipole",
+        wrt="pos",
+        sign=+1,
+        note=(
+            "mace/modules/models.py:1169 differentiates the model's own "
+            "`dipole` key, and `compute_dielectric_gradients` returns the "
+            "gradient with no sign flip."
+        ),
+    ),
+    "dalpha_dr": Derivative(
+        of="polarizability",
+        wrt="pos",
+        sign=+1,
+        note=(
+            "the Cartesian polarizability flattened to nine components "
+            "(mace/modules/models.py:1173-1176), differentiated the same way "
+            "as `dmu_dr`."
+        ),
+    ),
+    # --- not observables ---------------------------------------------------
+    "hessian": Drop(
+        reason=(
+            "the second derivative of the energy with respect to the "
+            "positions, and the derivative grammar is first order by design: "
+            "it names d(quantity)/d(input) for a declared quantity and a "
+            "declared input, and all three of its special cases are first "
+            "order. Reading it instead as the first derivative of the forces "
+            "does not rescue it, and the sign is how that shows: "
+            "`compute_hessians_vmap` differentiates `-1 * forces` "
+            "(mace/modules/utils.py:168), so the key holds +d2E/dpos2, which "
+            "is MINUS d(forces)/d(pos). Measured on the tiny_scaleshift anchor "
+            "against a central difference of the forces, "
+            "max|hessian[:, 0] + dF/dx| = 1.8e-10 against "
+            "max|hessian[:, 0] - dF/dx| = 0.32. It is a real output and it is "
+            "not lost: the derivative engine owns second derivatives, the same "
+            "way the export path owns `edge_forces`."
+        )
+    ),
+    "displacement": Drop(
+        reason=(
+            "the symmetric strain handle the cell derivative is taken against. "
+            "It is created as zeros to attach the cell to the autograd graph "
+            "and nothing ever writes to it, so its value is identically zero "
+            "on every structure. It belongs to the derivative engine, not to "
+            "the output surface."
+        )
+    ),
+    "edge_forces": Drop(
+        reason=(
+            "indexed by the neighbour list, so it is neither per-atom nor "
+            "per-graph and the spec's classification cannot express it. It is "
+            "the per-edge decomposition the LAMMPS pair style sums into its "
+            "virial, and belongs to the export path."
+        )
+    ),
+    "node_feats": Drop(
+        reason=(
+            "the backbone's node features: what every head reads, not what one "
+            "produces. No dataset carries a target for it, so declaring it "
+            "would make the head-creation check unsatisfiable. The evaluation "
+            "CLI exposes it as `descriptors`, which is CLI-1's layer."
+        )
+    ),
+    "external_field": Drop(
+        reason=(
+            "an input echoed back, which is how the golden harness classifies "
+            "it too. It reaches v1 as a declared input feature, which is also "
+            "what makes a derivative against it expressible."
+        )
+    ),
+    "total_charge": Drop(
+        reason=(
+            "an input echoed back, like `external_field`. Declared as an input "
+            "feature rather than as an observable."
+        )
+    ),
+    "charges_history": Drop(
+        reason=(
+            "the iterates of the electrostatic self-consistency loop: how a "
+            "fixed point was reached, not the fixed point. Run telemetry, and "
+            "it belongs in the stage's log."
+        )
+    ),
+    "scf_energy_history": Drop(
+        reason="run telemetry of the self-consistent loop, like `charges_history`."
+    ),
+    "scf_steps": Drop(
+        reason="run telemetry of the self-consistent loop, like `charges_history`."
+    ),
+    "equilibrated_magmom": Drop(
+        reason=(
+            "an input the self-consistent stage converged, exposed through the "
+            "stage result rather than as a model observable. Note the golden "
+            "harness classifies it as an output channel, because from where it "
+            "sits it is one; the distinction is which mechanism owns it."
+        )
+    ),
+}
+
+
+def legacy_model_keys() -> set[str]:
+    """The keys the two frozen model modules can return, read from the source."""
+    return surface_scan.scan_model_surface(list(LEGACY_MODEL_SOURCES)).all_keys
+
+
+def legacy_calculator_keys() -> set[str]:
+    """The keys the ase calculators can write into ``results``."""
+    return surface_scan.scan_calculator_surface(
+        list(LEGACY_CALCULATOR_SOURCES)
+    ).all_keys
+
+
+def legacy_eval_keys() -> set[str]:
+    """The names the evaluation CLI writes onto its structures, unprefixed."""
+    scan, _stores = surface_scan.scan_eval_surface()
+    return scan.all_keys
+
+
+def channel_of(key: str) -> harness.Channel | None:
+    """The golden harness's declaration for ``key`` on the model surface."""
+    name = harness.resolve_channel(key, harness.SURFACE_MODEL)
+    return None if name is None else harness.CHANNELS[name]
+
+
+def per_atom_of(key: str) -> bool | None:
+    """Whether ``key`` is per-atom, derived from its harness kind.
+
+    ``None`` for the kinds that are neither -- a per-edge quantity, a hessian,
+    a gradient whose atom axis is not the leading one. A key that lands here
+    cannot be a plain observable, and the test asserts exactly that.
+    """
+    channel = channel_of(key)
+    if channel is None:
+        return None
+    if channel.kind in PER_ATOM_KINDS:
+        return True
+    if channel.kind in PER_GRAPH_KINDS:
+        return False
+    return None

--- a/tests/architecture/test_observable_completeness.py
+++ b/tests/architecture/test_observable_completeness.py
@@ -1,0 +1,265 @@
+"""Every legacy model output is accounted for by the declarative spec.
+
+Two failure modes this suite is built against. The first is a key nobody
+classified, which is how the ase calculator ended up returning 21 of the 43
+model keys with their padding rows still in them. The second, quieter one is a
+test that measures nothing: an extraction that finds no keys reports perfect
+coverage, so the counts are asserted as numbers rather than left to a set
+comparison that an empty set would satisfy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from mace_core.observables import ObservableSpec, derivative_name, derivative_sign
+
+from tests.architecture.observable_coverage import (
+    DECLARED_INPUTS,
+    DISPOSITIONS,
+    LEGACY_MODEL_SOURCES,
+    Derivative,
+    Drop,
+    Spec,
+    channel_of,
+    legacy_calculator_keys,
+    legacy_eval_keys,
+    legacy_model_keys,
+    per_atom_of,
+)
+from tests.golden import surface_scan
+
+SURFACE_DOC = (
+    Path(__file__).resolve().parents[2] / "docs" / "reforge" / "output_surface.md"
+)
+
+
+def test_the_scan_resolves_every_write_it_finds():
+    """The honesty check. A write whose key cannot be computed would shrink the
+    surface silently, so it fails here instead."""
+    scan = surface_scan.scan_model_surface(list(LEGACY_MODEL_SOURCES))
+    assert surface_scan.unexplained(scan) == []
+
+
+def test_the_model_forward_surface_is_forty_three_keys():
+    keys = legacy_model_keys()
+    assert len(keys) == 43, sorted(keys)
+
+
+def test_every_legacy_key_has_exactly_one_disposition():
+    keys = legacy_model_keys()
+    missing = sorted(keys - set(DISPOSITIONS))
+    assert not missing, (
+        f"{missing} are returned by a frozen model forward and have no row in "
+        f"observable_coverage.DISPOSITIONS. Add a Spec, a Derivative or a Drop "
+        f"row; an unclassified output is one nothing downstream can pad, "
+        f"unpad or train."
+    )
+    stale = sorted(set(DISPOSITIONS) - keys)
+    assert not stale, (
+        f"{stale} have a disposition row and are no longer returned by any "
+        f"frozen model forward. Remove the rows."
+    )
+
+
+@pytest.mark.parametrize(
+    "key", sorted(k for k, d in DISPOSITIONS.items() if isinstance(d, Spec))
+)
+def test_a_spec_row_builds_a_valid_observable_spec(key):
+    """The classification the padding depends on has to exist for every row,
+    and a row states its irreps either outright or with the model-dependent
+    part named. There is no third state: no row is allowed to defer the
+    question to a later ticket."""
+    row = DISPOSITIONS[key]
+    per_atom = per_atom_of(key)
+    assert per_atom is not None, (
+        f"{key!r} is declared as an observable but the golden harness gives it "
+        f"a kind that is neither per-atom nor per-graph. It cannot be a Spec "
+        f"row; make it a Derivative or a Drop."
+    )
+    assert bool(row.irreps) != bool(row.irreps_pattern), (
+        f"{key!r} must state exactly one of `irreps` and `irreps_pattern`. "
+        f"Neither means the row was never worked out, and both means it is "
+        f"unclear which one a reader should believe."
+    )
+    if row.irreps_pattern:
+        assert row.set_by.strip(), (
+            f"{key!r} says its shape depends on the model without saying on "
+            f"what. Name the parameter in `set_by`."
+        )
+        return
+    channel = channel_of(key)
+    assert channel is not None
+    spec = ObservableSpec(
+        name=key,
+        irreps=row.irreps,
+        per_atom=per_atom,
+        # The legacy unit, as the golden harness records it. This ticket does
+        # not canonicalise unit strings, so `Ang` is left as it is written
+        # there rather than rewritten to `Å`.
+        units=channel.unit,
+        # Neutral: which normalization each family wants is decided by the
+        # ticket that builds its head, not by this coverage table.
+        normalization="none",
+    )
+    assert spec.per_atom == per_atom
+    assert spec.dimension >= 1
+
+
+def test_no_observable_row_defers_its_irreps_to_another_ticket():
+    """The whole set was worked out, and this asserts it stays that way. A row
+    that cannot say what its irreps are is a row nobody has read the model
+    for, and it should fail here rather than sit as a TODO."""
+    unresolved = sorted(
+        key
+        for key, row in DISPOSITIONS.items()
+        if isinstance(row, Spec) and not row.irreps and not row.irreps_pattern
+    )
+    assert not unresolved, unresolved
+
+
+@pytest.mark.parametrize(
+    "key", sorted(k for k, d in DISPOSITIONS.items() if isinstance(d, Derivative))
+)
+def test_a_derivative_row_resolves_through_the_rule(key):
+    row = DISPOSITIONS[key]
+    assert row.wrt in DECLARED_INPUTS, (
+        f"{key!r} is differentiated against {row.wrt!r}, which is not one of "
+        f"the declared inputs {sorted(DECLARED_INPUTS)}."
+    )
+    parent = DISPOSITIONS.get(row.of)
+    assert isinstance(parent, (Spec, Derivative)), (
+        f"{key!r} is the derivative of {row.of!r}, which is not itself a "
+        f"declared observable or a derivative of one. A derivative chain has "
+        f"to ground out in something declared."
+    )
+    name = derivative_name(row.of, row.wrt)
+    assert name.isidentifier()
+    derived_sign = derivative_sign(row.of, row.wrt)
+    assert row.sign == derived_sign, (
+        f"{key!r} is reported with sign {row.sign:+d} by the frozen tree and "
+        f"the rule derives {derived_sign:+d}. There is no way to annotate that "
+        f"away, deliberately: either the row differentiates the wrong thing, "
+        f"or the grammar has a real gap. `hessian` was the first candidate for "
+        f"such a gap and turned out to be the former: it is a second "
+        f"derivative of the energy, not a first derivative of the forces."
+    )
+
+
+def test_the_three_named_derivatives_keep_their_legacy_names():
+    """forces, stress and magforces are the pairs that have a name of their own,
+    and the two negated ones are the two the frozen tree negates."""
+    assert derivative_name("energy", "pos") == "forces"
+    assert derivative_sign("energy", "pos") == -1
+    assert derivative_name("energy", "cell") == "stress"
+    assert derivative_sign("energy", "cell") == +1
+    assert derivative_name("energy", "magmom") == "magforces"
+    assert derivative_sign("energy", "magmom") == -1
+    for name in ("forces", "stress", "magforces"):
+        assert isinstance(DISPOSITIONS[name], Derivative)
+
+
+def test_the_renamed_derivatives_are_renamed_and_not_lost():
+    """Two legacy spellings become their rule-derived names. A rename is a
+    breaking change and is fine; losing one is not.
+
+    `BEC` is deliberately absent. It looks like a third, and treating it as one
+    would have merged it into `dmu_dr`; see its row for why the two are
+    different quantities. `hessian` is absent for a different reason: it is a
+    second derivative and carries a Drop row.
+    """
+    renamed = {
+        "dmu_dr": "d_dipole_d_pos",
+        "dalpha_dr": "d_polarizability_d_pos",
+    }
+    for key, expected in renamed.items():
+        row = DISPOSITIONS[key]
+        assert derivative_name(row.of, row.wrt) == expected
+    assert isinstance(DISPOSITIONS["BEC"], Spec)
+
+
+def test_no_two_derivative_rows_resolve_to_one_name():
+    """Two legacy keys collapsing onto a single canonical name is either the
+    abstraction working or a silent merge of two different quantities. It has
+    to be looked at rather than discovered later, so it fails here."""
+    seen: dict[str, str] = {}
+    for key, row in DISPOSITIONS.items():
+        if not isinstance(row, Derivative):
+            continue
+        name = derivative_name(row.of, row.wrt)
+        assert name not in seen, (
+            f"{key!r} and {seen[name]!r} both resolve to {name!r}. If they are "
+            f"one quantity, say so and drop one row; if they are not, one of "
+            f"them is not a derivative of what it claims."
+        )
+        seen[name] = key
+
+
+def test_a_key_the_classification_cannot_place_is_never_a_spec_row():
+    """`edge_forces` is per-edge and a hessian is a square over 3N degrees of
+    freedom. Neither is per-atom or per-graph, so neither can be an observable
+    under a classification that only has those two."""
+    for key, row in DISPOSITIONS.items():
+        if per_atom_of(key) is None:
+            assert isinstance(row, (Derivative, Drop)), key
+
+
+@pytest.mark.parametrize(
+    "key", sorted(k for k, d in DISPOSITIONS.items() if isinstance(d, Drop))
+)
+def test_a_drop_row_says_what_owns_the_key_instead(key):
+    reason = DISPOSITIONS[key].reason
+    assert reason.strip()
+    assert len(reason.split()) >= 8, (
+        f"the reason for dropping {key!r} is too short to be a decision "
+        f"anybody can review later: {reason!r}"
+    )
+
+
+def test_the_scf_trio_is_reached_at_all():
+    """The three keys an extraction that stops at return literals never sees.
+    They are assigned onto the output after it is built."""
+    keys = legacy_model_keys()
+    for key in ("scf_energy_history", "scf_steps", "equilibrated_magmom"):
+        assert key in keys
+        assert isinstance(DISPOSITIONS[key], Drop)
+
+
+# ---------------------------------------------------------------------------
+# The three-layer surface
+# ---------------------------------------------------------------------------
+
+
+def documented_counts() -> dict[str, tuple[int, int]]:
+    """The per-layer `(keys, new here)` pairs the surface document records."""
+    rows = {}
+    for line in SURFACE_DOC.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^\|\s*\((a|b|c)\)[^|]*\|(.*)$", line)
+        if match is None:
+            continue
+        cells = [cell.strip() for cell in match.group(2).split("|")]
+        numbers = [int(cell) for cell in cells if cell.isdigit()]
+        assert len(numbers) == 2, line
+        rows[match.group(1)] = (numbers[0], numbers[1])
+    return rows
+
+
+def test_the_surface_document_records_the_derived_counts():
+    model = legacy_model_keys()
+    calculator = legacy_calculator_keys()
+    evaluation = legacy_eval_keys()
+    derived = {
+        "a": (len(model), len(model)),
+        "b": (len(calculator), len(calculator - model)),
+        "c": (len(evaluation), len(evaluation - model - calculator)),
+    }
+    assert documented_counts() == derived
+    assert derived == {"a": (43, 43), "b": (31, 15), "c": (13, 3)}
+
+
+def test_the_union_is_sixty_one_names():
+    union = legacy_model_keys() | legacy_calculator_keys() | legacy_eval_keys()
+    assert len(union) == 61
+    assert "**61**" in SURFACE_DOC.read_text(encoding="utf-8")


### PR DESCRIPTION
`MACEOutput` replaces the dict every legacy model forward returns: six core fields plus a typed `extras` hatch, generic over the tensor type so `mace_core` imports no framework. A plain dataclass, since the values are tensors whose type this package cannot name and there is nothing to validate.

`ObservableSpec` makes a property a row instead of a code change. Derivatives are named `d_<q>_d_<x>`, with `forces`, `stress` and `magforces` keeping their own names. The grammar runs over declared inputs, not just positions and the cell, because `magforces` already needs the third. `defaults/observables.yaml` ships energy with its two derivatives.

All 43 keys the frozen forwards emit are classified in `tests/architecture/observable_coverage.py`, read out of the source by the P0-5 scan rather than listed, so a new legacy key fails the test. 22 carry a literal irreps string, 6 state it with the model parameter that sets the rest (readout count, maximum multipole order, whether an anisotropic readout is declared), 5 are derivatives, 10 are drops naming what owns them instead. Nothing is deferred: a row that cannot say what its irreps are fails the test rather than acquiring a TODO.

`docs/reforge/output_surface.md` records the three-layer surface: 43 + 15 + 3 = 61 names, every number re-derived by the test.

Three things the sign checks turned up, all measured on the committed anchors:

- `virials = -dE/dstrain` but `stress = +dE/dstrain / V`. They differ by a sign,  not only the volume (`max|stress*V + virials|` = 1.2e-35).
- `hessian` is `+d2E/dpos2`, the negative of `d(forces)/d(pos)`. It is a second derivative, so it gets a Drop row naming the derivative engine.
- `BEC` is not another spelling of `dmu_dr`. LES differentiates a Berry-phase polarization built from mean-removed latent charges; the dielectric model differentiates its `dipole` readout. Different quantity, different unit, measured shape `(n_atoms, 2, 3, 3)`.

Implements CORE-1 (#1555).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a foundational contract layer with strict validation on derivative signs/names and completeness tests tied to legacy output keys; mistakes here would propagate to training, calculators, and parity gates, but runtime legacy paths are unchanged until backends adopt these types.
> 
> **Overview**
> Introduces the **mace-core** contract for v1 model outputs and observables: **`MACEOutput`** replaces the legacy forward dict with six core fields plus typed **`extras`**, generic over tensor type so the package stays framework-free.
> 
> A **declarative observable catalogue** loads from YAML (`defaults/observables.yaml` for energy, forces, stress): Pydantic **`InputSpec` / `ObservableSpec` / `ObservableCatalogue`**, irreps grammar parsing, and derivative naming (`d_<q>_d_<x>` with explicit names/signs for forces, stress, magforces). **`pyproject.toml`** now depends on numpy, pydantic, and PyYAML.
> 
> **Architecture gates** classify all **43** legacy model forward keys in `observable_coverage.py` and assert completeness via `surface_scan` plus **`test_observable_completeness`** (including the **61-name** union across model, ASE calculator, and eval CLI documented in **`output_surface.md`**). Reforge docs (`target_layout.md`, `extending_mace.md`) are updated to describe table-row observables and **`LossConfig`** weights instead of `default_loss_weight` in YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86080f5e1e425e3247113be75c2520072fb64b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->